### PR TITLE
[Small fix] SAM Translator install fails on Py3.2.3 or higher

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -2,7 +2,7 @@ boto3>=1.6.2
 botocore>=1.9.2
 docutils==0.14
 enum34==1.1.6
-functools32==3.2.3.post2
+functools32==3.2.3.post2; python_version<"3.2.3"
 futures==3.2.0
 jmespath==0.9.3
 jsonschema==2.6.0


### PR DESCRIPTION
… or else ignore it

*Issue #, if available:*

*Description of changes:*

**Functools32** dependency is only required for Python versions older than 3.2.3 otherwise it will fail installation - This PR adds a marker to prevent that from happening

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
