### PR TITLE
Adding AWSSecretsManagerGetSecretValuePolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1157,6 +1157,34 @@
         ]
       }
     },
+    "AWSSecretsManagerGetSecretValuePolicy": {
+      "Description": "Grants permissions to GetSecretValue for the specified AWS Secrets Manager secret",
+      "Parameters": {
+        "SecretArn": {
+          "Description": "The ARN of the secret to grant access to"
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "secretsmanager:GetSecretValue"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "${secretArn}",
+                {
+                  "secretArn": {
+                    "Ref": "SecretArn"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     "MobileAnalyticsWriteOnlyAccessPolicy": {
       "Description": "Gives write only permissions to put event data for all application resources",
       "Parameters": {


### PR DESCRIPTION
Adding the AWSSecretsManagerGetSecretValuePolicy policy to grant secretsmanager:GetSecretValue permissions to a single secret ARN.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
