### PR TITLE
Correcting import errors when installed with aws-sam-cli 0.3.0

### DIFF
--- a/samtranslator/model/eventsources/cloudwatchlogs.py
+++ b/samtranslator/model/eventsources/cloudwatchlogs.py
@@ -3,7 +3,8 @@ from samtranslator.model.types import is_str
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.model.intrinsics import fnSub
 from samtranslator.model.log import SubscriptionFilter
-from push import PushEventSource
+from samtranslator.model.eventsources.push import PushEventSource
+
 
 class CloudWatchLogs(PushEventSource):
     """CloudWatch Logs event source for SAM Functions."""

--- a/samtranslator/model/preferences/deployment_preference_collection.py
+++ b/samtranslator/model/preferences/deployment_preference_collection.py
@@ -1,4 +1,4 @@
-from deployment_preference import DeploymentPreference
+from samtranslator.model.preferences.deployment_preference import DeploymentPreference
 from samtranslator.model.codedeploy import CodeDeployApplication
 from samtranslator.model.codedeploy import CodeDeployDeploymentGroup
 from samtranslator.model.iam import IAMRole

--- a/samtranslator/model/s3_utils/uri_parser.py
+++ b/samtranslator/model/s3_utils/uri_parser.py
@@ -1,4 +1,7 @@
-from urlparse import urlparse, parse_qs
+try:
+    from urlparse import urlparse, parse_qs
+except ImportError:
+    from urllib.parse import urlparse, parse_qs
 
 from six import string_types
 

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1,8 +1,6 @@
 """ SAM macro definitions """
-from copy import deepcopy
-
 from six import string_types
-from tags.resource_tagging import get_tag_list
+from samtranslator.model.tags.resource_tagging import get_tag_list
 import samtranslator.model.eventsources
 import samtranslator.model.eventsources.pull
 import samtranslator.model.eventsources.push
@@ -19,8 +17,8 @@ from samtranslator.model.types import dict_of, is_str, is_type, list_of, one_of,
 from samtranslator.model.function_policies import FunctionPolicies, PolicyTypes
 from samtranslator.translator import logical_id_generator
 from samtranslator.translator.arn_generator import ArnGenerator
-from api.api_generator import ApiGenerator
-from s3_utils.uri_parser import parse_s3_uri
+from samtranslator.model.api.api_generator import ApiGenerator
+from samtranslator.model.s3_utils.uri_parser import parse_s3_uri
 
 
 class SamFunction(SamResourceMacro):

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -1,15 +1,16 @@
 from samtranslator.public.sdk.resource import SamResourceType
 from samtranslator.public.intrinsics import is_intrinsics
 
+# Key of the dictionary containing Globals section in SAM template
+_KEYWORD = "Globals"
+_RESOURCE_PREFIX = "AWS::Serverless::"
+
+
 class Globals(object):
     """
     Class to parse and process Globals section in SAM template. If a property is specified at Global section for
     say Function, then this class will add it to each resource of AWS::Serverless::Function type.
     """
-
-    # Key of the dictionary containing Globals section in SAM template
-    _KEYWORD = "Globals"
-    _RESOURCE_PREFIX = "AWS::Serverless::"
 
     supported_properties = {
         # Everything on Serverless::Function except Role, Policies, FunctionName, Events
@@ -57,8 +58,8 @@ class Globals(object):
         """
         self.template_globals = {}
 
-        if self._KEYWORD in template:
-            self.template_globals = self._parse(template[self._KEYWORD])
+        if _KEYWORD in template:
+            self.template_globals = self._parse(template[_KEYWORD])
 
     def merge(self, resource_type, resource_properties):
         """
@@ -102,25 +103,25 @@ class Globals(object):
         globals = {}
 
         if not isinstance(globals_dict, dict):
-            raise InvalidGlobalsSectionException(self._KEYWORD, "It must be a non-empty dictionary".format(self._KEYWORD))
+            raise InvalidGlobalsSectionException(_KEYWORD, "It must be a non-empty dictionary".format(_KEYWORD))
 
         for section_name, properties in globals_dict.iteritems():
             resource_type = self._make_resource_type(section_name)
 
             if resource_type not in self.supported_properties:
-                raise InvalidGlobalsSectionException(self._KEYWORD,
+                raise InvalidGlobalsSectionException(_KEYWORD,
                                                "'{section}' is not supported. "
                                                "Must be one of the following values - {supported}"
                                                .format(section=section_name,
                                                        supported=self.supported_resource_section_names))
 
             if not isinstance(properties, dict):
-                raise InvalidGlobalsSectionException(self._KEYWORD, "Value of ${section} must be a dictionary")
+                raise InvalidGlobalsSectionException(_KEYWORD, "Value of ${section} must be a dictionary")
 
             for key, value in properties.iteritems():
                 supported = self.supported_properties[resource_type]
                 if key not in supported:
-                    raise InvalidGlobalsSectionException(self._KEYWORD,
+                    raise InvalidGlobalsSectionException(_KEYWORD,
                                                    "'{key}' is not a supported property of '{section}'. "
                                                    "Must be one of the following values - {supported}"
                                                    .format(key=key, section=section_name, supported=supported))
@@ -132,7 +133,7 @@ class Globals(object):
         return globals
 
     def _make_resource_type(self, key):
-        return self._RESOURCE_PREFIX + key
+        return _RESOURCE_PREFIX + key
 
 
 

--- a/samtranslator/region_configuration.py
+++ b/samtranslator/region_configuration.py
@@ -1,4 +1,5 @@
-from translator.arn_generator import ArnGenerator
+from samtranslator.translator.arn_generator import ArnGenerator
+
 
 class RegionConfiguration(object):
     """

--- a/samtranslator/validator/validator.py
+++ b/samtranslator/validator/validator.py
@@ -1,7 +1,10 @@
 import json
+
 import jsonschema
 from jsonschema.exceptions import ValidationError
-import sam_schema
+
+from samtranslator.validator import sam_schema
+
 
 class SamTemplateValidator(object):
 


### PR DESCRIPTION
*Issue #, if available:*

I encountered numerous ImportErrors when installing `aws-sam-cli` 0.3.0 and worked through all of them when just trying to invoke the utility to display help text.

*Description of changes:*

Removed relative imports and replaced with absolute imports. Also moved two class variables to global variables in `globals.py` and updated accordingly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
