### PR TITLE
docs: update API EndpointConfiguration options

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -214,7 +214,7 @@ CacheClusterEnabled | `boolean` | Indicates whether cache clustering is enabled 
 CacheClusterSize | `string` | The stage's cache cluster size.
 Variables | Map of `string` to `string` | A map (string to string map) that defines the stage variables, where the variable name is the key and the variable value is the value. Variable names are limited to alphanumeric characters. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&amp;=,-]+`.
 MethodSettings | [CloudFormation MethodSettings property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-methodsetting.html) | Configures all settings for API stage including Logging, Metrics, CacheTTL, Throttling. This value is passed through to CloudFormation. So any values supported by CloudFormation ``MethodSettings`` property can be used here.
-EndpointConfiguration | `string` | Specify the type of endpoint for API endpoint. Value is either `REGIONAL` or `EDGE`.
+EndpointConfiguration | `string` | Specify the type of endpoint for API endpoint. Value is either `REGIONAL`, `EDGE`, or `PRIVATE`.
 BinaryMediaTypes | List of `string` |  List of MIME types that your API could return. Use this to enable binary support for APIs. Use `~1` instead of `/` in the mime types (See examples in [template.yaml](../examples/2016-10-31/implicit_api_settings/template.yaml)).
 Cors | `string` or [Cors Configuration](#cors-configuration) | Enable CORS for all your APIs. Specify the domain to allow as a string or specify a dictionary with additional [Cors Configuration](#cors-configuration). NOTE: Cors requires SAM to modify your Swagger definition. Hence it works only inline swagger defined with `DefinitionBody`.
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/serverless-application-model/issues/544

*Description of changes:*
Added option of `PRIVATE` for the endpoint configuration in the docs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
