### PR TITLE
Fix ANY method ARN generation using wildcard

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -429,11 +429,12 @@ class Api(PushEventSource):
             raise RuntimeError("Could not add permission to lambda function.")
 
         path = self.Path.replace('{proxy+}', '*')
+        method = '*' if self.Method == 'any' else self.Method.upper()
 
         api_id = self.RestApiId
 
         # RestApiId can be a simple string or intrinsic function like !Ref. Using Fn::Sub will handle both cases
-        resource = '${__ApiId__}/' + '${__Stage__}/' + self.Method.upper() + path
+        resource = '${__ApiId__}/' + '${__Stage__}/' + method + path
         partition = ArnGenerator.get_partition_name()
         source_arn = fnSub(ArnGenerator.generate_arn(partition=partition, service='execute-api', resource=resource),
                            {"__ApiId__": api_id, "__Stage__": stage})

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -429,7 +429,7 @@ class Api(PushEventSource):
             raise RuntimeError("Could not add permission to lambda function.")
 
         path = self.Path.replace('{proxy+}', '*')
-        method = '*' if self.Method == 'any' else self.Method.upper()
+        method = '*' if self.Method.lower() == 'any' else self.Method.upper()
 
         api_id = self.RestApiId
 

--- a/tests/translator/output/api_with_cors.json
+++ b/tests/translator/output/api_with_cors.json
@@ -78,7 +78,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/foo", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
@@ -428,7 +428,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/foo", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
             {
               "__Stage__": "*", 
               "__ApiId__": {

--- a/tests/translator/output/aws-cn/api_with_cors.json
+++ b/tests/translator/output/aws-cn/api_with_cors.json
@@ -78,7 +78,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/foo", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
@@ -444,7 +444,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/foo", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
             {
               "__Stage__": "*", 
               "__ApiId__": {

--- a/tests/translator/output/aws-cn/implicit_api.json
+++ b/tests/translator/output/aws-cn/implicit_api.json
@@ -98,7 +98,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
@@ -200,7 +200,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "*", 
               "__ApiId__": {

--- a/tests/translator/output/aws-cn/implicit_api_with_serverless_rest_api_resource.json
+++ b/tests/translator/output/aws-cn/implicit_api_with_serverless_rest_api_resource.json
@@ -98,7 +98,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
@@ -200,7 +200,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "*", 
               "__ApiId__": {

--- a/tests/translator/output/aws-us-gov/api_with_cors.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors.json
@@ -78,7 +78,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/foo", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
@@ -444,7 +444,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/foo", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/foo", 
             {
               "__Stage__": "*", 
               "__ApiId__": {

--- a/tests/translator/output/aws-us-gov/implicit_api.json
+++ b/tests/translator/output/aws-us-gov/implicit_api.json
@@ -98,7 +98,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
@@ -210,7 +210,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "*", 
               "__ApiId__": {

--- a/tests/translator/output/aws-us-gov/implicit_api_with_serverless_rest_api_resource.json
+++ b/tests/translator/output/aws-us-gov/implicit_api_with_serverless_rest_api_resource.json
@@ -98,7 +98,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
@@ -210,7 +210,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "*", 
               "__ApiId__": {

--- a/tests/translator/output/implicit_api.json
+++ b/tests/translator/output/implicit_api.json
@@ -98,7 +98,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
@@ -200,7 +200,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "*", 
               "__ApiId__": {

--- a/tests/translator/output/implicit_api_with_serverless_rest_api_resource.json
+++ b/tests/translator/output/implicit_api_with_serverless_rest_api_resource.json
@@ -98,7 +98,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
@@ -200,7 +200,7 @@
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/ANY/*", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/*/*", 
             {
               "__Stage__": "*", 
               "__ApiId__": {


### PR DESCRIPTION
*Issue #, if available:* #59 

*Description of changes:* Convert the `ANY` method to a wildcard `*` when generating permission ARNs

I did not add test templates because this change is already covered by existing tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
