### PR TITLE
Remove Dependency on DynamoDB

### DIFF
--- a/examples/apps/lambda-canary-python3/template.yaml
+++ b/examples/apps/lambda-canary-python3/template.yaml
@@ -18,17 +18,6 @@ Resources:
           Statement:
             - Effect: Allow
               Action:
-                - 'dynamodb:PutItem'
-              Resource:
-                'Fn::Join':
-                  - ''
-                  - - 'arn:aws:dynamodb:'
-                    - Ref: 'AWS::Region'
-                    - ':'
-                    - Ref: 'AWS::AccountId'
-                    - ':table/*'
-            - Effect: Allow
-              Action:
                 - 'lambda:InvokeFunction'
               Resource:
                 'Fn::Join':


### PR DESCRIPTION
This canary doesn't need access to DynamoDB.

*Issue #, if available:*

*Description of changes:*
Avoid unnecessary dependency on DynamoDB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
