### PR TITLE
fix: remove JSON Schema validation warning

### DIFF
--- a/samtranslator/parser/parser.py
+++ b/samtranslator/parser/parser.py
@@ -27,10 +27,10 @@ class Parser:
                 [InvalidTemplateException("'Resources' section is required")])
 
         validation_errors = SamTemplateValidator.validate(sam_template)
-        has_errors = len(validation_errors)
+        # has_errors = len(validation_errors)
 
-        if has_errors:
+        # if has_errors:
             # NOTE: eventually we will throw on invalid schema
             # raise InvalidDocumentException([InvalidTemplateException(validation_errors)])
-            logging.warning(
-                "JSON_VALIDATION_WARNING: {0}".format(validation_errors))
+            # logging.warning(
+            #     "JSON_VALIDATION_WARNING: {0}".format(validation_errors))


### PR DESCRIPTION
The schema is currently lacking and therefore is just noise. We may add this back in the future or remove it entirely.

*Issue #535, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
