### PR TITLE
Add SSE to SimpleTable

### DIFF
--- a/docs/cloudformation_compatibility.rst
+++ b/docs/cloudformation_compatibility.rst
@@ -103,6 +103,7 @@ DynamoDB
 Stream                   All
 StartingPosition         All
 BatchSize                All
+SSESpecification         All
 ======================== ================================== ========================
 
 Api

--- a/docs/globals.rst
+++ b/docs/globals.rst
@@ -80,6 +80,9 @@ presently.
       BinaryMediaTypes:
       Cors:
 
+    SimpleTable:
+      SSESpecifiction
+
 Implicit APIs
 ~~~~~~~~~~~~~
 

--- a/docs/globals.rst
+++ b/docs/globals.rst
@@ -81,7 +81,7 @@ presently.
       Cors:
 
     SimpleTable:
-      SSESpecifiction
+      SSESpecification
 
 Implicit APIs
 ~~~~~~~~~~~~~

--- a/samtranslator/model/dynamodb.py
+++ b/samtranslator/model/dynamodb.py
@@ -14,7 +14,7 @@ class DynamoDBTable(Resource):
             'StreamSpecification': PropertyType(False, is_type(dict)),
             'TableName': PropertyType(False, one_of(is_str(), is_type(dict))),
             'Tags': PropertyType(False, list_of(is_type(dict))),
-            'SSESpecification': PropertyType(False, list_of(is_type(dict)))
+            'SSESpecification': PropertyType(False, is_type(dict))
     }
 
     runtime_attrs = {

--- a/samtranslator/model/dynamodb.py
+++ b/samtranslator/model/dynamodb.py
@@ -13,8 +13,9 @@ class DynamoDBTable(Resource):
             'ProvisionedThroughput': PropertyType(True, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),
             'StreamSpecification': PropertyType(False, is_type(dict)),
             'TableName': PropertyType(False, one_of(is_str(), is_type(dict))),
-            'Tags': PropertyType(False, list_of(is_type(dict)))
-        }
+            'Tags': PropertyType(False, list_of(is_type(dict))),
+            'SSESpecification': PropertyType(False, list_of(is_type(dict)))
+    }
 
     runtime_attrs = {
         "name": lambda self: ref(self.logical_id),

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -1,6 +1,7 @@
 from samtranslator.public.sdk.resource import SamResourceType
 from samtranslator.public.intrinsics import is_intrinsics
 
+
 class Globals(object):
     """
     Class to parse and process Globals section in SAM template. If a property is specified at Global section for
@@ -44,6 +45,10 @@ class Globals(object):
             "MethodSettings",
             "BinaryMediaTypes",
             "Cors"
+        ],
+
+        SamResourceType.SimpleTable.value: [
+            "SSESpecification"
         ]
     }
 
@@ -133,9 +138,6 @@ class Globals(object):
 
     def _make_resource_type(self, key):
         return self._RESOURCE_PREFIX + key
-
-
-
 
 class GlobalProperties(object):
     """
@@ -298,7 +300,6 @@ class GlobalProperties(object):
             raise TypeError(
                 "Unsupported type of objects. GlobalType={}, LocalType={}".format(token_global, token_local))
 
-
     def _merge_lists(self, global_list, local_list):
         """
         Merges the global list with the local list. List merging is simply a concatenation = global + local
@@ -368,7 +369,6 @@ class GlobalProperties(object):
 
         else:
             return self.TOKEN.PRIMITIVE
-
 
     class TOKEN:
         """

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -130,7 +130,6 @@ class Globals(object):
                                                    "Must be one of the following values - {supported}"
                                                    .format(key=key, section=section_name, supported=supported))
 
-
             # Store all Global properties in a map with key being the AWS::Serverless::* resource type
             globals[resource_type] = GlobalProperties(properties)
 
@@ -138,6 +137,7 @@ class Globals(object):
 
     def _make_resource_type(self, key):
         return self._RESOURCE_PREFIX + key
+
 
 class GlobalProperties(object):
     """
@@ -385,7 +385,7 @@ class InvalidGlobalsSectionException(Exception):
     Attributes:
         message -- explanation of the error
     """
-    def __init__(self, logical_id,  message):
+    def __init__(self, logical_id, message):
         self._logical_id = logical_id
         self._message = message
 

--- a/samtranslator/plugins/globals/globals_plugin.py
+++ b/samtranslator/plugins/globals/globals_plugin.py
@@ -5,6 +5,7 @@ from samtranslator.public.exceptions import InvalidDocumentException
 
 from samtranslator.plugins.globals.globals import Globals, InvalidGlobalsSectionException
 
+
 class GlobalsPlugin(BasePlugin):
     """
     Plugin to process Globals section of a SAM template before the template is translated to CloudFormation.

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -641,6 +641,9 @@
             },
             "ProvisionedThroughput": {
               "$ref": "#/definitions/AWS::Serverless::SimpleTable.ProvisionedThroughput"
+            },
+            "SSESpecification": {
+              "$ref": "#/definitions/AWS::Serverless::SimpleTable.SSESpecification"
             }
           },
           "type": "object"
@@ -684,6 +687,18 @@
       },
       "required": [
         "WriteCapacityUnits"
+      ],
+      "type": "object"
+    },
+    "AWS::Serverless::SimpleTable.SSESpecification": {
+      "additionalProperties": false,
+      "properties": {
+        "SSEEnabled": {
+          "type": "boolean"
+        }
+      },
+      "required": [
+        "SSEEnabled"
       ],
       "type": "object"
     },

--- a/tests/translator/input/globals_for_simpletable.yaml
+++ b/tests/translator/input/globals_for_simpletable.yaml
@@ -1,0 +1,8 @@
+Globals:
+  SimpleTable:
+    SSESpecification:
+      SSEEnabled: true
+
+Resources:
+  MinimalTable:
+    Type: AWS::Serverless::SimpleTable

--- a/tests/translator/input/simple_table_ref_parameter_intrinsic.yaml
+++ b/tests/translator/input/simple_table_ref_parameter_intrinsic.yaml
@@ -7,3 +7,6 @@ Resources:
           Ref: ReadCapacity
         WriteCapacityUnits:
           Ref: WriteCapacity
+      SSESpecification:
+        SSEEnabled:
+          Ref: EnableSSE

--- a/tests/translator/input/simpletable_with_sse.yaml
+++ b/tests/translator/input/simpletable_with_sse.yaml
@@ -1,0 +1,6 @@
+Resources:
+  TableWithSSE:
+    Type: 'AWS::Serverless::SimpleTable'
+    Properties:
+        SSESpecification:
+          SSEEnabled: true

--- a/tests/translator/output/aws-cn/globals_for_simpletable.json
+++ b/tests/translator/output/aws-cn/globals_for_simpletable.json
@@ -1,0 +1,28 @@
+{
+    "Resources": {
+      "MinimalTable": {
+        "Type": "AWS::DynamoDB::Table", 
+        "Properties": {
+          "ProvisionedThroughput": {
+            "WriteCapacityUnits": 5, 
+            "ReadCapacityUnits": 5
+          },
+          "SSESpecification": {
+              "SSEEnabled": true
+          },
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id", 
+              "AttributeType": "S"
+            }
+          ], 
+          "KeySchema": [
+            {
+              "KeyType": "HASH", 
+              "AttributeName": "id"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-cn/simple_table_ref_parameter_intrinsic.json
+++ b/tests/translator/output/aws-cn/simple_table_ref_parameter_intrinsic.json
@@ -17,6 +17,11 @@
             "AttributeType": "S"
           }
         ],
+        "SSESpecification": {
+          "SSEEnabled": {
+            "Ref": "EnableSSE"
+          }
+        },
         "KeySchema": [
           {
             "KeyType": "HASH",

--- a/tests/translator/output/aws-cn/simpletable_with_sse.json
+++ b/tests/translator/output/aws-cn/simpletable_with_sse.json
@@ -1,0 +1,28 @@
+{
+    "Resources": {
+      "TableWithSSE": {
+        "Type": "AWS::DynamoDB::Table", 
+        "Properties": {
+          "ProvisionedThroughput": {
+            "WriteCapacityUnits": 5, 
+            "ReadCapacityUnits": 5
+          }, 
+          "SSESpecification": {
+            "SSEEnabled": true
+          },
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id", 
+              "AttributeType": "S"
+            }
+          ], 
+          "KeySchema": [
+            {
+              "KeyType": "HASH", 
+              "AttributeName": "id"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-us-gov/globals_for_simpletable.json
+++ b/tests/translator/output/aws-us-gov/globals_for_simpletable.json
@@ -1,0 +1,28 @@
+{
+    "Resources": {
+      "MinimalTable": {
+        "Type": "AWS::DynamoDB::Table", 
+        "Properties": {
+          "ProvisionedThroughput": {
+            "WriteCapacityUnits": 5, 
+            "ReadCapacityUnits": 5
+          },
+          "SSESpecification": {
+              "SSEEnabled": true
+          },
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id", 
+              "AttributeType": "S"
+            }
+          ], 
+          "KeySchema": [
+            {
+              "KeyType": "HASH", 
+              "AttributeName": "id"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-us-gov/simple_table_ref_parameter_intrinsic.json
+++ b/tests/translator/output/aws-us-gov/simple_table_ref_parameter_intrinsic.json
@@ -11,6 +11,11 @@
             "Ref": "ReadCapacity"
           }
         },
+        "SSESpecification": {
+          "SSEEnabled": {
+            "Ref": "EnableSSE"
+          }
+        },
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/aws-us-gov/simpletable_with_sse.json
+++ b/tests/translator/output/aws-us-gov/simpletable_with_sse.json
@@ -1,0 +1,28 @@
+{
+    "Resources": {
+      "TableWithSSE": {
+        "Type": "AWS::DynamoDB::Table", 
+        "Properties": {
+          "ProvisionedThroughput": {
+            "WriteCapacityUnits": 5, 
+            "ReadCapacityUnits": 5
+          }, 
+          "SSESpecification": {
+            "SSEEnabled": true
+          },
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id", 
+              "AttributeType": "S"
+            }
+          ], 
+          "KeySchema": [
+            {
+              "KeyType": "HASH", 
+              "AttributeName": "id"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/tests/translator/output/error_globals_unsupported_type.json
+++ b/tests/translator/output/error_globals_unsupported_type.json
@@ -1,8 +1,8 @@
 {
   "errors": [
     {
-      "errorMessage": "'Globals' section is invalid. 'NewType' is not supported. Must be one of the following values - ['Function', 'Api']"
+      "errorMessage": "'Globals' section is invalid. 'NewType' is not supported. Must be one of the following values - ['Function', 'SimpleTable', Api']"
     }
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. 'Globals' section is invalid. 'NewType' is not supported. Must be one of the following values - ['Function', 'Api']"
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. 'Globals' section is invalid. 'NewType' is not supported. Must be one of the following values - ['Function', 'SimpleTable', 'Api']"
 }

--- a/tests/translator/output/globals_for_simpletable.json
+++ b/tests/translator/output/globals_for_simpletable.json
@@ -1,0 +1,28 @@
+{
+    "Resources": {
+      "MinimalTable": {
+        "Type": "AWS::DynamoDB::Table", 
+        "Properties": {
+          "ProvisionedThroughput": {
+            "WriteCapacityUnits": 5, 
+            "ReadCapacityUnits": 5
+          },
+          "SSESpecification": {
+              "SSEEnabled": true
+          },
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id", 
+              "AttributeType": "S"
+            }
+          ], 
+          "KeySchema": [
+            {
+              "KeyType": "HASH", 
+              "AttributeName": "id"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/tests/translator/output/simple_table_ref_parameter_intrinsic.json
+++ b/tests/translator/output/simple_table_ref_parameter_intrinsic.json
@@ -11,6 +11,11 @@
             "Ref": "ReadCapacity"
           }
         },
+        "SSESpecification": {
+          "SSEEnabled": {
+            "Ref": "EnableSSE"
+          }
+        },
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/simpletable_with_sse.json
+++ b/tests/translator/output/simpletable_with_sse.json
@@ -1,0 +1,28 @@
+{
+    "Resources": {
+      "TableWithSSE": {
+        "Type": "AWS::DynamoDB::Table", 
+        "Properties": {
+          "ProvisionedThroughput": {
+            "WriteCapacityUnits": 5, 
+            "ReadCapacityUnits": 5
+          }, 
+          "SSESpecification": {
+            "SSEEnabled": true
+          },
+          "AttributeDefinitions": [
+            {
+              "AttributeName": "id", 
+              "AttributeType": "S"
+            }
+          ], 
+          "KeySchema": [
+            {
+              "KeyType": "HASH", 
+              "AttributeName": "id"
+            }
+          ]
+        }
+      }
+    }
+  }

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -92,6 +92,7 @@ class TestTranslatorEndToEnd(TestCase):
         'function_with_policy_templates',
         'globals_for_function',
         'globals_for_api',
+        'globals_for_simpletable',
         'all_policy_templates',
         'simple_table_ref_parameter_intrinsic',
         'simple_table_with_table_name',

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -47,6 +47,7 @@ class TestTranslatorEndToEnd(TestCase):
         'cloudwatchlog',
         'streams',
         'simpletable',
+        'simpletable_with_sse',
         'implicit_api',
         'explicit_api',
         'api_endpoint_configuration',

--- a/tests/translator/validator/test_validator.py
+++ b/tests/translator/validator/test_validator.py
@@ -13,6 +13,7 @@ input_folder = 'tests/translator/input'
     'cloudwatchlog',
     'streams',
     'simpletable',
+    'simpletable_with_sse',
     'implicit_api',
     'explicit_api',
     'api_endpoint_configuration',

--- a/tests/translator/validator/test_validator.py
+++ b/tests/translator/validator/test_validator.py
@@ -58,6 +58,7 @@ input_folder = 'tests/translator/input'
     'function_with_policy_templates',
     'globals_for_function',
     'globals_for_api',
+    'globals_for_simpletable',
     'all_policy_templates',
     'simple_table_ref_parameter_intrinsic',
     'simple_table_with_table_name',

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -69,6 +69,10 @@ Globals:
   Api:
     EndpointConfiguration: REGIONAL
     Cors: "'www.example.com'"
+
+  SimpleTable:
+    SSESpecification:
+      SSEEnabled: true
 ```
 
 

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -232,6 +232,7 @@ PrimaryKey | [Primary Key Object](#primary-key-object) | Attribute name and type
 ProvisionedThroughput | [Provisioned Throughput Object](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html) | Read and write throughput provisioning information. Defaults to 5 read and 5 write capacity units per second.
 Tags | Map of `string` to `string` | A map (string to string) that specifies the tags to be added to this table. Keys and values are limited to alphanumeric characters. 
 TableName | `string` | Name for the DynamoDB Table
+SSESpecification | [DynamoDB SSESpecification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html) | Specifies the settings to enable server-side encryption.
 
 ##### Return values
 
@@ -252,6 +253,8 @@ ProvisionedThroughput:
 Tags:
   Department: Engineering
   AppType: Serverless
+SSESpecification:
+  SSEEnabled: true
 ```
 
 ### Event source types


### PR DESCRIPTION
Closes #376 

Adding optional [SSE](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html) to `AWS::Serverless::SimpleTable`.  See #376 for more info.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
