### PR TITLE
updating safe_lambda_deployment.rst to include example Cloudwatch alarms for safe deployment usage

### DIFF
--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -106,6 +106,40 @@ resource:
           PreTraffic: !Ref PreTrafficLambdaFunction
           PostTraffic: !Ref PostTrafficLambdaFunction
 
+  AliasErrorMetricGreaterThanZeroAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Lambda Function Error > 0
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Resource
+          Value: !Sub "${MyLambdaFunction}:live"
+        - Name: FunctionName
+          Value: !Ref MyLambdaFunction
+      EvaluationPeriods: 2
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+
+  LatestVersionErrorMetricGreaterThanZeroAlarm:
+    Type: "AWS::CloudWatch::Alarm"
+    Properties:
+      AlarmDescription: Lambda Function Error > 0
+      ComparisonOperator: GreaterThanThreshold
+      Dimensions:
+        - Name: Resource
+          Value: !Ref MyLambdaFunction.Version
+        - Name: FunctionName
+          Value: !Ref MyLambdaFunction
+      EvaluationPeriods: 2
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 60
+      Statistic: Sum
+      Threshold: 0
+
   PreTrafficLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:


### PR DESCRIPTION
Show example of Cloudwatch alarms in Cloudformation that relate the safe deployments. These are not easy to find online and will help people jumpstart the process of getting this going.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
