### PR TITLE
Added two templates to policy templates. Both are read only API calls…

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -628,6 +628,7 @@
             "Action": [
               "ses:GetIdentityVerificationAttributes",
               "ses:SendEmail",
+              "ses:SendRawEmail",
               "ses:VerifyEmailIdentity"
             ],
             "Resource": {
@@ -1357,6 +1358,37 @@
             "Resource": "*"
           }
         ]
+      }
+    },
+    "CostExplorerReadOnlyPolicy": {
+      "Description": "Gives access to the readonly Cost Explorer APIs for billing history",
+      "Parameters": {},
+      "Definition": {
+        "Statement": [{
+          "Effect": "Allow",
+          "Action": [
+            "ce:GetCostAndUsage",
+            "ce:GetDimensionValues",
+            "ce:GetReservationCoverage",
+            "ce:GetReservationPurchaseRecommendation",
+            "ce:GetReservationUtilization",
+            "ce:GetTags"
+          ],
+          "Resource": "*"
+        }]
+      }
+    },
+    "OrganizationsListAccountsPolicy": {
+      "Description": "Gives readonly permission to list child account names and ids",
+      "Parameters": {},
+      "Definition": {
+        "Statement": [{
+          "Effect": "Allow",
+          "Action": [
+            "organizations:ListAccounts"
+          ],
+          "Resource": "*"
+        }]
       }
     }
   }

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -125,3 +125,7 @@ Resources:
             CollectionId: collection
 
         - EKSDescribePolicy: {}
+        
+        - CostExplorerReadOnlyPolicy: {}
+        
+        - OrganizationsListAccountsPolicy: {}

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -502,6 +502,7 @@
                   "Action": [
                     "ses:GetIdentityVerificationAttributes", 
                     "ses:SendEmail", 
+                    "ses:SendRawEmail",
                     "ses:VerifyEmailIdentity"
                   ], 
                   "Resource": {
@@ -1039,6 +1040,37 @@
                     "eks:ListClusters"
                   ],
                   "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy42", 
+            "PolicyDocument": {
+              "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                  "ce:GetCostAndUsage",
+                  "ce:GetDimensionValues",
+                  "ce:GetReservationCoverage",
+                  "ce:GetReservationPurchaseRecommendation",
+                  "ce:GetReservationUtilization",
+                  "ce:GetTags"
+                ],
+                "Resource": "*"
+              }]
+            }
+          }, 
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy43", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "organizations:ListAccounts"
+                  ], 
+                  "Resource": "*", 
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -502,6 +502,7 @@
                   "Action": [
                     "ses:GetIdentityVerificationAttributes", 
                     "ses:SendEmail", 
+                    "ses:SendRawEmail",
                     "ses:VerifyEmailIdentity"
                   ], 
                   "Resource": {
@@ -1039,6 +1040,37 @@
                     "eks:ListClusters"
                   ],
                   "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy42", 
+            "PolicyDocument": {
+              "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                  "ce:GetCostAndUsage",
+                  "ce:GetDimensionValues",
+                  "ce:GetReservationCoverage",
+                  "ce:GetReservationPurchaseRecommendation",
+                  "ce:GetReservationUtilization",
+                  "ce:GetTags"
+                ],
+                "Resource": "*"
+              }]
+            }
+          }, 
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy43", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "organizations:ListAccounts"
+                  ], 
+                  "Resource": "*", 
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -502,6 +502,7 @@
                   "Action": [
                     "ses:GetIdentityVerificationAttributes", 
                     "ses:SendEmail", 
+                    "ses:SendRawEmail",
                     "ses:VerifyEmailIdentity"
                   ], 
                   "Resource": {
@@ -1040,6 +1041,37 @@
                     "eks:ListClusters"
                   ],
                   "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy42", 
+            "PolicyDocument": {
+              "Statement": [{
+                "Effect": "Allow",
+                "Action": [
+                  "ce:GetCostAndUsage",
+                  "ce:GetDimensionValues",
+                  "ce:GetReservationCoverage",
+                  "ce:GetReservationPurchaseRecommendation",
+                  "ce:GetReservationUtilization",
+                  "ce:GetTags"
+                ],
+                "Resource": "*"
+              }]
+            }
+          }, 
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy43", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "organizations:ListAccounts"
+                  ], 
+                  "Resource": "*", 
                   "Effect": "Allow"
                 }
               ]


### PR DESCRIPTION
… (ce:* and Organizations:ListAccounts), that cannot be resource scoped, useful for using lambda for cost reporting. Also added SendRawEmail to existing SESCrudPolicy

*Issue #, if available:*

*Description of changes:*
Two new read-only policy templates to support adding https://github.com/aws-samples/aws-cost-explorer-report to the Serverless Application Repository. API calls do not support resource downscoping due to nature of calls.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
