### PR TITLE
docs: fix grammar in globals.rst

### DIFF
--- a/docs/globals.rst
+++ b/docs/globals.rst
@@ -182,7 +182,7 @@ Lists are additive
 ~~~~~~~~~~~~~~~~~~~
 *Lists are also known as arrays*
 
-List entries in the resource will be **appended** to the global entries. 
+Global entries will be **prepended** to the list in the resource.
 
 Example:
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixes a grammar mistake in the docs that implies that items in resource lists are added to the global list.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
