### PR TITLE
fix: missing Ref in intrinsic function call

### DIFF
--- a/examples/2016-10-31/hello_world/template.yaml
+++ b/examples/2016-10-31/hello_world/template.yaml
@@ -13,5 +13,5 @@ Resources:
       Handler: index.handler
       Runtime: nodejs6.10
       CodeUri:
-        Bucket: !Bucket
-        Key: !CodeZipKey
+        Bucket: !Ref Bucket
+        Key: !Ref CodeZipKey


### PR DESCRIPTION
Keyword **Ref** is required in templates to refer to values from Parameters or Resources.