### PR TITLE
Remove redundant license clause from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,3 @@
 *Issue #, if available:*
 
 *Description of changes:*
-
-
-By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


### PR DESCRIPTION
I've added this PR to this repository for discussion's sake, but if this suggestion is applicable to all of Amazon's recently-published public GitHub repositories created from the same internal template.

---
Users accepting GitHub's Terms of Service already agree to license any contribution to a repository under the same terms as that repository's license, so including the same agreement in a Pull Request is redundant.

See: https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license:

> ### 6. Contributions Under Repository License
> Whenever you make a contribution to a repository containing notice of a license, you license your contribution under the same terms, and you agree that you have the right to license your contribution under those terms. If you have a separate agreement to license your contributions under different terms, such as a contributor license agreement, that agreement will supersede.
> 
> Isn't this just how it works already? Yep. This is widely accepted as the norm in the open-source community; it's commonly referred to by the shorthand "inbound=outbound". We're just making it explicit.

Removing this statement from your PR template will reduce friction and encourage more active community participation with less hesitation.