### PR TITLE
Indicate API definitions must be on S3

### DIFF
--- a/HOWTO.md
+++ b/HOWTO.md
@@ -37,7 +37,7 @@ MyLambdaFunction:
 MyApi:
     Type: AWS::Serverless::Api
     Properties:
-        DefinitionUri: ./specs/swagger.yaml
+        DefinitionUri: s3://<mybucket>/specs/swagger.yaml
         ...
 ```
 


### PR DESCRIPTION
`'DefinitionUri' is not a valid S3 Uri of the form "s3://bucket/key" with optional versionId query parameter.` is returned otherwise