### PR TITLE
Added note about ~1 on BinaryMediaTypes, punctuation cleanup

### DIFF
--- a/examples/2016-10-31/implicit_api_settings/template.yaml
+++ b/examples/2016-10-31/implicit_api_settings/template.yaml
@@ -12,9 +12,9 @@ Globals:
 
     # Send/receive binary data through the APIs
     BinaryMediaTypes:
-      # This is equivalent to image/gif when deployed
+      # These are equivalent to image/gif and image/png when deployed
       - image~1gif
-      - iimage~1png
+      - image~1png
 
     # Logging, Metrics, Throttling, and all other Stage settings
     MethodSettings: [{

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -190,7 +190,7 @@ An `AWS::Serverless::Api` resource need not be explicitly added to a AWS Serverl
 
 Property Name | Type | Description
 ---|:---:|---
-Name | `string` | A name for the API Gateway RestApi resource
+Name | `string` | A name for the API Gateway RestApi resource.
 StageName | `string` | **Required** The name of the stage, which API Gateway uses as the first path segment in the invoke Uniform Resource Identifier (URI).
 DefinitionUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | S3 URI or location to the Swagger document describing the API. Either one of `DefinitionUri` or `DefinitionBody` must be specified.
 DefinitionBody | `JSON or YAML Object` | Swagger specification that describes your API. Either one of `DefinitionUri` or `DefinitionBody` must be specified.
@@ -198,9 +198,9 @@ CacheClusterEnabled | `boolean` | Indicates whether cache clustering is enabled 
 CacheClusterSize | `string` | The stage's cache cluster size.
 Variables | Map of `string` to `string` | A map (string to string map) that defines the stage variables, where the variable name is the key and the variable value is the value. Variable names are limited to alphanumeric characters. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&amp;=,-]+`.
 MethodSettings | [CloudFormation MethodSettings property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html) | Configures all settings for API stage including Logging, Metrics, CacheTTL, Throttling. This value is passed through to CloudFormation. So any values supported by CloudFormation ``MethodSettings`` property can be used here.
-EndpointConfiguration | `string` | Specify the type of endpoint for API endpoint. Value is either `REGIONAL` or `EDGE`
-BinaryMediaTypes | List of `string` |  List of MIME types that your API could return. Use this to enable binary support for APIs
-Cors | `string` or [Cors Configuration](#cors-configuration) | Enable CORS for all your APIs. Specify the domain to allow as a string or specify a dictionary with additional [Cors Configuration](#cors-configuration). NOTE: Cors requires SAM to modify your Swagger definition. Hence it works only inline swagger defined with `DefinitionBody`
+EndpointConfiguration | `string` | Specify the type of endpoint for API endpoint. Value is either `REGIONAL` or `EDGE`.
+BinaryMediaTypes | List of `string` |  List of MIME types that your API could return. Use this to enable binary support for APIs. Use `~1` instead of `/` in the mime types (See examples in [template.yaml](../examples/2016-10-31/implicit_api_settings/template.yaml)).
+Cors | `string` or [Cors Configuration](#cors-configuration) | Enable CORS for all your APIs. Specify the domain to allow as a string or specify a dictionary with additional [Cors Configuration](#cors-configuration). NOTE: Cors requires SAM to modify your Swagger definition. Hence it works only inline swagger defined with `DefinitionBody`.
 
 
 ##### Return values


### PR DESCRIPTION
*Description of changes:* Small documentation update, pointing out the use of `~1` on `BinaryMediaTypes`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
