### PR TITLE
Fix docs reference about hooks naming convention

### DIFF
--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -265,7 +265,7 @@ CodeDeploy assumes that there are no dependencies between Deployment Groups and 
 Since every Lambda function is to its own CodeDeploy DeploymentGroup, they will be deployed in parallel.
 The CodeDeploy service will assume the new CodeDeployServiceRole to Invoke any Pre/Post hook functions and perform the traffic shifting and Alias updates.
 
-  NOTE: The CodeDeployServiceRole only allows InvokeFunction on functions with names prefixed with  ``CodeDeploy_``. For example,  you should name your Hook functions as such: ``CodeDeploy_PreTrafficHook``.
+  NOTE: The CodeDeployServiceRole only allows InvokeFunction on functions with names prefixed with  ``CodeDeployHook_``. For example,  you should name your Hook functions as such: ``CodeDeployHook_PreTrafficHook``.
 
 
 .. _Globals: globals.rst


### PR DESCRIPTION
The IAM role CodeDeployServiceRole is created with this default policy that allows running the hook functions:
```
        {
            "Action": [
                "lambda:InvokeFunction"
            ],
            "Resource": "arn:aws:lambda:*:*:function:CodeDeployHook_*",
            "Effect": "Allow"
        }
```
Naming the hook functions as per the current docs prefixed just with`CodeDeploy_` would not match the policy so the CodeDeploy Deployment would not be able to run the hook. I tested and, as expected, it works fine when the hook functions are prefixed with `CodeDeployHook_`.