### PR TITLE
DefinitionUri supports a relative path

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -117,7 +117,7 @@ An `AWS::Serverless::Api` resource need not be explicitly added to a AWS Serverl
 Property Name | Type | Description
 ---|:---:|---
 StageName | `string` | **Required** The name of the stage, which API Gateway uses as the first path segment in the invoke Uniform Resource Identifier (URI).
-DefinitionUri | `string` | **Required** S3 URI to the Swagger document describing the API.
+DefinitionUri | `string` | **Required** S3 URI or relative path to the Swagger document describing the API.
 CacheClusterEnabled | `boolean` | Indicates whether cache clustering is enabled for the stage.
 CacheClusterSize | `string` | The stage's cache cluster size.
 Variables | Map of `string` to `string` | A map (string to string map) that defines the stage variables, where the variable name is the key and the variable value is the value. Variable names are limited to alphanumeric characters. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&amp;=,-]+`.


### PR DESCRIPTION
Clarified documentation that DefinitionUri can support a relative path which is less steps than needing uploading the swagger definition to S3 first.