### PR TITLE
Add FilterLogEvents policy to policy templates.

### DIFF
--- a/docs/policy_templates_data/policy_templates.json
+++ b/docs/policy_templates_data/policy_templates.json
@@ -1243,7 +1243,9 @@
     "FilterLogEventsPolicy": {
       "Description": "Gives permission to filter Log Events from any Log Group",
       "Parameters": {
-
+        "LogGroupName": {
+          "Description": "Name of the Log Group"
+        }
       },
       "Definition": {
         "Statement": [
@@ -1252,7 +1254,16 @@
             "Action": [
               "logs:FilterLogEvents"
             ],
-            "Resource": "*"
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*",
+                {
+                  "logGroupName": {
+                    "Ref": "LogGroupName"
+                  }
+                }
+              ]
+            }
           }
         ]
       }

--- a/docs/policy_templates_data/policy_templates.json
+++ b/docs/policy_templates_data/policy_templates.json
@@ -1241,7 +1241,7 @@
       }
     },
     "FilterLogEventsPolicy": {
-      "Description": "Gives permission to filter Log Events from any Log Group",
+      "Description": "Gives permission to filter Log Events from a specified Log Group",
       "Parameters": {
         "LogGroupName": {
           "Description": "Name of the Log Group"
@@ -1256,7 +1256,7 @@
             ],
             "Resource": {
               "Fn::Sub": [
-                "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*",
+                "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}",
                 {
                   "logGroupName": {
                     "Ref": "LogGroupName"

--- a/docs/policy_templates_data/policy_templates.json
+++ b/docs/policy_templates_data/policy_templates.json
@@ -1239,6 +1239,23 @@
           }
         ]
       }
+    },
+    "FilterLogEventsPolicy": {
+      "Description": "Gives permission to filter Log Events from any Log Group",
+      "Parameters": {
+
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "logs:FilterLogEvents"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
     }
   }
 }

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -65,7 +65,7 @@
     "CloudWatchPutMetricPolicy": {
       "Description": "Gives permissions to put metrics to CloudWatch",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -82,7 +82,7 @@
     "EC2DescribePolicy": {
       "Description": "Gives permission to describe EC2 instances",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -312,7 +312,7 @@
     "AMIDescribePolicy": {
       "Description": "Gives permissions to describe AMIs",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -331,7 +331,7 @@
     "CloudFormationDescribeStacksPolicy": {
       "Description": "Gives permission to describe CloudFormation stacks",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -497,7 +497,7 @@
     "VPCAccessPolicy": {
       "Description": "Gives access to create, delete, describe and detach ENIs",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -823,7 +823,7 @@
     "CodePipelineLambdaExecutionPolicy": {
       "Description": "Gives permission for a Lambda function invoked by AWS CodePipeline to report back status of the job",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -845,7 +845,7 @@
     "ServerlessRepoReadWriteAccessPolicy": {
       "Description": "Gives access permissions to create and list applications in the AWS Serverless Application Repository service",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -926,7 +926,7 @@
     "CloudWatchDashboardPolicy": {
       "Description": "Gives permissions to put metrics to operate on CloudWatch Dashboards",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -975,7 +975,7 @@
     "RekognitionLabelsPolicy": {
       "Description": "Gives permission to detect object and moderation labels",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -1090,7 +1090,7 @@
     "ComprehendBasicAccessPolicy": {
       "Description": "Gives access to Amazon Comprehend APIs for detecting entities, key phrases, languages and sentiments",
       "Parameters": {
-        
+
       },
       "Definition": {
         "Statement": [
@@ -1266,7 +1266,7 @@
       }
     },
     "FilterLogEventsPolicy": {
-      "Description": "Gives permission to filter Log Events from any Log Group",
+      "Description": "Gives permission to filter Log Events from a specified Log Group",
       "Parameters": {
         "LogGroupName": {
           "Description": "Name of the Log Group"
@@ -1281,7 +1281,7 @@
             ],
             "Resource": {
               "Fn::Sub": [
-                "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*",
+                "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}",
                 {
                   "logGroupName": {
                     "Ref": "LogGroupName"

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1264,6 +1264,23 @@
           }
         ]
       }
+    },
+    "FilterLogEventsPolicy": {
+      "Description": "Gives permission to filter Log Events from any Log Group",
+      "Parameters": {
+
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "logs:FilterLogEvents"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
     }
   }
 }

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1268,7 +1268,9 @@
     "FilterLogEventsPolicy": {
       "Description": "Gives permission to filter Log Events from any Log Group",
       "Parameters": {
-
+        "LogGroupName": {
+          "Description": "Name of the Log Group"
+        }
       },
       "Definition": {
         "Statement": [
@@ -1277,7 +1279,16 @@
             "Action": [
               "logs:FilterLogEvents"
             ],
-            "Resource": "*"
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*",
+                {
+                  "logGroupName": {
+                    "Ref": "LogGroupName"
+                  }
+                }
+              ]
+            }
           }
         ]
       }

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -119,4 +119,5 @@ Resources:
         - PinpointEndpointAccessPolicy:
             PinpointApplicationId: id
 
-        - FilterLogEventsPolicy: {}
+        - FilterLogEventsPolicy:
+            LogGroupName: name

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -118,3 +118,5 @@ Resources:
 
         - PinpointEndpointAccessPolicy:
             PinpointApplicationId: id
+
+        - FilterLogEventsPolicy: {}

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -996,7 +996,14 @@
                   "Action": [
                     "logs:FilterLogEvents"
                   ],
-                  "Resource": "*",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*", 
+                      {
+                        "logGroupName": "name"
+                      }
+                    ]
+                  },
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -998,7 +998,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}", 
+                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}",
                       {
                         "logGroupName": "name"
                       }
@@ -1011,7 +1011,7 @@
           }
         ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
+          "Version": "2012-10-17", 
           "Statement": [
             {
               "Action": [

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1,913 +1,913 @@
 {
   "Resources": {
     "KitchenSinkFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "KitchenSinkFunctionRole", 
+            "KitchenSinkFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "KitchenSinkFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Policies": [
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy0", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "sqs:ChangeMessageVisibility", 
-                    "sqs:ChangeMessageVisibilityBatch", 
-                    "sqs:DeleteMessage", 
-                    "sqs:DeleteMessageBatch", 
-                    "sqs:GetQueueAttributes", 
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:ChangeMessageVisibilityBatch",
+                    "sqs:DeleteMessage",
+                    "sqs:DeleteMessageBatch",
+                    "sqs:GetQueueAttributes",
                     "sqs:ReceiveMessage"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}", 
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy1", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy1",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "lambda:InvokeFunction"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*",
                       {
                         "functionName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy2", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy2",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "cloudwatch:PutMetricData"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy3", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy3",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "ec2:DescribeRegions", 
+                    "ec2:DescribeRegions",
                     "ec2:DescribeInstances"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy4", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:GetItem", 
-                    "dynamodb:DeleteItem", 
-                    "dynamodb:PutItem", 
-                    "dynamodb:Scan", 
-                    "dynamodb:Query", 
-                    "dynamodb:UpdateItem", 
-                    "dynamodb:BatchWriteItem", 
+                    "dynamodb:GetItem",
+                    "dynamodb:DeleteItem",
+                    "dynamodb:PutItem",
+                    "dynamodb:Scan",
+                    "dynamodb:Query",
+                    "dynamodb:UpdateItem",
+                    "dynamodb:BatchWriteItem",
                     "dynamodb:BatchGetItem"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy5", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:GetItem", 
-                    "dynamodb:Scan", 
-                    "dynamodb:Query", 
+                    "dynamodb:GetItem",
+                    "dynamodb:Scan",
+                    "dynamodb:Query",
                     "dynamodb:BatchGetItem"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy6", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "ses:SendBounce"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}", 
+                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
                       {
                         "identityName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy7", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "es:ESHttpPost"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}", 
+                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}",
                       {
                         "domainName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy8", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "s3:GetObject", 
-                    "s3:ListBucket", 
-                    "s3:GetBucketLocation", 
-                    "s3:GetObjectVersion", 
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetObjectVersion",
                     "s3:GetLifecycleConfiguration"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}",
                         {
                           "bucketName": "name"
                         }
                       ]
-                    }, 
+                    },
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}/*", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}/*",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy9", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "s3:GetObject", 
-                    "s3:ListBucket", 
-                    "s3:GetBucketLocation", 
-                    "s3:GetObjectVersion", 
-                    "s3:PutObject", 
-                    "s3:GetLifecycleConfiguration", 
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetObjectVersion",
+                    "s3:PutObject",
+                    "s3:GetLifecycleConfiguration",
                     "s3:PutLifecycleConfiguration"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}",
                         {
                           "bucketName": "name"
                         }
                       ]
-                    }, 
+                    },
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}/*", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}/*",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy10", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "ec2:DescribeImages"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/*"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy11", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "cloudformation:DescribeStacks"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy12", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:CompareFaces", 
-                    "rekognition:DetectFaces", 
-                    "rekognition:DetectLabels", 
+                    "rekognition:CompareFaces",
+                    "rekognition:DetectFaces",
+                    "rekognition:DetectLabels",
                     "rekognition:DetectModerationLabels"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy13", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:ListCollections", 
-                    "rekognition:ListFaces", 
-                    "rekognition:SearchFaces", 
+                    "rekognition:ListCollections",
+                    "rekognition:ListFaces",
+                    "rekognition:SearchFaces",
                     "rekognition:SearchFacesByImage"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy14", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:CreateCollection", 
+                    "rekognition:CreateCollection",
                     "rekognition:IndexFaces"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy15", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "sqs:SendMessage*"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}", 
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy16", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "sns:Publish"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}", 
+                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}",
                       {
                         "topicName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy17", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "ec2:CreateNetworkInterface", 
-                    "ec2:DeleteNetworkInterface", 
-                    "ec2:DescribeNetworkInterfaces", 
+                    "ec2:CreateNetworkInterface",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DescribeNetworkInterfaces",
                     "ec2:DetachNetworkInterface"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy18", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:DescribeStream", 
-                    "dynamodb:GetRecords", 
-                    "dynamodb:GetShardIterator", 
+                    "dynamodb:DescribeStream",
+                    "dynamodb:GetRecords",
+                    "dynamodb:GetShardIterator",
                     "dynamodb:ListStreams"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/${streamName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/${streamName}",
                       {
-                        "streamName": "name", 
+                        "streamName": "name",
                         "tableName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy19", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "kinesis:ListStreams", 
+                    "kinesis:ListStreams",
                     "kinesis:DescribeLimits"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/*"
-                  }, 
+                  },
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "kinesis:DescribeStream", 
-                    "kinesis:GetRecords", 
+                    "kinesis:DescribeStream",
+                    "kinesis:GetRecords",
                     "kinesis:GetShardIterator"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}", 
+                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}",
                       {
                         "streamName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy20", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "ses:GetIdentityVerificationAttributes", 
-                    "ses:SendEmail", 
+                    "ses:GetIdentityVerificationAttributes",
+                    "ses:SendEmail",
                     "ses:VerifyEmailIdentity"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}", 
+                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
                       {
                         "identityName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy21", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "sns:ListSubscriptionsByTopic", 
-                    "sns:CreateTopic", 
-                    "sns:SetTopicAttributes", 
-                    "sns:Subscribe", 
+                    "sns:ListSubscriptionsByTopic",
+                    "sns:CreateTopic",
+                    "sns:SetTopicAttributes",
+                    "sns:Subscribe",
                     "sns:Publish"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}*", 
+                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}*",
                       {
                         "topicName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy22", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "kinesis:AddTagsToStream", 
-                    "kinesis:CreateStream", 
-                    "kinesis:DecreaseStreamRetentionPeriod", 
-                    "kinesis:DeleteStream", 
-                    "kinesis:DescribeStream", 
-                    "kinesis:GetShardIterator", 
-                    "kinesis:IncreaseStreamRetentionPeriod", 
-                    "kinesis:ListTagsForStream", 
-                    "kinesis:MergeShards", 
-                    "kinesis:PutRecord", 
-                    "kinesis:PutRecords", 
-                    "kinesis:SplitShard", 
+                    "kinesis:AddTagsToStream",
+                    "kinesis:CreateStream",
+                    "kinesis:DecreaseStreamRetentionPeriod",
+                    "kinesis:DeleteStream",
+                    "kinesis:DescribeStream",
+                    "kinesis:GetShardIterator",
+                    "kinesis:IncreaseStreamRetentionPeriod",
+                    "kinesis:ListTagsForStream",
+                    "kinesis:MergeShards",
+                    "kinesis:PutRecord",
+                    "kinesis:PutRecords",
+                    "kinesis:SplitShard",
                     "kinesis:RemoveTagsFromStream"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}", 
+                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}",
                       {
                         "streamName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy23", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "kms:Decrypt", 
+                  "Action": "kms:Decrypt",
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${keyId}", 
+                      "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${keyId}",
                       {
                         "keyId": "keyId"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy24", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "polly:GetLexicon", 
+                    "polly:GetLexicon",
                     "polly:DeleteLexicon"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:polly:${AWS::Region}:${AWS::AccountId}:lexicon/${lexiconName}", 
+                        "arn:${AWS::Partition}:polly:${AWS::Region}:${AWS::AccountId}:lexicon/${lexiconName}",
                         {
                           "lexiconName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "polly:DescribeVoices", 
-                    "polly:ListLexicons", 
-                    "polly:PutLexicon", 
+                    "polly:DescribeVoices",
+                    "polly:ListLexicons",
+                    "polly:PutLexicon",
                     "polly:SynthesizeSpeech"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:polly:${AWS::Region}:${AWS::AccountId}:lexicon/*"
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy25", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "s3:GetObject", 
-                    "s3:GetObjectAcl", 
-                    "s3:GetObjectVersion", 
-                    "s3:PutObject", 
-                    "s3:PutObjectAcl", 
+                    "s3:GetObject",
+                    "s3:GetObjectAcl",
+                    "s3:GetObjectVersion",
+                    "s3:PutObject",
+                    "s3:PutObjectAcl",
                     "s3:DeleteObject"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}/*", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}/*",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "s3:ListBucket", 
-                    "s3:GetBucketLocation", 
-                    "s3:GetLifecycleConfiguration", 
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetLifecycleConfiguration",
                     "s3:PutLifecycleConfiguration"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy26", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "codepipeline:PutJobSuccessResult", 
+                    "codepipeline:PutJobSuccessResult",
                     "codepipeline:PutJobFailureResult"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:*"
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy27", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "serverlessrepo:CreateApplication", 
-                    "serverlessrepo:CreateApplicationVersion", 
-                    "serverlessrepo:GetApplication", 
-                    "serverlessrepo:ListApplications", 
+                    "serverlessrepo:CreateApplication",
+                    "serverlessrepo:CreateApplicationVersion",
+                    "serverlessrepo:GetApplication",
+                    "serverlessrepo:ListApplications",
                     "serverlessrepo:ListApplicationVersions"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:serverlessrepo:${AWS::Region}:${AWS::AccountId}:applications/*"
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy28", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "ec2:CopyImage"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/${imageId}", 
+                      "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/${imageId}",
                       {
                         "imageId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy29", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "codepipeline:ListPipelineExecutions"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${pipelinename}", 
+                      "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${pipelinename}",
                       {
                         "pipelinename": "pipeline"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy30", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "cloudwatch:GetDashboard", 
-                    "cloudwatch:ListDashboards", 
-                    "cloudwatch:PutDashboard", 
+                    "cloudwatch:GetDashboard",
+                    "cloudwatch:ListDashboards",
+                    "cloudwatch:PutDashboard",
                     "cloudwatch:ListMetrics"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy31", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:CompareFaces", 
+                    "rekognition:CompareFaces",
                     "rekognition:DetectFaces"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "collection"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy32", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:DetectLabels", 
+                    "rekognition:DetectLabels",
                     "rekognition:DetectModerationLabels"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy33", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:CreateBackup", 
+                    "dynamodb:CreateBackup",
                     "dynamodb:DescribeContinuousBackups"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "dynamodb:DeleteBackup", 
-                    "dynamodb:DescribeBackup", 
+                    "dynamodb:DeleteBackup",
+                    "dynamodb:DescribeBackup",
                     "dynamodb:ListBackups"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy34", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "dynamodb:RestoreTableFromBackup"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "dynamodb:PutItem", 
-                    "dynamodb:UpdateItem", 
-                    "dynamodb:DeleteItem", 
-                    "dynamodb:GetItem", 
-                    "dynamodb:Query", 
-                    "dynamodb:Scan", 
+                    "dynamodb:PutItem",
+                    "dynamodb:UpdateItem",
+                    "dynamodb:DeleteItem",
+                    "dynamodb:GetItem",
+                    "dynamodb:Query",
+                    "dynamodb:Scan",
                     "dynamodb:BatchWriteItem"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy35", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "comprehend:BatchDetectKeyPhrases", 
-                    "comprehend:DetectDominantLanguage", 
-                    "comprehend:DetectEntities", 
-                    "comprehend:BatchDetectEntities", 
-                    "comprehend:DetectKeyPhrases", 
-                    "comprehend:DetectSentiment", 
-                    "comprehend:BatchDetectDominantLanguage", 
+                    "comprehend:BatchDetectKeyPhrases",
+                    "comprehend:DetectDominantLanguage",
+                    "comprehend:DetectEntities",
+                    "comprehend:BatchDetectEntities",
+                    "comprehend:DetectKeyPhrases",
+                    "comprehend:DetectSentiment",
+                    "comprehend:BatchDetectDominantLanguage",
                     "comprehend:BatchDetectSentiment"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
@@ -952,14 +952,14 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy37", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "mobileanalytics:PutEvents"
                   ],
-                  "Resource": "*", 
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
@@ -998,7 +998,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*", 
+                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}", 
                       {
                         "logGroupName": "name"
                       }
@@ -1009,15 +1009,15 @@
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -987,6 +987,20 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy39",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:FilterLogEvents"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -996,7 +996,14 @@
                   "Action": [
                     "logs:FilterLogEvents"
                   ],
-                  "Resource": "*",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*", 
+                      {
+                        "logGroupName": "name"
+                      }
+                    ]
+                  },
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1,913 +1,913 @@
 {
   "Resources": {
     "KitchenSinkFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "KitchenSinkFunctionRole", 
+            "KitchenSinkFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "KitchenSinkFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Policies": [
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy0", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "sqs:ChangeMessageVisibility", 
-                    "sqs:ChangeMessageVisibilityBatch", 
-                    "sqs:DeleteMessage", 
-                    "sqs:DeleteMessageBatch", 
-                    "sqs:GetQueueAttributes", 
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:ChangeMessageVisibilityBatch",
+                    "sqs:DeleteMessage",
+                    "sqs:DeleteMessageBatch",
+                    "sqs:GetQueueAttributes",
                     "sqs:ReceiveMessage"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}", 
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy1", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy1",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "lambda:InvokeFunction"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*",
                       {
                         "functionName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy2", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy2",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "cloudwatch:PutMetricData"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy3", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy3",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "ec2:DescribeRegions", 
+                    "ec2:DescribeRegions",
                     "ec2:DescribeInstances"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy4", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:GetItem", 
-                    "dynamodb:DeleteItem", 
-                    "dynamodb:PutItem", 
-                    "dynamodb:Scan", 
-                    "dynamodb:Query", 
-                    "dynamodb:UpdateItem", 
-                    "dynamodb:BatchWriteItem", 
+                    "dynamodb:GetItem",
+                    "dynamodb:DeleteItem",
+                    "dynamodb:PutItem",
+                    "dynamodb:Scan",
+                    "dynamodb:Query",
+                    "dynamodb:UpdateItem",
+                    "dynamodb:BatchWriteItem",
                     "dynamodb:BatchGetItem"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy5", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:GetItem", 
-                    "dynamodb:Scan", 
-                    "dynamodb:Query", 
+                    "dynamodb:GetItem",
+                    "dynamodb:Scan",
+                    "dynamodb:Query",
                     "dynamodb:BatchGetItem"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy6", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "ses:SendBounce"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}", 
+                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
                       {
                         "identityName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy7", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "es:ESHttpPost"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}", 
+                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}",
                       {
                         "domainName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy8", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "s3:GetObject", 
-                    "s3:ListBucket", 
-                    "s3:GetBucketLocation", 
-                    "s3:GetObjectVersion", 
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetObjectVersion",
                     "s3:GetLifecycleConfiguration"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}",
                         {
                           "bucketName": "name"
                         }
                       ]
-                    }, 
+                    },
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}/*", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}/*",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy9", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "s3:GetObject", 
-                    "s3:ListBucket", 
-                    "s3:GetBucketLocation", 
-                    "s3:GetObjectVersion", 
-                    "s3:PutObject", 
-                    "s3:GetLifecycleConfiguration", 
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetObjectVersion",
+                    "s3:PutObject",
+                    "s3:GetLifecycleConfiguration",
                     "s3:PutLifecycleConfiguration"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}",
                         {
                           "bucketName": "name"
                         }
                       ]
-                    }, 
+                    },
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}/*", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}/*",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy10", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "ec2:DescribeImages"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/*"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy11", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "cloudformation:DescribeStacks"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy12", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:CompareFaces", 
-                    "rekognition:DetectFaces", 
-                    "rekognition:DetectLabels", 
+                    "rekognition:CompareFaces",
+                    "rekognition:DetectFaces",
+                    "rekognition:DetectLabels",
                     "rekognition:DetectModerationLabels"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy13", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:ListCollections", 
-                    "rekognition:ListFaces", 
-                    "rekognition:SearchFaces", 
+                    "rekognition:ListCollections",
+                    "rekognition:ListFaces",
+                    "rekognition:SearchFaces",
                     "rekognition:SearchFacesByImage"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy14", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:CreateCollection", 
+                    "rekognition:CreateCollection",
                     "rekognition:IndexFaces"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy15", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "sqs:SendMessage*"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}", 
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy16", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "sns:Publish"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}", 
+                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}",
                       {
                         "topicName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy17", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "ec2:CreateNetworkInterface", 
-                    "ec2:DeleteNetworkInterface", 
-                    "ec2:DescribeNetworkInterfaces", 
+                    "ec2:CreateNetworkInterface",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DescribeNetworkInterfaces",
                     "ec2:DetachNetworkInterface"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy18", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:DescribeStream", 
-                    "dynamodb:GetRecords", 
-                    "dynamodb:GetShardIterator", 
+                    "dynamodb:DescribeStream",
+                    "dynamodb:GetRecords",
+                    "dynamodb:GetShardIterator",
                     "dynamodb:ListStreams"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/${streamName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/${streamName}",
                       {
-                        "streamName": "name", 
+                        "streamName": "name",
                         "tableName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy19", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "kinesis:ListStreams", 
+                    "kinesis:ListStreams",
                     "kinesis:DescribeLimits"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/*"
-                  }, 
+                  },
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "kinesis:DescribeStream", 
-                    "kinesis:GetRecords", 
+                    "kinesis:DescribeStream",
+                    "kinesis:GetRecords",
                     "kinesis:GetShardIterator"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}", 
+                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}",
                       {
                         "streamName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy20", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "ses:GetIdentityVerificationAttributes", 
-                    "ses:SendEmail", 
+                    "ses:GetIdentityVerificationAttributes",
+                    "ses:SendEmail",
                     "ses:VerifyEmailIdentity"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}", 
+                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
                       {
                         "identityName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy21", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "sns:ListSubscriptionsByTopic", 
-                    "sns:CreateTopic", 
-                    "sns:SetTopicAttributes", 
-                    "sns:Subscribe", 
+                    "sns:ListSubscriptionsByTopic",
+                    "sns:CreateTopic",
+                    "sns:SetTopicAttributes",
+                    "sns:Subscribe",
                     "sns:Publish"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}*", 
+                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}*",
                       {
                         "topicName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy22", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "kinesis:AddTagsToStream", 
-                    "kinesis:CreateStream", 
-                    "kinesis:DecreaseStreamRetentionPeriod", 
-                    "kinesis:DeleteStream", 
-                    "kinesis:DescribeStream", 
-                    "kinesis:GetShardIterator", 
-                    "kinesis:IncreaseStreamRetentionPeriod", 
-                    "kinesis:ListTagsForStream", 
-                    "kinesis:MergeShards", 
-                    "kinesis:PutRecord", 
-                    "kinesis:PutRecords", 
-                    "kinesis:SplitShard", 
+                    "kinesis:AddTagsToStream",
+                    "kinesis:CreateStream",
+                    "kinesis:DecreaseStreamRetentionPeriod",
+                    "kinesis:DeleteStream",
+                    "kinesis:DescribeStream",
+                    "kinesis:GetShardIterator",
+                    "kinesis:IncreaseStreamRetentionPeriod",
+                    "kinesis:ListTagsForStream",
+                    "kinesis:MergeShards",
+                    "kinesis:PutRecord",
+                    "kinesis:PutRecords",
+                    "kinesis:SplitShard",
                     "kinesis:RemoveTagsFromStream"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}", 
+                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}",
                       {
                         "streamName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy23", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "kms:Decrypt", 
+                  "Action": "kms:Decrypt",
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${keyId}", 
+                      "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${keyId}",
                       {
                         "keyId": "keyId"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy24", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "polly:GetLexicon", 
+                    "polly:GetLexicon",
                     "polly:DeleteLexicon"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:polly:${AWS::Region}:${AWS::AccountId}:lexicon/${lexiconName}", 
+                        "arn:${AWS::Partition}:polly:${AWS::Region}:${AWS::AccountId}:lexicon/${lexiconName}",
                         {
                           "lexiconName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "polly:DescribeVoices", 
-                    "polly:ListLexicons", 
-                    "polly:PutLexicon", 
+                    "polly:DescribeVoices",
+                    "polly:ListLexicons",
+                    "polly:PutLexicon",
                     "polly:SynthesizeSpeech"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:polly:${AWS::Region}:${AWS::AccountId}:lexicon/*"
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy25", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "s3:GetObject", 
-                    "s3:GetObjectAcl", 
-                    "s3:GetObjectVersion", 
-                    "s3:PutObject", 
-                    "s3:PutObjectAcl", 
+                    "s3:GetObject",
+                    "s3:GetObjectAcl",
+                    "s3:GetObjectVersion",
+                    "s3:PutObject",
+                    "s3:PutObjectAcl",
                     "s3:DeleteObject"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}/*", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}/*",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "s3:ListBucket", 
-                    "s3:GetBucketLocation", 
-                    "s3:GetLifecycleConfiguration", 
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetLifecycleConfiguration",
                     "s3:PutLifecycleConfiguration"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy26", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "codepipeline:PutJobSuccessResult", 
+                    "codepipeline:PutJobSuccessResult",
                     "codepipeline:PutJobFailureResult"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:*"
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy27", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "serverlessrepo:CreateApplication", 
-                    "serverlessrepo:CreateApplicationVersion", 
-                    "serverlessrepo:GetApplication", 
-                    "serverlessrepo:ListApplications", 
+                    "serverlessrepo:CreateApplication",
+                    "serverlessrepo:CreateApplicationVersion",
+                    "serverlessrepo:GetApplication",
+                    "serverlessrepo:ListApplications",
                     "serverlessrepo:ListApplicationVersions"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:serverlessrepo:${AWS::Region}:${AWS::AccountId}:applications/*"
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy28", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "ec2:CopyImage"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/${imageId}", 
+                      "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/${imageId}",
                       {
                         "imageId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy29", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "codepipeline:ListPipelineExecutions"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${pipelinename}", 
+                      "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${pipelinename}",
                       {
                         "pipelinename": "pipeline"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy30", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "cloudwatch:GetDashboard", 
-                    "cloudwatch:ListDashboards", 
-                    "cloudwatch:PutDashboard", 
+                    "cloudwatch:GetDashboard",
+                    "cloudwatch:ListDashboards",
+                    "cloudwatch:PutDashboard",
                     "cloudwatch:ListMetrics"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy31", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:CompareFaces", 
+                    "rekognition:CompareFaces",
                     "rekognition:DetectFaces"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "collection"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy32", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:DetectLabels", 
+                    "rekognition:DetectLabels",
                     "rekognition:DetectModerationLabels"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy33", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:CreateBackup", 
+                    "dynamodb:CreateBackup",
                     "dynamodb:DescribeContinuousBackups"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "dynamodb:DeleteBackup", 
-                    "dynamodb:DescribeBackup", 
+                    "dynamodb:DeleteBackup",
+                    "dynamodb:DescribeBackup",
                     "dynamodb:ListBackups"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy34", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "dynamodb:RestoreTableFromBackup"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "dynamodb:PutItem", 
-                    "dynamodb:UpdateItem", 
-                    "dynamodb:DeleteItem", 
-                    "dynamodb:GetItem", 
-                    "dynamodb:Query", 
-                    "dynamodb:Scan", 
+                    "dynamodb:PutItem",
+                    "dynamodb:UpdateItem",
+                    "dynamodb:DeleteItem",
+                    "dynamodb:GetItem",
+                    "dynamodb:Query",
+                    "dynamodb:Scan",
                     "dynamodb:BatchWriteItem"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy35", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "comprehend:BatchDetectKeyPhrases", 
-                    "comprehend:DetectDominantLanguage", 
-                    "comprehend:DetectEntities", 
-                    "comprehend:BatchDetectEntities", 
-                    "comprehend:DetectKeyPhrases", 
-                    "comprehend:DetectSentiment", 
-                    "comprehend:BatchDetectDominantLanguage", 
+                    "comprehend:BatchDetectKeyPhrases",
+                    "comprehend:DetectDominantLanguage",
+                    "comprehend:DetectEntities",
+                    "comprehend:BatchDetectEntities",
+                    "comprehend:DetectKeyPhrases",
+                    "comprehend:DetectSentiment",
+                    "comprehend:BatchDetectDominantLanguage",
                     "comprehend:BatchDetectSentiment"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
@@ -952,14 +952,14 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy37", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "mobileanalytics:PutEvents"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
@@ -998,7 +998,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*", 
+                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}", 
                       {
                         "logGroupName": "name"
                       }
@@ -1009,15 +1009,15 @@
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -987,6 +987,20 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy39",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:FilterLogEvents"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -997,7 +997,14 @@
                   "Action": [
                     "logs:FilterLogEvents"
                   ],
-                  "Resource": "*",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*", 
+                      {
+                        "logGroupName": "name"
+                      }
+                    ]
+                  },
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1,913 +1,913 @@
 {
   "Resources": {
     "KitchenSinkFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "hello.zip"
-        }, 
-        "Handler": "hello.handler", 
+        },
+        "Handler": "hello.handler",
         "Role": {
           "Fn::GetAtt": [
-            "KitchenSinkFunctionRole", 
+            "KitchenSinkFunctionRole",
             "Arn"
           ]
-        }, 
-        "Runtime": "python2.7", 
+        },
+        "Runtime": "python2.7",
         "Tags": [
           {
-            "Value": "SAM", 
+            "Value": "SAM",
             "Key": "lambda:createdBy"
           }
         ]
       }
-    }, 
+    },
     "KitchenSinkFunctionRole": {
-      "Type": "AWS::IAM::Role", 
+      "Type": "AWS::IAM::Role",
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ], 
+        ],
         "Policies": [
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy0", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy0",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "sqs:ChangeMessageVisibility", 
-                    "sqs:ChangeMessageVisibilityBatch", 
-                    "sqs:DeleteMessage", 
-                    "sqs:DeleteMessageBatch", 
-                    "sqs:GetQueueAttributes", 
+                    "sqs:ChangeMessageVisibility",
+                    "sqs:ChangeMessageVisibilityBatch",
+                    "sqs:DeleteMessage",
+                    "sqs:DeleteMessageBatch",
+                    "sqs:GetQueueAttributes",
                     "sqs:ReceiveMessage"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}", 
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy1", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy1",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "lambda:InvokeFunction"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*", 
+                      "arn:${AWS::Partition}:lambda:${AWS::Region}:${AWS::AccountId}:function:${functionName}*",
                       {
                         "functionName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy2", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy2",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "cloudwatch:PutMetricData"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy3", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy3",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "ec2:DescribeRegions", 
+                    "ec2:DescribeRegions",
                     "ec2:DescribeInstances"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy4", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:GetItem", 
-                    "dynamodb:DeleteItem", 
-                    "dynamodb:PutItem", 
-                    "dynamodb:Scan", 
-                    "dynamodb:Query", 
-                    "dynamodb:UpdateItem", 
-                    "dynamodb:BatchWriteItem", 
+                    "dynamodb:GetItem",
+                    "dynamodb:DeleteItem",
+                    "dynamodb:PutItem",
+                    "dynamodb:Scan",
+                    "dynamodb:Query",
+                    "dynamodb:UpdateItem",
+                    "dynamodb:BatchWriteItem",
                     "dynamodb:BatchGetItem"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy5", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:GetItem", 
-                    "dynamodb:Scan", 
-                    "dynamodb:Query", 
+                    "dynamodb:GetItem",
+                    "dynamodb:Scan",
+                    "dynamodb:Query",
                     "dynamodb:BatchGetItem"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy6", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "ses:SendBounce"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}", 
+                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
                       {
                         "identityName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy7", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "es:ESHttpPost"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}", 
+                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}",
                       {
                         "domainName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy8", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "s3:GetObject", 
-                    "s3:ListBucket", 
-                    "s3:GetBucketLocation", 
-                    "s3:GetObjectVersion", 
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetObjectVersion",
                     "s3:GetLifecycleConfiguration"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}",
                         {
                           "bucketName": "name"
                         }
                       ]
-                    }, 
+                    },
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}/*", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}/*",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy9", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "s3:GetObject", 
-                    "s3:ListBucket", 
-                    "s3:GetBucketLocation", 
-                    "s3:GetObjectVersion", 
-                    "s3:PutObject", 
-                    "s3:GetLifecycleConfiguration", 
+                    "s3:GetObject",
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetObjectVersion",
+                    "s3:PutObject",
+                    "s3:GetLifecycleConfiguration",
                     "s3:PutLifecycleConfiguration"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}",
                         {
                           "bucketName": "name"
                         }
                       ]
-                    }, 
+                    },
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}/*", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}/*",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy10", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "ec2:DescribeImages"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/*"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy11", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "cloudformation:DescribeStacks"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/*"
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy12", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:CompareFaces", 
-                    "rekognition:DetectFaces", 
-                    "rekognition:DetectLabels", 
+                    "rekognition:CompareFaces",
+                    "rekognition:DetectFaces",
+                    "rekognition:DetectLabels",
                     "rekognition:DetectModerationLabels"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy13", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:ListCollections", 
-                    "rekognition:ListFaces", 
-                    "rekognition:SearchFaces", 
+                    "rekognition:ListCollections",
+                    "rekognition:ListFaces",
+                    "rekognition:SearchFaces",
                     "rekognition:SearchFacesByImage"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy14", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:CreateCollection", 
+                    "rekognition:CreateCollection",
                     "rekognition:IndexFaces"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy15", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "sqs:SendMessage*"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}", 
+                      "arn:${AWS::Partition}:sqs:${AWS::Region}:${AWS::AccountId}:${queueName}",
                       {
                         "queueName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy16", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "sns:Publish"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}", 
+                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}",
                       {
                         "topicName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy17", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "ec2:CreateNetworkInterface", 
-                    "ec2:DeleteNetworkInterface", 
-                    "ec2:DescribeNetworkInterfaces", 
+                    "ec2:CreateNetworkInterface",
+                    "ec2:DeleteNetworkInterface",
+                    "ec2:DescribeNetworkInterfaces",
                     "ec2:DetachNetworkInterface"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy18", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:DescribeStream", 
-                    "dynamodb:GetRecords", 
-                    "dynamodb:GetShardIterator", 
+                    "dynamodb:DescribeStream",
+                    "dynamodb:GetRecords",
+                    "dynamodb:GetShardIterator",
                     "dynamodb:ListStreams"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/${streamName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/${streamName}",
                       {
-                        "streamName": "name", 
+                        "streamName": "name",
                         "tableName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy19", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "kinesis:ListStreams", 
+                    "kinesis:ListStreams",
                     "kinesis:DescribeLimits"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/*"
-                  }, 
+                  },
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "kinesis:DescribeStream", 
-                    "kinesis:GetRecords", 
+                    "kinesis:DescribeStream",
+                    "kinesis:GetRecords",
                     "kinesis:GetShardIterator"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}", 
+                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}",
                       {
                         "streamName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy20", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "ses:GetIdentityVerificationAttributes", 
-                    "ses:SendEmail", 
+                    "ses:GetIdentityVerificationAttributes",
+                    "ses:SendEmail",
                     "ses:VerifyEmailIdentity"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}", 
+                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
                       {
                         "identityName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy21", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "sns:ListSubscriptionsByTopic", 
-                    "sns:CreateTopic", 
-                    "sns:SetTopicAttributes", 
-                    "sns:Subscribe", 
+                    "sns:ListSubscriptionsByTopic",
+                    "sns:CreateTopic",
+                    "sns:SetTopicAttributes",
+                    "sns:Subscribe",
                     "sns:Publish"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}*", 
+                      "arn:${AWS::Partition}:sns:${AWS::Region}:${AWS::AccountId}:${topicName}*",
                       {
                         "topicName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy22", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "kinesis:AddTagsToStream", 
-                    "kinesis:CreateStream", 
-                    "kinesis:DecreaseStreamRetentionPeriod", 
-                    "kinesis:DeleteStream", 
-                    "kinesis:DescribeStream", 
-                    "kinesis:GetShardIterator", 
-                    "kinesis:IncreaseStreamRetentionPeriod", 
-                    "kinesis:ListTagsForStream", 
-                    "kinesis:MergeShards", 
-                    "kinesis:PutRecord", 
-                    "kinesis:PutRecords", 
-                    "kinesis:SplitShard", 
+                    "kinesis:AddTagsToStream",
+                    "kinesis:CreateStream",
+                    "kinesis:DecreaseStreamRetentionPeriod",
+                    "kinesis:DeleteStream",
+                    "kinesis:DescribeStream",
+                    "kinesis:GetShardIterator",
+                    "kinesis:IncreaseStreamRetentionPeriod",
+                    "kinesis:ListTagsForStream",
+                    "kinesis:MergeShards",
+                    "kinesis:PutRecord",
+                    "kinesis:PutRecords",
+                    "kinesis:SplitShard",
                     "kinesis:RemoveTagsFromStream"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}", 
+                      "arn:${AWS::Partition}:kinesis:${AWS::Region}:${AWS::AccountId}:stream/${streamName}",
                       {
                         "streamName": "name"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy23", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
-                  "Action": "kms:Decrypt", 
+                  "Action": "kms:Decrypt",
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${keyId}", 
+                      "arn:${AWS::Partition}:kms:${AWS::Region}:${AWS::AccountId}:key/${keyId}",
                       {
                         "keyId": "keyId"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy24", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "polly:GetLexicon", 
+                    "polly:GetLexicon",
                     "polly:DeleteLexicon"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:polly:${AWS::Region}:${AWS::AccountId}:lexicon/${lexiconName}", 
+                        "arn:${AWS::Partition}:polly:${AWS::Region}:${AWS::AccountId}:lexicon/${lexiconName}",
                         {
                           "lexiconName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "polly:DescribeVoices", 
-                    "polly:ListLexicons", 
-                    "polly:PutLexicon", 
+                    "polly:DescribeVoices",
+                    "polly:ListLexicons",
+                    "polly:PutLexicon",
                     "polly:SynthesizeSpeech"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:polly:${AWS::Region}:${AWS::AccountId}:lexicon/*"
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy25", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "s3:GetObject", 
-                    "s3:GetObjectAcl", 
-                    "s3:GetObjectVersion", 
-                    "s3:PutObject", 
-                    "s3:PutObjectAcl", 
+                    "s3:GetObject",
+                    "s3:GetObjectAcl",
+                    "s3:GetObjectVersion",
+                    "s3:PutObject",
+                    "s3:PutObjectAcl",
                     "s3:DeleteObject"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}/*", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}/*",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "s3:ListBucket", 
-                    "s3:GetBucketLocation", 
-                    "s3:GetLifecycleConfiguration", 
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetLifecycleConfiguration",
                     "s3:PutLifecycleConfiguration"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": [
-                        "arn:${AWS::Partition}:s3:::${bucketName}", 
+                        "arn:${AWS::Partition}:s3:::${bucketName}",
                         {
                           "bucketName": "name"
                         }
                       ]
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy26", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "codepipeline:PutJobSuccessResult", 
+                    "codepipeline:PutJobSuccessResult",
                     "codepipeline:PutJobFailureResult"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:*"
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy27", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "serverlessrepo:CreateApplication", 
-                    "serverlessrepo:CreateApplicationVersion", 
-                    "serverlessrepo:GetApplication", 
-                    "serverlessrepo:ListApplications", 
+                    "serverlessrepo:CreateApplication",
+                    "serverlessrepo:CreateApplicationVersion",
+                    "serverlessrepo:GetApplication",
+                    "serverlessrepo:ListApplications",
                     "serverlessrepo:ListApplicationVersions"
-                  ], 
+                  ],
                   "Resource": [
                     {
                       "Fn::Sub": "arn:${AWS::Partition}:serverlessrepo:${AWS::Region}:${AWS::AccountId}:applications/*"
                     }
-                  ], 
+                  ],
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy28", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "ec2:CopyImage"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/${imageId}", 
+                      "arn:${AWS::Partition}:ec2:${AWS::Region}:${AWS::AccountId}:image/${imageId}",
                       {
                         "imageId": "id"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy29", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "codepipeline:ListPipelineExecutions"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${pipelinename}", 
+                      "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:${pipelinename}",
                       {
                         "pipelinename": "pipeline"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy30", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "cloudwatch:GetDashboard", 
-                    "cloudwatch:ListDashboards", 
-                    "cloudwatch:PutDashboard", 
+                    "cloudwatch:GetDashboard",
+                    "cloudwatch:ListDashboards",
+                    "cloudwatch:PutDashboard",
                     "cloudwatch:ListMetrics"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy31", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:CompareFaces", 
+                    "rekognition:CompareFaces",
                     "rekognition:DetectFaces"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "collection"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy32", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "rekognition:DetectLabels", 
+                    "rekognition:DetectLabels",
                     "rekognition:DetectModerationLabels"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy33", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "dynamodb:CreateBackup", 
+                    "dynamodb:CreateBackup",
                     "dynamodb:DescribeContinuousBackups"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "dynamodb:DeleteBackup", 
-                    "dynamodb:DescribeBackup", 
+                    "dynamodb:DeleteBackup",
+                    "dynamodb:DescribeBackup",
                     "dynamodb:ListBackups"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy34", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "dynamodb:RestoreTableFromBackup"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/backup/*",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
-                }, 
+                },
                 {
                   "Action": [
-                    "dynamodb:PutItem", 
-                    "dynamodb:UpdateItem", 
-                    "dynamodb:DeleteItem", 
-                    "dynamodb:GetItem", 
-                    "dynamodb:Query", 
-                    "dynamodb:Scan", 
+                    "dynamodb:PutItem",
+                    "dynamodb:UpdateItem",
+                    "dynamodb:DeleteItem",
+                    "dynamodb:GetItem",
+                    "dynamodb:Query",
+                    "dynamodb:Scan",
                     "dynamodb:BatchWriteItem"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "table"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy35", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
-                    "comprehend:BatchDetectKeyPhrases", 
-                    "comprehend:DetectDominantLanguage", 
-                    "comprehend:DetectEntities", 
-                    "comprehend:BatchDetectEntities", 
-                    "comprehend:DetectKeyPhrases", 
-                    "comprehend:DetectSentiment", 
-                    "comprehend:BatchDetectDominantLanguage", 
+                    "comprehend:BatchDetectKeyPhrases",
+                    "comprehend:DetectDominantLanguage",
+                    "comprehend:DetectEntities",
+                    "comprehend:BatchDetectEntities",
+                    "comprehend:DetectKeyPhrases",
+                    "comprehend:DetectSentiment",
+                    "comprehend:BatchDetectDominantLanguage",
                     "comprehend:BatchDetectSentiment"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
@@ -952,14 +952,14 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy37", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "mobileanalytics:PutEvents"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
@@ -999,7 +999,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}*", 
+                      "arn:${AWS::Partition}:logs:${AWS::Region}:${AWS::Account}:log-group:${logGroupName}", 
                       {
                         "logGroupName": "name"
                       }
@@ -1010,15 +1010,15 @@
               ]
             }
           }
-        ], 
+        ],
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -988,6 +988,20 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy39",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "logs:FilterLogEvents"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "AssumeRolePolicyDocument": {


### PR DESCRIPTION
This commit essentially copies the pattern of commit #408
to add a policy template that permits calling the
filter log events cloudwatch API.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
