### PR TITLE
Update links to Policy Templates for documentation

### DIFF
--- a/docs/policy_templates.rst
+++ b/docs/policy_templates.rst
@@ -73,5 +73,5 @@ folder.
     Policies:
       - CloudWatchPutMetricPolicy: {}      
 
-.. _policy_templates.json: policy_templates_data/policy_templates.json
-.. _all_policy_templates.yaml: ../examples/2016-10-31/policy_templates/all_policy_templates.yaml
+.. _policy_templates.json: https://github.com/awslabs/serverless-application-model/blob/develop/docs/policy_templates_data/policy_templates.json
+.. _all_policy_templates.yaml: https://github.com/awslabs/serverless-application-model/blob/develop/examples/2016-10-31/policy_templates/all_policy_templates.yaml


### PR DESCRIPTION
These links were broken in the documentation at https://awslabs.github.io/serverless-application-model/policy_templates.html

That's because they were relative links that didn't exist within the documentation website.
* OLD (Doesn't exist): https://awslabs.github.io/serverless-application-model/policy_templates_data/policy_templates.json
* NEW: https://github.com/awslabs/serverless-application-model/blob/develop/docs/policy_templates_data/policy_templates.json

There might be a more generic way to do this across all the documentation, but I don't know enough about Sphinx to do it generically.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
