### PR TITLE
Fix CORS template to use '200' instead of 200

### DIFF
--- a/examples/2016-10-31/api_swagger_cors/swagger.yaml
+++ b/examples/2016-10-31/api_swagger_cors/swagger.yaml
@@ -11,7 +11,7 @@ paths:
       produces:
       - application/json
       responses:
-        200:
+        '200':
           description: 200 response
           schema:
             $ref: "#/definitions/Empty"
@@ -31,7 +31,7 @@ paths:
       produces:
       - application/json
       responses:
-        200:
+        '200':
           description: 200 response
           schema:
             $ref: "#/definitions/Empty"
@@ -76,7 +76,7 @@ paths:
       produces:
       - application/json
       responses:
-        200:
+        '200':
           description: 200 response
           schema:
             $ref: "#/definitions/Empty"


### PR DESCRIPTION
An error occurred (ValidationError) when calling the CreateChangeSet operation: Template format error: [/Resources/ApiGatewayApi/Properties/DefinitionBody/paths//api/networth/options/responses] map keys must be strings; received numeric [200] instead