### PR TITLE
Fixed typo as in 'FunctionArn' to 'Arn'

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -84,7 +84,7 @@ When the logical ID of this resource is provided to the [Fn::GetAtt](http://docs
 
 Attribute Name | Description
 ---|---
-FunctionArn | The ARN of the Lambda function.
+Arn | The ARN of the Lambda function.
 
 ###### Example: AWS::Serverless::Function
 


### PR DESCRIPTION
Quick fix in the docs that is explained in this Issue: https://github.com/awslabs/serverless-application-model/issues/16