### PR TITLE
Swagger-With-CORS example works as-is

### DIFF
--- a/examples/2016-10-31/api_swagger_cors/swagger.yaml
+++ b/examples/2016-10-31/api_swagger_cors/swagger.yaml
@@ -19,8 +19,7 @@ paths:
         responses:
           default:
             statusCode: 200
-        # NOTE: Replace <<region>> and <<account>> fields
-        uri: arn:aws:apigateway:<<region>>:lambda:path/2015-03-31/functions/arn:aws:lambda:<<region>>:<<accountId>>:function:${stageVariables.LambdaFunctionName}/invocations
+        uri: arn:aws:apigateway:${stageVariables.Region}:lambda:path/2015-03-31/functions/arn:aws:lambda:${stageVariables.Region}:${stageVariables.AccountId}:function:${stageVariables.LambdaFunctionName}/invocations
 
         passthroughBehavior: when_no_match
         httpMethod: POST

--- a/examples/2016-10-31/api_swagger_cors/template.yaml
+++ b/examples/2016-10-31/api_swagger_cors/template.yaml
@@ -9,10 +9,9 @@ Resources:
       DefinitionUri: s3://<bucket>/swagger.yaml
       StageName: Prod
       Variables:
-        # NOTE: Before using this template, replace the <<region>> and <<account>> fields
-        #       in Lambda integration URI in the swagger file to region and accountId 
-        #       you are deploying to
+        AccountId: !Ref AWS::AccountId
         LambdaFunctionName: !Ref LambdaFunction
+        Region: !Ref AWS::Region
 
   LambdaFunction:
     Type: AWS::Serverless::Function


### PR DESCRIPTION
Instead of telling people to edit the example with their region and account id, why not automatically pass those values in as stage variables?