### PR TITLE
add support for InlineCode in AWS::Serverless::Function

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -34,7 +34,8 @@ class SamFunction(SamResourceMacro):
         'FunctionName': PropertyType(False, one_of(is_str(), is_type(dict))),
         'Handler': PropertyType(True, is_str()),
         'Runtime': PropertyType(True, is_str()),
-        'CodeUri': PropertyType(True, one_of(is_str(), is_type(dict))),
+        'CodeUri': PropertyType(False, one_of(is_str(), is_type(dict))),
+        'ZipFile': PropertyType(False, one_of(is_str(), is_type(dict))),
         'DeadLetterQueue': PropertyType(False, is_type(dict)),
         'Description': PropertyType(False, is_str()),
         'MemorySize': PropertyType(False, is_type(int)),
@@ -313,6 +314,16 @@ class SamFunction(SamResourceMacro):
         return resources
 
     def _construct_code_dict(self):
+        if self.CodeUri:
+            return self._construct_code_dict_code_uri()
+        elif self.ZipFile:
+            return {
+                "ZipFile": self.ZipFile
+            }
+        else:
+            raise InvalidResourceException(self.logical_id, "Either 'ZipFile' or 'CodeUri' must be set")
+
+    def _construct_code_dict_code_uri(self):
         """Constructs the Lambda function's `Code property`_, from the SAM function's CodeUri property.
 
         .. _Code property: \

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -35,7 +35,7 @@ class SamFunction(SamResourceMacro):
         'Handler': PropertyType(True, is_str()),
         'Runtime': PropertyType(True, is_str()),
         'CodeUri': PropertyType(False, one_of(is_str(), is_type(dict))),
-        'ZipFile': PropertyType(False, one_of(is_str(), is_type(dict))),
+        'InlineCode': PropertyType(False, one_of(is_str(), is_type(dict))),
         'DeadLetterQueue': PropertyType(False, is_type(dict)),
         'Description': PropertyType(False, is_str()),
         'MemorySize': PropertyType(False, is_type(int)),
@@ -316,12 +316,12 @@ class SamFunction(SamResourceMacro):
     def _construct_code_dict(self):
         if self.CodeUri:
             return self._construct_code_dict_code_uri()
-        elif self.ZipFile:
+        elif self.InlineCode:
             return {
-                "ZipFile": self.ZipFile
+                "ZipFile": self.InlineCode
             }
         else:
-            raise InvalidResourceException(self.logical_id, "Either 'ZipFile' or 'CodeUri' must be set")
+            raise InvalidResourceException(self.logical_id, "Either 'InlineCode' or 'CodeUri' must be set")
 
     def _construct_code_dict_code_uri(self):
         """Constructs the Lambda function's `Code property`_, from the SAM function's CodeUri property.

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -60,8 +60,12 @@
             },
             "StageName": {
               "anyOf": [
-                { "type": "string" },
-                { "type": "object" }
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "object"
+                }
               ]
             },
             "Variables": {
@@ -69,8 +73,12 @@
               "patternProperties": {
                 "^[a-zA-Z0-9]+$": {
                   "anyOf": [
-                    { "type": "string" },
-                    { "type": "object" }
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object"
+                    }
                   ]
                 }
               },
@@ -144,108 +152,129 @@
           "type": "object"
         },
         "Properties": {
-          "additionalProperties": false,
-          "properties": {
-            "CodeUri": {
+          "allOf": [
+            {
               "anyOf": [
                 {
-                  "type": [
-                    "string"
-                  ]
+                  "properties": {
+                    "ZipFile": {
+                      "type": "string"
+                    }
+                  }
                 },
                 {
-                  "$ref": "#/definitions/AWS::Serverless::Function.S3Location"
+                  "properties": {
+                    "CodeUri": {
+                      "anyOf": [
+                        {
+                          "type": [
+                            "string"
+                          ]
+                        },
+                        {
+                          "$ref": "#/definitions/AWS::Serverless::Function.S3Location"
+                        }
+                      ]
+                    }
+                  }
                 }
               ]
             },
-            "DeadLetterQueue": {
-              "$ref": "#/definitions/AWS::Serverless::Function.DeadLetterQueue"
-            },
-            "Description": {
-              "type": "string"
-            },
-            "Environment": {
-              "$ref": "#/definitions/AWS::Serverless::Function.FunctionEnvironment"
-            },
-            "Events": {
-              "additionalProperties": false,
-              "patternProperties": {
-                "^[a-zA-Z0-9]+$": {
-                  "$ref": "#/definitions/AWS::Serverless::Function.EventSource"
-                }
-              },
-              "type": "object"
-            },
-            "FunctionName": {
-              "type": "string"
-            },
-            "Handler": {
-              "type": "string"
-            },
-            "KmsKeyArn": {
-              "type": "string"
-            },
-            "MemorySize": {
-              "type": "number"
-            },
-            "Policies": {
-              "anyOf": [
-                {
-                  "type": [
-                    "string"
-                  ]
+            {
+              "properties": {
+                "DeadLetterQueue": {
+                  "$ref": "#/definitions/AWS::Serverless::Function.DeadLetterQueue"
                 },
-                {
-                  "items": {
-                    "type": "string"
-                  },
-                  "type": "array"
-                },
-                {
-                  "$ref": "#/definitions/AWS::Serverless::Function.IAMPolicyDocument"
-                },
-                {
-                  "items": {
-                    "$ref": "#/definitions/AWS::Serverless::Function.IAMPolicyDocument"
-                  },
-                  "type": "array"
-                }
-              ]
-            },
-            "Role": {
-              "anyOf": [
-                { "type": "string" },
-                { "type": "object" }
-              ]
-            },
-            "Runtime": {
-              "type": "string"
-            },
-            "Tags": {
-              "additionalProperties": false,
-              "patternProperties": {
-                "^[a-zA-Z0-9]+$": {
+                "Description": {
                   "type": "string"
+                },
+                "Environment": {
+                  "$ref": "#/definitions/AWS::Serverless::Function.FunctionEnvironment"
+                },
+                "Events": {
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^[a-zA-Z0-9]+$": {
+                      "$ref": "#/definitions/AWS::Serverless::Function.EventSource"
+                    }
+                  },
+                  "type": "object"
+                },
+                "FunctionName": {
+                  "type": "string"
+                },
+                "Handler": {
+                  "type": "string"
+                },
+                "KmsKeyArn": {
+                  "type": "string"
+                },
+                "MemorySize": {
+                  "type": "number"
+                },
+                "Policies": {
+                  "anyOf": [
+                    {
+                      "type": [
+                        "string"
+                      ]
+                    },
+                    {
+                      "items": {
+                        "type": "string"
+                      },
+                      "type": "array"
+                    },
+                    {
+                      "$ref": "#/definitions/AWS::Serverless::Function.IAMPolicyDocument"
+                    },
+                    {
+                      "items": {
+                        "$ref": "#/definitions/AWS::Serverless::Function.IAMPolicyDocument"
+                      },
+                      "type": "array"
+                    }
+                  ]
+                },
+                "Role": {
+                  "anyOf": [
+                    {
+                      "type": "string"
+                    },
+                    {
+                      "type": "object"
+                    }
+                  ]
+                },
+                "Runtime": {
+                  "type": "string"
+                },
+                "Tags": {
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^[a-zA-Z0-9]+$": {
+                      "type": "string"
+                    }
+                  },
+                  "type": "object"
+                },
+                "Timeout": {
+                  "type": "number"
+                },
+                "Tracing": {
+                  "type": "string"
+                },
+                "VpcConfig": {
+                  "$ref": "#/definitions/AWS::Serverless::Function.VpcConfig"
                 }
               },
+              "required": [
+                "Handler",
+                "Runtime"
+              ],
               "type": "object"
-            },
-            "Timeout": {
-              "type": "number"
-            },
-            "Tracing": {
-              "type": "string"
-            },
-            "VpcConfig": {
-              "$ref": "#/definitions/AWS::Serverless::Function.VpcConfig"
             }
-          },
-          "required": [
-            "CodeUri",
-            "Handler",
-            "Runtime"
-          ],
-          "type": "object"
+          ]
         },
         "Type": {
           "enum": [
@@ -285,9 +314,13 @@
           "type": "string"
         },
         "RestApiId": {
-          "anyOf":[
-            { "type": "string" },
-            { "type": "object" }
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
           ]
         }
       },
@@ -485,9 +518,13 @@
       "additionalProperties": false,
       "properties": {
         "Bucket": {
-          "anyOf":[
-            { "type": "string" },
-            { "type": "object" }
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
           ]
         },
         "Events": {
@@ -538,9 +575,13 @@
       "additionalProperties": false,
       "properties": {
         "S3Key": {
-          "anyOf":[
-            { "type": "string" },
-            { "type": "object" }
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
           ]
         }
       },
@@ -596,7 +637,7 @@
             "type": "object"
           },
           "type": "array"
-        }        
+        }
       },
       "required": [
         "SecurityGroupIds",
@@ -793,9 +834,13 @@
           "type": "string"
         },
         "Value": {
-          "anyOf":[
-            { "type": "string" },
-            { "type": "object" }
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
           ]
         }
       },

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -157,7 +157,7 @@
               "anyOf": [
                 {
                   "properties": {
-                    "ZipFile": {
+                    "InlineCode": {
                       "type": "string"
                     }
                   }

--- a/tests/model/test_sam_resources.py
+++ b/tests/model/test_sam_resources.py
@@ -1,0 +1,46 @@
+from unittest import TestCase
+
+import pytest
+
+from samtranslator.intrinsics.resolver import IntrinsicsResolver
+from samtranslator.model import InvalidResourceException
+from samtranslator.model.lambda_ import LambdaFunction
+from samtranslator.model.sam_resources import SamFunction
+
+
+class TestCodeUri(TestCase):
+    kwargs = {
+        'intrinsics_resolver': IntrinsicsResolver({}),
+        'event_resources': [],
+        'managed_policy_map': {
+            "foo": "bar"
+        }
+    }
+
+    def test_with_code_uri(self):
+        function = SamFunction("foo")
+        function.CodeUri = "s3://foobar/foo.zip"
+
+        cfnResources = function.to_cloudformation(**self.kwargs)
+        generatedFunctionList = [x for x in cfnResources if isinstance(x, LambdaFunction)]
+        self.assertEqual(generatedFunctionList.__len__(), 1)
+        self.assertEqual(generatedFunctionList[0].Code, {
+            "S3Key": "foo.zip",
+            "S3Bucket": "foobar",
+        })
+
+    def test_with_zip_file(self):
+        function = SamFunction("foo")
+        function.ZipFile = "hello world"
+
+        cfnResources = function.to_cloudformation(**self.kwargs)
+        generatedFunctionList = [x for x in cfnResources if isinstance(x, LambdaFunction)]
+        self.assertEqual(generatedFunctionList.__len__(), 1)
+        self.assertEqual(generatedFunctionList[0].Code, {
+            "ZipFile": "hello world"
+        })
+
+    def test_with_no_code_uri_or_zipfile(self):
+        function = SamFunction("foo")
+        with pytest.raises(InvalidResourceException):
+            function.to_cloudformation(**self.kwargs)

--- a/tests/model/test_sam_resources.py
+++ b/tests/model/test_sam_resources.py
@@ -31,7 +31,7 @@ class TestCodeUri(TestCase):
 
     def test_with_zip_file(self):
         function = SamFunction("foo")
-        function.ZipFile = "hello world"
+        function.InlineCode = "hello world"
 
         cfnResources = function.to_cloudformation(**self.kwargs)
         generatedFunctionList = [x for x in cfnResources if isinstance(x, LambdaFunction)]

--- a/tests/translator/input/basic_function.yaml
+++ b/tests/translator/input/basic_function.yaml
@@ -14,6 +14,14 @@ Resources:
       Runtime: python2.7
       Tracing: Active
 
+  FunctionWithZipFile:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      ZipFile: "hello world"
+      Handler: hello.handler
+      Runtime: python2.7
+      Tracing: Active
+
   FunctionWithCodeUriObject:
     Type: 'AWS::Serverless::Function'
     Properties:

--- a/tests/translator/input/basic_function.yaml
+++ b/tests/translator/input/basic_function.yaml
@@ -14,10 +14,10 @@ Resources:
       Runtime: python2.7
       Tracing: Active
 
-  FunctionWithZipFile:
+  FunctionWithInlineCode:
     Type: 'AWS::Serverless::Function'
     Properties:
-      ZipFile: "hello world"
+      InlineCode: "hello world"
       Handler: hello.handler
       Runtime: python2.7
       Tracing: Active

--- a/tests/translator/output/aws-cn/basic_function.json
+++ b/tests/translator/output/aws-cn/basic_function.json
@@ -360,6 +360,56 @@
           ]
         }
       }
+    },
+    "FunctionWithZipFileRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "FunctionWithZipFile": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "TracingConfig": {
+          "Mode": "Active"
+        },
+        "Code": {
+          "ZipFile": "hello world"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithZipFileRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7"
+      }
     }
   }
 }

--- a/tests/translator/output/aws-cn/basic_function.json
+++ b/tests/translator/output/aws-cn/basic_function.json
@@ -361,7 +361,7 @@
         }
       }
     },
-    "FunctionWithZipFileRole": {
+    "FunctionWithInlineCodeRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
@@ -386,7 +386,7 @@
         }
       }
     },
-    "FunctionWithZipFile": {
+    "FunctionWithInlineCode": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "TracingConfig": {
@@ -404,7 +404,7 @@
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "FunctionWithZipFileRole",
+            "FunctionWithInlineCodeRole",
             "Arn"
           ]
         },

--- a/tests/translator/output/aws-us-gov/basic_function.json
+++ b/tests/translator/output/aws-us-gov/basic_function.json
@@ -361,7 +361,7 @@
         }
       }
     },
-    "FunctionWithZipFileRole": {
+    "FunctionWithInlineCodeRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
@@ -386,7 +386,7 @@
         }
       }
     },
-    "FunctionWithZipFile": {
+    "FunctionWithInlineCode": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "TracingConfig": {
@@ -404,7 +404,7 @@
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "FunctionWithZipFileRole",
+            "FunctionWithInlineCodeRole",
             "Arn"
           ]
         },

--- a/tests/translator/output/aws-us-gov/basic_function.json
+++ b/tests/translator/output/aws-us-gov/basic_function.json
@@ -52,19 +52,19 @@
       }
     },
     "MinimalFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -74,90 +74,90 @@
           ]
         }
       }
-    }, 
+    },
     "MinimalFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "MinimalFunctionRole", 
+            "MinimalFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "FunctionWithPolicyDocument": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "FunctionWithPolicyDocumentRole", 
+            "FunctionWithPolicyDocumentRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "FunctionWithPolicies": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "FunctionWithPoliciesRole", 
+            "FunctionWithPoliciesRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "FunctionWithCodeUriObjectRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -167,34 +167,34 @@
           ]
         }
       }
-    }, 
+    },
     "MyFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
-        "Path": "/", 
+        "Path": "/",
         "Policies": [
           {
-            "PolicyName": "root", 
+            "PolicyName": "root",
             "PolicyDocument": {
-              "Version": "2012-10-17", 
+              "Version": "2012-10-17",
               "Statement": [
                 {
-                  "Action": "*", 
-                  "Resource": "*", 
+                  "Action": "*",
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "ec2.amazonaws.com"
@@ -204,90 +204,90 @@
           ]
         }
       }
-    }, 
+    },
     "CompleteFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
-        "FunctionName": "MyAwesomeFunction", 
+        },
+        "FunctionName": "MyAwesomeFunction",
         "VpcConfig": {
           "SubnetIds": [
-            "subnet-9d4a7b6c", 
+            "subnet-9d4a7b6c",
             "subnet-65ea5f08"
-          ], 
+          ],
           "SubnetIdsUsingRef": [
             {
               "Ref": "SomeParameter"
-            }, 
+            },
             {
               "Ref": "SomeOtherParameter"
             }
-          ], 
+          ],
           "SecurityGroupIds": [
             "sg-edcd9784"
           ]
-        }, 
+        },
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
-        ], 
+        ],
         "Environment": {
           "Variables": {
-            "Name2": "Value2", 
+            "Name2": "Value2",
             "Name": "Value"
           }
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": "arn:aws:iam::012345678901:role/lambda_basic_execution",
-        "Timeout": 60, 
-        "Runtime": "python2.7", 
+        "Timeout": 60,
+        "Runtime": "python2.7",
         "Description": "Starter Lambda Function"
       }
-    }, 
+    },
     "FunctionWithCodeUriObject": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "somebucket", 
-          "S3Key": "somekey", 
+          "S3Bucket": "somebucket",
+          "S3Key": "somekey",
           "S3ObjectVersion": 1
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "FunctionWithCodeUriObjectRole", 
+            "FunctionWithCodeUriObjectRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "FunctionWithPoliciesRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/AmazonDynamoDBFullAccess",
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -297,60 +297,60 @@
           ]
         }
       }
-    }, 
+    },
     "FunctionWithRoleRef": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
           "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionRole", 
+            "MyFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "FunctionWithPolicyDocumentRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Policies": [
           {
-            "PolicyName": "FunctionWithPolicyDocumentRolePolicy0", 
+            "PolicyName": "FunctionWithPolicyDocumentRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "dynamodb:*"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -359,6 +359,56 @@
             }
           ]
         }
+      }
+    },
+    "FunctionWithZipFileRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "FunctionWithZipFile": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "TracingConfig": {
+          "Mode": "Active"
+        },
+        "Code": {
+          "ZipFile": "hello world"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithZipFileRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7"
       }
     }
   }

--- a/tests/translator/output/basic_function.json
+++ b/tests/translator/output/basic_function.json
@@ -360,6 +360,56 @@
           ]
         }
       }
+    },
+    "FunctionWithZipFileRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "FunctionWithZipFile": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "TracingConfig": {
+          "Mode": "Active"
+        },
+        "Code": {
+          "ZipFile": "hello world"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "Handler": "hello.handler",
+        "Role": {
+          "Fn::GetAtt": [
+            "FunctionWithZipFileRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "python2.7"
+      }
     }
   }
 }

--- a/tests/translator/output/basic_function.json
+++ b/tests/translator/output/basic_function.json
@@ -361,7 +361,7 @@
         }
       }
     },
-    "FunctionWithZipFileRole": {
+    "FunctionWithInlineCodeRole": {
       "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
@@ -386,7 +386,7 @@
         }
       }
     },
-    "FunctionWithZipFile": {
+    "FunctionWithInlineCode": {
       "Type": "AWS::Lambda::Function",
       "Properties": {
         "TracingConfig": {
@@ -404,7 +404,7 @@
         "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "FunctionWithZipFileRole",
+            "FunctionWithInlineCodeRole",
             "Arn"
           ]
         },

--- a/tests/translator/output/error_function_no_codeuri.json
+++ b/tests/translator/output/error_function_no_codeuri.json
@@ -1,8 +1,8 @@
 {
   "errors": [
     {
-      "errorMessage": "Resource with id [Function] is invalid. Either 'ZipFile' or 'CodeUri' must be set."
+      "errorMessage": "Resource with id [Function] is invalid. Either 'InlineCode' or 'CodeUri' must be set."
     }
   ], 
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Function] is invalid. Either 'ZipFile' or 'CodeUri' must be set"
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Function] is invalid. Either 'InlineCode' or 'CodeUri' must be set"
 }

--- a/tests/translator/output/error_function_no_codeuri.json
+++ b/tests/translator/output/error_function_no_codeuri.json
@@ -1,8 +1,8 @@
 {
   "errors": [
     {
-      "errorMessage": "Resource with id [Function] is invalid. Missing required property 'CodeUri'."
+      "errorMessage": "Resource with id [Function] is invalid. Either 'ZipFile' or 'CodeUri' must be set."
     }
   ], 
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Function] is invalid. Missing required property 'CodeUri'."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Function] is invalid. Either 'ZipFile' or 'CodeUri' must be set"
 }

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -103,8 +103,8 @@ Property Name | Type | Description
 ---|:---:|---
 Handler | `string` | **Required.** Function within your code that is called to begin execution.
 Runtime | `string` | **Required.** The runtime environment.
-CodeUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | **Either CodeUri or ZipFile must be specified.** S3 Uri or location to the function code. The S3 object this Uri references MUST be a [Lambda deployment package](http://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).
-ZipFile | `string` | **Either CodeUri or ZipFile must be specified.** The inline code for the lambda.
+CodeUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | **Either CodeUri or InlineCode must be specified.** S3 Uri or location to the function code. The S3 object this Uri references MUST be a [Lambda deployment package](http://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).
+InlineCode | `string` | **Either CodeUri or InlineCode must be specified.** The inline code for the lambda.
 FunctionName | `string` | A name for the function. If you don't specify a name, a unique name will be generated for you. [More Info](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-functionname)
 Description | `string` | Description of the function.
 MemorySize | `integer` | Size of the memory allocated per invocation of the function in MB. Defaults to 128.

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -103,7 +103,8 @@ Property Name | Type | Description
 ---|:---:|---
 Handler | `string` | **Required.** Function within your code that is called to begin execution.
 Runtime | `string` | **Required.** The runtime environment.
-CodeUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | **Required.** S3 Uri or location to the function code. The S3 object this Uri references MUST be a [Lambda deployment package](http://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).
+CodeUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | **Either CodeUri or ZipFile must be specified.** S3 Uri or location to the function code. The S3 object this Uri references MUST be a [Lambda deployment package](http://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).
+ZipFile | `string` | **Either CodeUri or ZipFile must be specified.** The inline code for the lambda.
 FunctionName | `string` | A name for the function. If you don't specify a name, a unique name will be generated for you. [More Info](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-functionname)
 Description | `string` | Description of the function.
 MemorySize | `integer` | Size of the memory allocated per invocation of the function in MB. Defaults to 128.


### PR DESCRIPTION
*Issue #, if available:*
#287 

*Description of changes:*
Adds support for ZipFile lambda definitions

Due to the nature of 'allOf', the schema cannot enforce 'additionalProperties: false' with the current schema approach.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
