### PR TITLE
Fix handling scalar DependsOn values of S3 buckets

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -241,6 +241,11 @@ class S3(PushEventSource):
         """
 
         depends_on = bucket.get("DependsOn", [])
+
+        # DependsOn can be either a list of strings or a scalar string
+        if isinstance(depends_on, string_types):
+            depends_on = [ depends_on ]
+
         depends_on_set = set(depends_on)
         depends_on_set.add(permission.logical_id)
         bucket["DependsOn"] = list(depends_on_set)

--- a/tests/translator/input/s3_with_dependsOn.yaml
+++ b/tests/translator/input/s3_with_dependsOn.yaml
@@ -1,0 +1,21 @@
+Resources:
+  Topic:
+    Type: AWS::SNS::Topic
+
+  ThumbnailFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/thumbnails.zip
+      Handler: index.generate_thumbails
+      Runtime: nodejs4.3
+      Events:
+        ImageBucket:
+          Type: S3
+          Properties:
+            Bucket:
+              Ref: Images
+            Events: s3:ObjectCreated:*
+
+  Images:
+    Type: AWS::S3::Bucket
+    DependsOn: Topic

--- a/tests/translator/output/aws-cn/s3_with_dependsOn.json
+++ b/tests/translator/output/aws-cn/s3_with_dependsOn.json
@@ -1,0 +1,89 @@
+{
+  "Resources": {
+    "Topic": {
+      "Type": "AWS::SNS::Topic"
+    },
+    "Images": {
+      "Type": "AWS::S3::Bucket",
+      "DependsOn": [
+        "ThumbnailFunctionImageBucketPermission",
+        "Topic"
+      ],
+      "Properties": {
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Function": {
+                "Fn::GetAtt": [
+                  "ThumbnailFunction", 
+                  "Arn"
+                ]
+              }, 
+              "Event": "s3:ObjectCreated:*"
+            }
+          ]
+        }
+      }
+    }, 
+    "ThumbnailFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "ThumbnailFunctionImageBucketPermission": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        }, 
+        "FunctionName": {
+          "Ref": "ThumbnailFunction"
+        }, 
+        "Principal": "s3.amazonaws.com"
+      }
+    }, 
+    "ThumbnailFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "thumbnails.zip"
+        }, 
+        "Handler": "index.generate_thumbails", 
+        "Role": {
+          "Fn::GetAtt": [
+            "ThumbnailFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/s3_with_dependsOn.json
+++ b/tests/translator/output/aws-us-gov/s3_with_dependsOn.json
@@ -1,0 +1,89 @@
+{
+  "Resources": {
+    "Topic": {
+      "Type": "AWS::SNS::Topic"
+    },
+    "Images": {
+      "Type": "AWS::S3::Bucket",
+      "DependsOn": [
+        "ThumbnailFunctionImageBucketPermission",
+        "Topic"
+      ],
+      "Properties": {
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Function": {
+                "Fn::GetAtt": [
+                  "ThumbnailFunction", 
+                  "Arn"
+                ]
+              }, 
+              "Event": "s3:ObjectCreated:*"
+            }
+          ]
+        }
+      }
+    }, 
+    "ThumbnailFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "ThumbnailFunctionImageBucketPermission": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        }, 
+        "FunctionName": {
+          "Ref": "ThumbnailFunction"
+        }, 
+        "Principal": "s3.amazonaws.com"
+      }
+    }, 
+    "ThumbnailFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "thumbnails.zip"
+        }, 
+        "Handler": "index.generate_thumbails", 
+        "Role": {
+          "Fn::GetAtt": [
+            "ThumbnailFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/s3_with_dependsOn.json
+++ b/tests/translator/output/s3_with_dependsOn.json
@@ -1,0 +1,89 @@
+{
+  "Resources": {
+    "Topic": {
+      "Type": "AWS::SNS::Topic"
+    },
+    "Images": {
+      "Type": "AWS::S3::Bucket",
+      "DependsOn": [
+        "ThumbnailFunctionImageBucketPermission",
+        "Topic"
+      ],
+      "Properties": {
+        "NotificationConfiguration": {
+          "LambdaConfigurations": [
+            {
+              "Function": {
+                "Fn::GetAtt": [
+                  "ThumbnailFunction", 
+                  "Arn"
+                ]
+              }, 
+              "Event": "s3:ObjectCreated:*"
+            }
+          ]
+        }
+      }
+    }, 
+    "ThumbnailFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "ThumbnailFunctionImageBucketPermission": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "SourceAccount": {
+          "Ref": "AWS::AccountId"
+        }, 
+        "FunctionName": {
+          "Ref": "ThumbnailFunction"
+        }, 
+        "Principal": "s3.amazonaws.com"
+      }
+    }, 
+    "ThumbnailFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "thumbnails.zip"
+        }, 
+        "Handler": "index.generate_thumbails", 
+        "Role": {
+          "Fn::GetAtt": [
+            "ThumbnailFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -119,6 +119,7 @@ class TestTranslatorEndToEnd(TestCase):
         's3_filter',
         's3_multiple_events_same_bucket',
         's3_multiple_functions',
+        's3_with_dependsOn',
         'sns',
         'sns_existing_other_subscription',
         'sns_topic_outside_template',


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

DependsOn values can be either scalar strings or lists of strings. This
change fixes handling when an S3 bucket in an input template has a
scalar string value for DependsOn.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
