### PR TITLE
Expose skill ID for event source validation with skills

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -36,7 +36,7 @@ class PushEventSource(ResourceMacro):
     """
     principal = None
 
-    def _construct_permission(self, function, source_arn=None, source_account=None, suffix=""):
+    def _construct_permission(self, function, source_arn=None, source_account=None, suffix="", event_source_token=None):
         """Constructs the Lambda Permission resource allowing the source service to invoke the function this event
         source triggers.
 
@@ -56,6 +56,7 @@ class PushEventSource(ResourceMacro):
         lambda_permission.Principal = self.principal
         lambda_permission.SourceArn = source_arn
         lambda_permission.SourceAccount = source_account
+        lambda_permission.EventSourceToken = event_source_token
 
         return lambda_permission
 
@@ -477,7 +478,9 @@ class AlexaSkill(PushEventSource):
     resource_type = 'AlexaSkill'
     principal = 'alexa-appkit.amazon.com'
 
-    property_types = {}
+    property_types = {
+        'SkillId': PropertyType(False, is_str()),
+    }
 
     def to_cloudformation(self, **kwargs):
         function = kwargs.get('function')
@@ -486,7 +489,7 @@ class AlexaSkill(PushEventSource):
             raise TypeError("Missing required keyword argument: function")
 
         resources = []
-        resources.append(self._construct_permission(function))
+        resources.append(self._construct_permission(function, event_source_token=self.SkillId))
 
         return resources
 

--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -75,5 +75,6 @@ class LambdaPermission(Resource):
             'FunctionName': PropertyType(True, is_str()),
             'Principal': PropertyType(True, is_str()),
             'SourceAccount': PropertyType(False, is_str()),
-            'SourceArn': PropertyType(False, is_str())
+            'SourceArn': PropertyType(False, is_str()),
+            'EventSourceToken': PropertyType(False, is_str())
     }

--- a/tests/translator/input/alexa_skill_with_skill_id.yaml
+++ b/tests/translator/input/alexa_skill_with_skill_id.yaml
@@ -1,0 +1,20 @@
+# File: sam.yml
+# Version: 0.9
+
+AWSTemplateFormatVersion: '2010-09-09'
+Parameters: {}
+Resources:
+  AlexaSkillFunc:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Description: Created by SAM
+      Events:
+        AlexaSkillEvent:
+          Type: AlexaSkill
+          Properties:
+            SkillId: amzn1.ask.skill.12345678-1234-1234-1234-123456789
+      Handler: index.handler
+      MemorySize: 1024
+      Runtime: nodejs4.3
+      Timeout: 3

--- a/tests/translator/output/alexa_skill_with_skill_id.json
+++ b/tests/translator/output/alexa_skill_with_skill_id.json
@@ -1,0 +1,67 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09", 
+    "Parameters": {}, 
+    "Resources": {
+      "AlexaSkillFuncRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "ManagedPolicyArns": [
+            "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "lambda.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "AlexaSkillFuncAlexaSkillEventPermission": {
+        "Type": "AWS::Lambda::Permission", 
+        "Properties": {
+          "Action": "lambda:invokeFunction", 
+          "FunctionName": {
+            "Ref": "AlexaSkillFunc"
+          }, 
+          "Principal": "alexa-appkit.amazon.com",
+          "EventSourceToken": "amzn1.ask.skill.12345678-1234-1234-1234-123456789"
+        }
+      }, 
+      "AlexaSkillFunc": {
+        "Type": "AWS::Lambda::Function", 
+        "Properties": {
+          "Code": {
+            "S3Bucket": "sam-demo-bucket",
+            "S3Key": "hello.zip"
+          }, 
+          "Description": "Created by SAM",
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "lambda:createdBy"
+            }
+          ], 
+          "MemorySize": 1024, 
+          "Handler": "index.handler", 
+          "Role": {
+            "Fn::GetAtt": [
+              "AlexaSkillFuncRole", 
+              "Arn"
+            ]
+          }, 
+          "Timeout": 3, 
+          "Runtime": "nodejs4.3"
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-cn/alexa_skill_with_skill_id.json
+++ b/tests/translator/output/aws-cn/alexa_skill_with_skill_id.json
@@ -1,0 +1,67 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09", 
+    "Parameters": {}, 
+    "Resources": {
+      "AlexaSkillFuncRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "ManagedPolicyArns": [
+            "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "lambda.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "AlexaSkillFuncAlexaSkillEventPermission": {
+        "Type": "AWS::Lambda::Permission", 
+        "Properties": {
+          "Action": "lambda:invokeFunction", 
+          "FunctionName": {
+            "Ref": "AlexaSkillFunc"
+          }, 
+          "Principal": "alexa-appkit.amazon.com",
+          "EventSourceToken": "amzn1.ask.skill.12345678-1234-1234-1234-123456789"
+        }
+      }, 
+      "AlexaSkillFunc": {
+        "Type": "AWS::Lambda::Function", 
+        "Properties": {
+          "Code": {
+            "S3Bucket": "sam-demo-bucket",
+            "S3Key": "hello.zip"
+          }, 
+          "Description": "Created by SAM",
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "lambda:createdBy"
+            }
+          ], 
+          "MemorySize": 1024, 
+          "Handler": "index.handler", 
+          "Role": {
+            "Fn::GetAtt": [
+              "AlexaSkillFuncRole", 
+              "Arn"
+            ]
+          }, 
+          "Timeout": 3, 
+          "Runtime": "nodejs4.3"
+        }
+      }
+    }
+  }

--- a/tests/translator/output/aws-us-gov/alexa_skill_with_skill_id.json
+++ b/tests/translator/output/aws-us-gov/alexa_skill_with_skill_id.json
@@ -1,0 +1,67 @@
+{
+    "AWSTemplateFormatVersion": "2010-09-09", 
+    "Parameters": {}, 
+    "Resources": {
+      "AlexaSkillFuncRole": {
+        "Type": "AWS::IAM::Role", 
+        "Properties": {
+          "ManagedPolicyArns": [
+            "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          ], 
+          "AssumeRolePolicyDocument": {
+            "Version": "2012-10-17", 
+            "Statement": [
+              {
+                "Action": [
+                  "sts:AssumeRole"
+                ], 
+                "Effect": "Allow", 
+                "Principal": {
+                  "Service": [
+                    "lambda.amazonaws.com"
+                  ]
+                }
+              }
+            ]
+          }
+        }
+      }, 
+      "AlexaSkillFuncAlexaSkillEventPermission": {
+        "Type": "AWS::Lambda::Permission", 
+        "Properties": {
+          "Action": "lambda:invokeFunction", 
+          "FunctionName": {
+            "Ref": "AlexaSkillFunc"
+          }, 
+          "Principal": "alexa-appkit.amazon.com",
+          "EventSourceToken": "amzn1.ask.skill.12345678-1234-1234-1234-123456789"
+        }
+      }, 
+      "AlexaSkillFunc": {
+        "Type": "AWS::Lambda::Function", 
+        "Properties": {
+          "Code": {
+            "S3Bucket": "sam-demo-bucket",
+            "S3Key": "hello.zip"
+          }, 
+          "Description": "Created by SAM",
+          "Tags": [
+            {
+              "Value": "SAM", 
+              "Key": "lambda:createdBy"
+            }
+          ], 
+          "MemorySize": 1024, 
+          "Handler": "index.handler", 
+          "Role": {
+            "Fn::GetAtt": [
+              "AlexaSkillFuncRole", 
+              "Arn"
+            ]
+          }, 
+          "Timeout": 3, 
+          "Runtime": "nodejs4.3"
+        }
+      }
+    }
+  }

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -125,6 +125,7 @@ class TestTranslatorEndToEnd(TestCase):
         'sns_existing_other_subscription',
         'sns_topic_outside_template',
         'alexa_skill',
+        'alexa_skill_with_skill_id',
         'iot_rule',
         'function_managed_inline_policy',
         'unsupported_resources',


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Allows users to optionally specify their skill ID when configuring an AlexaSkillEvent on a function. This will validate that the Lambda is called [by the expected skill](https://developer.amazon.com/docs/custom-skills/host-a-custom-skill-as-an-aws-lambda-function.html#use-aws-cli) and is strongly recommended by Alexa.

I am open to changing the name to match the underlying CF property (EventSourceToken), but given this property must be the skill ID in this application I think this is a more sensible abstraction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
