### PR TITLE
Elaborate on setting status code when using lambda as API

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -270,7 +270,7 @@ BatchSize: 10
 
 The object describing an event source with type `Api`.
 
-If an [AWS::Serverless::Api](#aws-serverless-api) resource is defined, the path and method values MUST correspond to an operation in the Swagger definition of the API. If no [AWS::Serverless::Api](#aws-serverless-api) is defined, the function input and output are a representation of the HTTP request and HTTP response.
+If an [AWS::Serverless::Api](#aws-serverless-api) resource is defined, the path and method values MUST correspond to an operation in the Swagger definition of the API. If no [AWS::Serverless::Api](#aws-serverless-api) is defined, the function input and output are a representation of the HTTP request and HTTP response. For example, using the JavaScript API, the status code and body of the response can be controlled by returning an object with the keys `statusCode` and `body`.
 
 ##### Properties
 


### PR DESCRIPTION
Hi!

I just spent quite a while trying to understand how I could control the status code of my response when using a `Serverless::Function`.

I have added a sentence to the relevant piece of documentation to more clearly state that the return value from the function is constructed into a response object. This documentation would have saved me a few hours of pain, so hopefully this will help future users with the same question.

This does not appear to be documented clearly in any other location, but if it is, please point me in the right direction.

If you desire for this change to be made in a different format or in a different place, let me know and I will do so.

Thanks!

😺 🌮 

