### PR TITLE
Adds sample template and sample code for Lambda@Edge

### DIFF
--- a/examples/2016-10-31/lambda_edge/README.md
+++ b/examples/2016-10-31/lambda_edge/README.md
@@ -1,0 +1,40 @@
+## Lambda@Edge sample
+
+This example leverages [SAM Safe Deployments feature](https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst) in order to ease Lambda@Edge deployments by automatically publishing a new version upon deployments. Since SAM supports standard Cloudformation resources Cloudfront Distribution configuration will be automatically updated as soon as a new Lambda function version is available.
+
+The following Lambda function snippet uses ``AutoPublishAlias`` property which provides an additional property named `<LogicalName>.Version`:
+
+```yaml
+LambdaEdgeFunctionSample:
+    Type: AWS::Serverless::Function
+    Properties:
+        CodeUri: s3://<bucket>/lambda_edge.zip
+        Runtime: nodejs6.10
+        Handler: app.handler
+        Timeout: 5
+        # More info at https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst
+        AutoPublishAlias: live 
+```
+
+We can now configure our [Cloudfront Distribution Lambda Association Property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-lambdafunctionassociation.html) to always reference the latest available Lambda Function Version ARN:
+
+```yaml
+CFDistribution:
+    Type: AWS::CloudFront::Distribution
+    Properties:
+    DistributionConfig:
+        Enabled: 'true'
+        ....
+        DefaultCacheBehavior:
+        
+        # Lambda@Edge configuration requires a function version not alias
+        LambdaFunctionAssociations:
+            - 
+            EventType: origin-request
+            # <SAM-Function.Version> provides {FunctionARN}:{Version} which is exactly what Cloudfront expects
+            # SAM Benefit here is upon function changes this function version will also be updated in Cloudfront
+            LambdaFunctionARN: !Ref LambdaEdgeFunctionSample.Version
+        ...
+```
+
+In this example, ``LambdaEdgeFunctionSample.Version`` will be evaluated as ``arn:aws:lambda:<aws-region>:<aws-account-id>:function:<lambda-function-name>:<version>`` which is expected input for Lambda@Edge. 

--- a/examples/2016-10-31/lambda_edge/index.js
+++ b/examples/2016-10-31/lambda_edge/index.js
@@ -1,0 +1,10 @@
+'use strict';
+
+exports.handler = (evt, ctx, cb) => {
+    console.log("New request received... adding Hello World HTTP Header");
+    var request = evt.Records[0].cf.request;
+    request.headers['hello'] = [{ key: 'hello', value: 'world'}];
+
+    cb(null, request);
+
+}

--- a/examples/2016-10-31/lambda_edge/template.yaml
+++ b/examples/2016-10-31/lambda_edge/template.yaml
@@ -1,0 +1,60 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Sample SAM configuration for Lambda@Edge to ease deployment and further updates
+Resources:
+
+    CFDistribution:
+      Type: AWS::CloudFront::Distribution
+      Properties:
+        DistributionConfig:
+          Enabled: 'true'
+          Comment: Lambda@Edge SAM Sample
+          DefaultRootObject: index.html
+          Origins:
+            -
+              Id: MyOrigin
+              DomainName: aws.amazon.com/lambda/edge/
+              CustomOriginConfig:
+                HTTPPort: 80
+                OriginProtocolPolicy: match-viewer
+          DefaultCacheBehavior:
+            TargetOriginId: MyOrigin
+            # Lambda@Edge configuration requires a function version not alias
+            LambdaFunctionAssociations:
+              - 
+                EventType: origin-request
+                # <SAM-Function.Version> provides {FunctionARN}:{Version} which is exactly what Cloudfront expects
+                # SAM Benefit here is upon function changes this function version will also be updated in Cloudfront
+                LambdaFunctionARN: !Ref LambdaEdgeFunctionSample.Version
+            ForwardedValues:
+              QueryString: 'false'
+              Headers:
+                - Origin
+              Cookies:
+                Forward: none
+            ViewerProtocolPolicy: allow-all
+
+    LambdaEdgeFunctionSample:
+        Type: AWS::Serverless::Function
+        Properties:
+          CodeUri: s3://<bucket>/lambda_edge.zip
+          Runtime: nodejs6.10
+          Handler: app.handler
+          Timeout: 5
+          # More info at https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst
+          AutoPublishAlias: live 
+
+
+Outputs:
+
+    LambdaEdgeFunctionSample: 
+      Description: Lambda@Edge Sample Function ARN
+      Value: !GetAtt LambdaEdgeFunctionSample.Arn
+
+    LambdaEdgeFunctionSampleVersion: 
+      Description: Lambda@Edge Sample Function ARN with Version
+      Value: !Ref LambdaEdgeFunctionSample.Version
+
+    CFDistribution: 
+      Description: Cloudfront Distribution Domain Name
+      Value: !GetAtt CFDistribution.DomainName

--- a/examples/2016-10-31/lambda_edge/template.yaml
+++ b/examples/2016-10-31/lambda_edge/template.yaml
@@ -38,12 +38,31 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
           CodeUri: s3://<bucket>/lambda_edge.zip
+          Role: !GetAtt LambdaEdgeFunctionRole.Arn
           Runtime: nodejs6.10
           Handler: app.handler
           Timeout: 5
           # More info at https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst
           AutoPublishAlias: live 
 
+    LambdaEdgeFunctionRole:
+      Type: "AWS::IAM::Role"
+      Properties:
+          Path: "/"
+          ManagedPolicyArns:
+              - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          AssumeRolePolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              -
+                Sid: "AllowLambdaServiceToAssumeRole"
+                Effect: "Allow"
+                Action: 
+                  - "sts:AssumeRole"
+                Principal:
+                  Service: 
+                    - "lambda.amazonaws.com"
+                    - "edgelambda.amazonaws.com"
 
 Outputs:
 


### PR DESCRIPTION
This PR adds a Lambda@Edge sample to ease the deployment task and facilitate further deployments that will automatically update Cloudfront configuration with the latest Lambda Function Version without any manual steps.

It leverages the new [Safe Deployments](https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst) feature to accomplish it.