### PR TITLE
Added remark about CodeUri property on Globals

### DIFF
--- a/docs/globals.rst
+++ b/docs/globals.rst
@@ -54,7 +54,8 @@ presently.
       # Some properties of AWS::Serverless::Function
       Handler:
       Runtime:
-      CodeUri:
+      # Specifying CodeUri on Globals is not yet supported by 'CloudFormation package' https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html
+      CodeUri: 
       DeadLetterQueue:
       Description:
       MemorySize:


### PR DESCRIPTION
Currently CodeUri on Globals is not yet supported by CloudFormation package.

*Issue #, if available:* As i was unaware of this it took me quite a while to figure this out...

*Description of changes:* Added just as simple comment to point out the fact the property is not yet supported by CloudFormation package.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
