### PR TITLE
Add AWSSecretsManagerGetSecretValueAccess Policy

### DIFF
--- a/docs/policy_templates_data/policy_templates.json
+++ b/docs/policy_templates_data/policy_templates.json
@@ -931,34 +931,34 @@
         ]
       }
     },
-	  "AWSSecretsManagerGetSecretValueAccess": {
-	    "Description": "Grants permissions to GetSecretValue for the specified AWS Secrets Manager secret",
-	    "Parameters": {
-	      "SecretArn": {
-	        "Description": "The ARN of the secret to grant access to"
-	      }
-	    },
-	    "Definition": {
-	      "Statement": [
-	        {
-	          "Effect": "Allow",
-	          "Action": [
-	            "secretsmanager:GetSecretValue"
-	          ],
-	          "Resource": {
-	            "Fn::Sub": [
-	              "${secretArn}",
-	              {
-	                "secretArn": {
-	                  "Ref": "SecretArn"
-	                }
-	              }
-	            ]
-	          }
-	        }
-	      ]
-	    }
-	  },
+    "AWSSecretsManagerGetSecretValueAccess": {
+      "Description": "Grants permissions to GetSecretValue for the specified AWS Secrets Manager secret",
+      "Parameters": {
+        "SecretArn": {
+          "Description": "The ARN of the secret to grant access to"
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "secretsmanager:GetSecretValue"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "${secretArn}",
+                {
+                  "secretArn": {
+                    "Ref": "SecretArn"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     "CodePipelineReadOnlyPolicy": {
       "Description": "Gives read permissions to get details about a CodePipeline pipeline",
       "Parameters": {

--- a/docs/policy_templates_data/policy_templates.json
+++ b/docs/policy_templates_data/policy_templates.json
@@ -931,6 +931,34 @@
         ]
       }
     },
+	  "AWSSecretsManagerGetSecretValueAccess": {
+	    "Description": "Grants permissions to GetSecretValue for the specified AWS Secrets Manager secret",
+	    "Parameters": {
+	      "SecretArn": {
+	        "Description": "The ARN of the secret to grant access to"
+	      }
+	    },
+	    "Definition": {
+	      "Statement": [
+	        {
+	          "Effect": "Allow",
+	          "Action": [
+	            "secretsmanager:GetSecretValue"
+	          ],
+	          "Resource": {
+	            "Fn::Sub": [
+	              "${secretArn}",
+	              {
+	                "secretArn": {
+	                  "Ref": "SecretArn"
+	                }
+	              }
+	            ]
+	          }
+	        }
+	      ]
+	    }
+	  },
     "CodePipelineReadOnlyPolicy": {
       "Description": "Gives read permissions to get details about a CodePipeline pipeline",
       "Parameters": {

--- a/docs/policy_templates_data/policy_templates.json
+++ b/docs/policy_templates_data/policy_templates.json
@@ -931,7 +931,7 @@
         ]
       }
     },
-    "AWSSecretsManagerGetSecretValueAccess": {
+    "AWSSecretsManagerGetSecretValuePolicy": {
       "Description": "Grants permissions to GetSecretValue for the specified AWS Secrets Manager secret",
       "Parameters": {
         "SecretArn": {


### PR DESCRIPTION
*Description of changes:*

This change adds a AWSSecretsManagerGetSecretValueAccess policy which grants access to the Secrets Manager GetSecretValue API for a single secret ARN.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
