### PR TITLE
doc: fix preTrafficHook link at lambda_safe_deployment

### DIFF
--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -147,7 +147,7 @@ NOTE: Verify that your AWS SDK version supports PutLifecycleEventHookExecutionSt
 
 .. _PutLifecycleEventHookExecutionStatus: https://docs.aws.amazon.com/codedeploy/latest/APIReference/API_PutLifecycleEventHookExecutionStatus.html
 
-.. _Here: https://github.com/awslabs/serverless-application-model/blob/master/examples/2016-10-31/lambda_safe_deployments/preTrafficHook.js
+.. _Here: https://github.com/awslabs/serverless-application-model/blob/master/examples/2016-10-31/lambda_safe_deployments/src/preTrafficHook.js
 
 Traffic Shifting Configurations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Link is missing the `/src` dir prefix, leading to 404.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
