### PR TITLE
fixing a typo in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The SAM specification and implementation are open sourced under the Apache 2.0 l
 
 
 ## Creating a serverless application using SAM
-To creating a serverless application using SAM, first, you create a SAM template: a JSON or YAML configuration file that describes your Lambda functions, API endpoints and the other resources in your application. Then, you test, upload, and deploy your application using the [SAM Local CLI](https://github.com/awslabs/aws-sam-local). During deployment, SAM automatically translates your application’s specification into CloudFormation syntax, filling in default values for any unspecified properties and determining the appropriate mappings and invocation permissions to setup for any Lambda functions.
+To create a serverless application using SAM, first, you create a SAM template: a JSON or YAML configuration file that describes your Lambda functions, API endpoints and the other resources in your application. Then, you test, upload, and deploy your application using the [SAM Local CLI](https://github.com/awslabs/aws-sam-local). During deployment, SAM automatically translates your application’s specification into CloudFormation syntax, filling in default values for any unspecified properties and determining the appropriate mappings and invocation permissions to setup for any Lambda functions.
 
 [Read the How-To Guide](HOWTO.md) and see [examples](examples/) to learn how to define & deploy serverless applications using SAM.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Readme.md said "To creating a serverless application using SAM"
Changed it to "To create a serverless application using SAM"

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
