### PR TITLE
fix: Fix resource for CodePipelineLambdaExecutionPolicy policy template

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -834,11 +834,7 @@
               "codepipeline:PutJobSuccessResult",
               "codepipeline:PutJobFailureResult"
             ],
-            "Resource": [
-              {
-                "Fn::Sub": "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:*"
-              }
-            ]
+            "Resource": "*"
           }
         ]
       }

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -686,11 +686,7 @@
                     "codepipeline:PutJobSuccessResult", 
                     "codepipeline:PutJobFailureResult"
                   ], 
-                  "Resource": [
-                    {
-                      "Fn::Sub": "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:*"
-                    }
-                  ], 
+                  "Resource": "*", 
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -686,11 +686,7 @@
                     "codepipeline:PutJobSuccessResult", 
                     "codepipeline:PutJobFailureResult"
                   ], 
-                  "Resource": [
-                    {
-                      "Fn::Sub": "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:*"
-                    }
-                  ], 
+                  "Resource": "*", 
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -686,11 +686,7 @@
                     "codepipeline:PutJobSuccessResult", 
                     "codepipeline:PutJobFailureResult"
                   ], 
-                  "Resource": [
-                    {
-                      "Fn::Sub": "arn:${AWS::Partition}:codepipeline:${AWS::Region}:${AWS::AccountId}:*"
-                    }
-                  ], 
+                  "Resource": "*", 
                   "Effect": "Allow"
                 }
               ]


### PR DESCRIPTION
Closes https://github.com/awslabs/serverless-application-model/issues/389

*Description of changes:*
`PutJobFailureResult` & `PutJobSuccessResult` do not support resource-level permissions and require you to choose All resources.

> You specify the actions in the policy's Action field, and you specify a wildcard character (*) as the resource value in the policy's Resource field.

https://docs.aws.amazon.com/codepipeline/latest/userguide/permissions-reference.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 👍