### PR TITLE
bug: simple-mobile-backend example app

### DIFF
--- a/examples/apps/simple-mobile-backend/template.yaml
+++ b/examples/apps/simple-mobile-backend/template.yaml
@@ -1,6 +1,9 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 Description: A simple mobile backend (read/write to DynamoDB).
+Parameters:
+  TableNameParameter:
+    Type: String
 Resources:
   simplemobilebackend:
     Type: 'AWS::Serverless::Function'
@@ -12,20 +15,5 @@ Resources:
       MemorySize: 128
       Timeout: 3
       Policies:
-        - Version: '2012-10-17'
-          Statement:
-            - Effect: Allow
-              Action:
-                - 'dynamodb:DeleteItem'
-                - 'dynamodb:GetItem'
-                - 'dynamodb:PutItem'
-                - 'dynamodb:Scan'
-                - 'dynamodb:UpdateItem'
-              Resource:
-                'Fn::Join':
-                  - ''
-                  - - 'arn:aws:dynamodb:'
-                    - Ref: 'AWS::Region'
-                    - ':'
-                    - Ref: 'AWS::AccountId'
-                    - ':table/*'
+      - DynamoDBCrudPolicy:
+          TableName: !Ref TableNameParameter


### PR DESCRIPTION
*Description of changes:*

The [simple-mobile-backend app](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:077246666028:applications~simple-mobile-backend) version 1.0.0 published to the app repo didn't match this template (which is supposed to be the source code for that published app), and also had a bug in it where the template parameter was not being Ref'ed properly when it was used as a policy template parameter. This commit updates the template to match what's in the Serverless Application Repository and also fixes the Ref bug.

*Testing*

* I verified this fix via sam package/deploy commands. Verified the IAM role created correctly substituted my TableNameParameter value.
* I then published the updated template to the Serverless Application Repository as version 1.0.1 and verified I could now successfully deploy the app and the IAM role created correctly substituted my TableNameParameter value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
