### PR TITLE
Fix parameter definition in example apps template

### DIFF
--- a/examples/apps/cloudfront-modify-response-header/template.yaml
+++ b/examples/apps/cloudfront-modify-response-header/template.yaml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: Blueprint for modifying CloudFront response header implemented in NodeJS.
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   cloudfrontmodifyresponseheader:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/cloudwatch-logs-process-data/template.yaml
+++ b/examples/apps/cloudwatch-logs-process-data/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   group.
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   cloudwatchlogsprocessdata:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/cloudwatch-logs-to-loggly/template.yaml
+++ b/examples/apps/cloudwatch-logs-to-loggly/template.yaml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: Sends logs from Cloudwatch logs to Loggly using a Lambda function.
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   cloudwatchlogstologgly:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/cognito-sync-trigger/template.yaml
+++ b/examples/apps/cognito-sync-trigger/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   incoming event.
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   cognitosynctrigger:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/datadog-process-rds-metrics/template.yaml
+++ b/examples/apps/datadog-process-rds-metrics/template.yaml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: Pushes RDS Enhanced metrics to Datadog.
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   datadogprocessrdsmetrics:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/inspector-scheduled-run/template.yaml
+++ b/examples/apps/inspector-scheduled-run/template.yaml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: Schedules a recurring Amazon Inspector assessment run
 Parameters:
   TopicNameParameter:
-    Type:String
+    Type: String
 Resources:
   inspectorscheduledrun:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/lex-book-trip-python/template.yaml
+++ b/examples/apps/lex-book-trip-python/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   understanding
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   lexbooktrippython:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/lex-book-trip/template.yaml
+++ b/examples/apps/lex-book-trip/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   understanding
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   lexbooktrip:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/lex-make-appointment-python/template.yaml
+++ b/examples/apps/lex-make-appointment-python/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   understanding
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   lexmakeappointmentpython:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/lex-make-appointment/template.yaml
+++ b/examples/apps/lex-make-appointment/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   understanding
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   lexmakeappointment:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/lex-order-flowers-python/template.yaml
+++ b/examples/apps/lex-order-flowers-python/template.yaml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: 'Order flowers, using Amazon Lex to perform natural language understanding'
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   lexorderflowerspython:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/lex-order-flowers/template.yaml
+++ b/examples/apps/lex-order-flowers/template.yaml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: 'Order flowers, using Amazon Lex to perform natural language understanding'
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   lexorderflowers:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/logicmonitor-send-cloudwatch-events/template.yaml
+++ b/examples/apps/logicmonitor-send-cloudwatch-events/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   correlation between events and performance data.
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   logicmonitorsendcloudwatchevents:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/s3-get-object-python/template.yaml
+++ b/examples/apps/s3-get-object-python/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   updated.
 Parameters:
   BucketNameParameter:
-    Type:String
+    Type: String
 Resources:
   s3getobjectpython:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/s3-get-object-python3/template.yaml
+++ b/examples/apps/s3-get-object-python3/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   updated.
 Parameters:
   BucketNameParameter:
-    Type:String
+    Type: String
 Resources:
   s3getobjectpython3:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/s3-get-object/template.yaml
+++ b/examples/apps/s3-get-object/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   updated.
 Parameters:
   BucketNameParameter:
-    Type:String
+    Type: String
 Resources:
   s3getobject:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/slack-echo-command-python/template.yaml
+++ b/examples/apps/slack-echo-command-python/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   the user.
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   slackechocommandpython:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/slack-echo-command/template.yaml
+++ b/examples/apps/slack-echo-command/template.yaml
@@ -5,7 +5,7 @@ Description: >-
   the user.
 Parameters:
   KeyIdParameter:
-    Type:String
+    Type: String
 Resources:
   slackechocommand:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/splunk-elb-application-access-logs-processor/template.yaml
+++ b/examples/apps/splunk-elb-application-access-logs-processor/template.yaml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: Stream Application ELB access logs from S3 to Splunk's HTTP event collector
 Parameters:
   BucketNameParameter:
-    Type:String
+    Type: String
 Resources:
   splunkelbapplicationaccesslogsprocessor:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/splunk-elb-classic-access-logs-processor/template.yaml
+++ b/examples/apps/splunk-elb-classic-access-logs-processor/template.yaml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: Stream Classic ELB access logs from S3 to Splunk's HTTP event collector
 Parameters:
   BucketNameParameter:
-    Type:String
+    Type: String
 Resources:
   splunkelbclassicaccesslogsprocessor:
     Type: 'AWS::Serverless::Function'

--- a/examples/apps/splunk-logging/template.yaml
+++ b/examples/apps/splunk-logging/template.yaml
@@ -3,7 +3,7 @@ Transform: 'AWS::Serverless-2016-10-31'
 Description: Demonstrates logging from AWS Lambda code to Splunk's HTTP event collector
 Parameters:
   BucketNameParameter:
-    Type:String
+    Type: String
 Resources:
   splunklogging:
     Type: 'AWS::Serverless::Function'


### PR DESCRIPTION
*Description of changes:*

This fixes the parameter definition from a yaml string to a yaml object in example apps template.

*Tests*
Ran ```aws cloudformation package``` and ```aws cloudformation deploy``` succesfully


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
