### PR TITLE
Removing unnecessary dependencies from requirements file

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,12 +1,5 @@
-boto3>=1.6.2
-botocore>=1.9.2
-docutils==0.14
-enum34==1.1.6
-functools32==3.2.3.post2
-futures==3.2.0
-jmespath==0.9.3
-jsonschema==2.6.0
-python-dateutil==2.6.1
-PyYAML==3.12
-s3transfer==0.1.13
-six==1.11.0
+boto3~=1.5.0
+enum34~=1.1.6
+jsonschema~=2.6.0
+six~=1.11.0
+

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -3,6 +3,7 @@ flake8>=3.3.0
 tox>=2.2.1
 pytest-cov>=2.4.0
 pylint>=1.7.2
+PyYAML==3.12
 
 # Test requirements
 pytest>=3.0.7


### PR DESCRIPTION
*Issue #, if available:*
Requirements file lists transitive dependencies of boto3 and not the own dependencies. This makes pip install fail in several of my machines because older version of these libraries were already installed.

*Description of changes:*
`boto3`: Many users might have this library already available in thier
Python installation from installing the AWS CLI. We use boto3 in
only one place, which is to get the region_name from `boto3.session.Session`
which hasn't changed since 2016. Updating the requirement to depend on
boto3 >=1.5.0 allows us to be compatible with existing installations that
might already have an older version of boto3

`botocore, docutils, futures, jmespath, python-dateutil, s3transfer`: These
packages are not used in the SAM translator but come as a dependency through
boto3. Hence removing the direct dependency.

`functools32`: Grepped for every single method offered by this package. We don't
use any of it directly within SAM Translator. This might have come as a
dependency through boto3.

`PyYAML`: Only required by the tests. So moving to dev dependency

`six`: Reducing the specificity of version requirement

`~=`: Using this operator in order to accept to a compatible minor/patch version
but preventing a major version change.

**Testing**:
- `make pr` and `make test` pass. Built a tar.gz distribution using
  `python setup.py sdist` and installed it in a clean virtualenv
  successfully. Tests ran successfully too. I was also able to import


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
