### PR TITLE
Remove regexp character class ambiguity

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -120,7 +120,7 @@ StageName | `string` | **Required** The name of the stage, which API Gateway use
 DefinitionUri | `string` | **Required** S3 URI to the Swagger document describing the API.
 CacheClusterEnabled | `boolean` | Indicates whether cache clustering is enabled for the stage.
 CacheClusterSize | `string` | The stage's cache cluster size.
-Variables | Map of `string` to `string` | A map (string to string map) that defines the stage variables, where the variable name is the key and the variable value is the value. Variable names are limited to alphanumeric characters. Values must match the following regular expression: [A-Za-z0-9-._~:/?#&amp;=,]+.
+Variables | Map of `string` to `string` | A map (string to string map) that defines the stage variables, where the variable name is the key and the variable value is the value. Variable names are limited to alphanumeric characters. Values must match the following regular expression: [A-Za-z0-9._~:/?#&amp;=,-]+.
 
 ##### Return values
 

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -120,7 +120,7 @@ StageName | `string` | **Required** The name of the stage, which API Gateway use
 DefinitionUri | `string` | **Required** S3 URI to the Swagger document describing the API.
 CacheClusterEnabled | `boolean` | Indicates whether cache clustering is enabled for the stage.
 CacheClusterSize | `string` | The stage's cache cluster size.
-Variables | Map of `string` to `string` | A map (string to string map) that defines the stage variables, where the variable name is the key and the variable value is the value. Variable names are limited to alphanumeric characters. Values must match the following regular expression: [A-Za-z0-9._~:/?#&amp;=,-]+.
+Variables | Map of `string` to `string` | A map (string to string map) that defines the stage variables, where the variable name is the key and the variable value is the value. Variable names are limited to alphanumeric characters. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&amp;=,-]+`.
 
 ##### Return values
 


### PR DESCRIPTION
A literal dash '-' in regexp character class must be at beginning or end or escaped to avoid meaning character range.