### PR TITLE
Allow wildcard as a valid character in parameters

### DIFF
--- a/samtranslator/policy_templates_data/schema.json
+++ b/samtranslator/policy_templates_data/schema.json
@@ -23,7 +23,7 @@
       "title": "Object containing all parameters of a template",
       "type": "object",
       "patternProperties": {
-        "^[a-zA-Z0-9]+$": {
+        "^[*a-zA-Z0-9]+$": {
           "$ref": "#/definitions/parameter"
         }
       },


### PR DESCRIPTION
Issue: #368 

Allow `*` in parameters

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
