### PR TITLE
ci: patch dependency on boto3 region_name param

### DIFF
--- a/tests/model/eventsources/test_cloudwatchlogs_event_source.py
+++ b/tests/model/eventsources/test_cloudwatchlogs_event_source.py
@@ -1,4 +1,4 @@
-from mock import Mock
+from mock import Mock, patch
 from unittest import TestCase
 from samtranslator.model.eventsources.cloudwatchlogs import CloudWatchLogs
 
@@ -18,6 +18,7 @@ class CloudWatchLogsEventSource(TestCase):
         self.permission = Mock()
         self.permission.logical_id = 'LogProcessorPermission'
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_get_source_arn(self):
         source_arn = self.cloudwatch_logs_event_source.get_source_arn()
         expected_source_arn = {'Fn::Sub': [
@@ -31,6 +32,7 @@ class CloudWatchLogsEventSource(TestCase):
         self.assertEquals(subscription_filter.FilterPattern, 'Fizbo')
         self.assertEquals(subscription_filter.DestinationArn, 'arn:aws:mock')
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_to_cloudformation_returns_permission_and_subscription_filter_resources(self):
         resources = self.cloudwatch_logs_event_source.to_cloudformation(
             function=self.function)

--- a/tests/model/test_sam_resources.py
+++ b/tests/model/test_sam_resources.py
@@ -1,5 +1,5 @@
 from unittest import TestCase
-
+from mock import patch
 import pytest
 
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
@@ -17,6 +17,7 @@ class TestCodeUri(TestCase):
         }
     }
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_with_code_uri(self):
         function = SamFunction("foo")
         function.CodeUri = "s3://foobar/foo.zip"
@@ -29,6 +30,7 @@ class TestCodeUri(TestCase):
             "S3Bucket": "foobar",
         })
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_with_zip_file(self):
         function = SamFunction("foo")
         function.InlineCode = "hello world"

--- a/tests/translator/model/preferences/test_deployment_preference_collection.py
+++ b/tests/translator/model/preferences/test_deployment_preference_collection.py
@@ -1,3 +1,4 @@
+from mock import patch
 from unittest import TestCase
 
 from samtranslator.model.codedeploy import CodeDeployApplication
@@ -18,16 +19,19 @@ class TestDeploymentPreferenceCollection(TestCase):
         self.pre_traffic_hook_global = 'pre_traffic_function_ref'
         self.function_logical_id = 'FunctionLogicalId'
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_when_no_global_dict_each_local_deployment_preference_requires_parameters(self):
         with self.assertRaises(InvalidResourceException):
             DeploymentPreferenceCollection().add('', dict())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_add_when_logical_id_previously_added_raises_value_error(self):
         with self.assertRaises(ValueError):
             deployment_preference_collection = DeploymentPreferenceCollection()
             deployment_preference_collection.add('1', {'Type': 'Canary'})
             deployment_preference_collection.add('1', {'Type': 'Linear'})
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_codedeploy_application(self):
         expected_codedeploy_application_resource = CodeDeployApplication(CODEDEPLOY_APPLICATION_LOGICAL_ID)
         expected_codedeploy_application_resource.ComputePlatform = 'Lambda'
@@ -35,6 +39,7 @@ class TestDeploymentPreferenceCollection(TestCase):
         self.assertEqual(DeploymentPreferenceCollection().codedeploy_application.to_dict(),
                          expected_codedeploy_application_resource.to_dict())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_codedeploy_iam_role(self):
         expected_codedeploy_iam_role = IAMRole('CodeDeployServiceRole')
         expected_codedeploy_iam_role.AssumeRolePolicyDocument = {
@@ -50,6 +55,7 @@ class TestDeploymentPreferenceCollection(TestCase):
         self.assertEqual(DeploymentPreferenceCollection().codedeploy_iam_role.to_dict(),
                          expected_codedeploy_iam_role.to_dict())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_deployment_group_with_minimal_parameters(self):
         expected_deployment_group = CodeDeployDeploymentGroup(self.function_logical_id + 'DeploymentGroup')
         expected_deployment_group.ApplicationName = {'Ref': CODEDEPLOY_APPLICATION_LOGICAL_ID}
@@ -77,6 +83,7 @@ class TestDeploymentPreferenceCollection(TestCase):
         self.assertEqual(deployment_group.to_dict(),
                          expected_deployment_group.to_dict())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_deployment_group_with_all_parameters(self):
         expected_deployment_group = CodeDeployDeploymentGroup(self.function_logical_id + 'DeploymentGroup')
         expected_deployment_group.AlarmConfiguration = {'Enabled': True,
@@ -106,6 +113,7 @@ class TestDeploymentPreferenceCollection(TestCase):
         self.assertEqual(deployment_group.to_dict(),
                          expected_deployment_group.to_dict())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_update_policy_with_minimal_parameters(self):
         expected_update_policy = {
             'CodeDeployLambdaAliasUpdate': {
@@ -120,6 +128,7 @@ class TestDeploymentPreferenceCollection(TestCase):
 
         self.assertEqual(expected_update_policy, update_policy.to_dict())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_update_policy_with_all_parameters(self):
         expected_update_polcy = {
             'CodeDeployLambdaAliasUpdate': {
@@ -136,6 +145,7 @@ class TestDeploymentPreferenceCollection(TestCase):
 
         self.assertEqual(expected_update_polcy, update_policy.to_dict())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_any_enabled_true_if_one_of_three_enabled(self):
         deployment_preference_collection = DeploymentPreferenceCollection()
         deployment_preference_collection.add('1', {'Type': 'LINEAR'})
@@ -144,6 +154,7 @@ class TestDeploymentPreferenceCollection(TestCase):
 
         self.assertTrue(deployment_preference_collection.any_enabled())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_any_enabled_true_if_all_of_three_enabled(self):
         deployment_preference_collection = DeploymentPreferenceCollection()
         deployment_preference_collection.add('1', {'Type': 'LINEAR'})
@@ -152,6 +163,7 @@ class TestDeploymentPreferenceCollection(TestCase):
 
         self.assertTrue(deployment_preference_collection.any_enabled())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_any_enabled_false_if_all_of_three_disabled(self):
         deployment_preference_collection = DeploymentPreferenceCollection()
         deployment_preference_collection.add('1', {'Type': 'Linear', 'Enabled': False})
@@ -160,6 +172,7 @@ class TestDeploymentPreferenceCollection(TestCase):
 
         self.assertFalse(deployment_preference_collection.any_enabled())
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_enabled_logical_ids_returns_one_if_one_of_three_enabled(self):
         deployment_preference_collection = DeploymentPreferenceCollection()
         enabled_logical_id = '1'

--- a/tests/translator/test_api_resource.py
+++ b/tests/translator/test_api_resource.py
@@ -103,6 +103,7 @@ def test_redeploy_implicit_api():
     assert second_updated_deployment_ids == translate_and_find_deployment_ids(manifest)
 
 
+@patch('boto3.session.Session.region_name', 'ap-southeast-1')
 def translate_and_find_deployment_ids(manifest):
     parameter_values = get_template_parameter_values()
     output_fragment = transform(manifest, parameter_values, mock_policy_loader)

--- a/tests/translator/test_function_resources.py
+++ b/tests/translator/test_function_resources.py
@@ -28,6 +28,7 @@ class TestVersionsAndAliases(TestCase):
         self.lambda_func = self._make_lambda_function(self.sam_func.logical_id)
         self.lambda_version = self._make_lambda_version("VersionLogicalId", self.sam_func)
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     @patch.object(SamFunction, "_get_resolved_alias_name")
     def test_sam_function_with_alias(self, get_resolved_alias_name_mock):
         alias_name = "AliasName"
@@ -74,6 +75,7 @@ class TestVersionsAndAliases(TestCase):
             self.func_dict["Properties"]["AutoPublishAlias"] = ["a", "b"]
             SamFunction.from_dict(logical_id="foo", resource_dict=self.func_dict)
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     @patch.object(SamFunction, "_get_resolved_alias_name")
     def test_sam_function_with_deployment_preference(self, get_resolved_alias_name_mock):
         deploy_preference_dict = {"Type": "LINEAR"}
@@ -140,6 +142,7 @@ class TestVersionsAndAliases(TestCase):
         with self.assertRaises(ValueError):
             sam_func.to_cloudformation(**kwargs)
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     @patch.object(SamFunction, "_get_resolved_alias_name")
     def test_sam_function_with_disabled_deployment_preference_does_not_add_update_policy(self, get_resolved_alias_name_mock):
         alias_name = "AliasName"
@@ -198,6 +201,7 @@ class TestVersionsAndAliases(TestCase):
             kwargs['deployment_preference_collection'] = self._make_deployment_preference_collection()
             sam_func.to_cloudformation(**kwargs)
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_sam_function_without_alias_allows_disabled_deployment_preference(self):
         enabled = False
         deploy_preference_dict = {"Enabled": enabled}
@@ -229,8 +233,9 @@ class TestVersionsAndAliases(TestCase):
         # Function, IAM Role
         self.assertEquals(len(resources), 2)
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     @patch.object(SamFunction, "_get_resolved_alias_name")
-    def test_sam_function_with_deployment_preference_instrinsic_ref_enabled_boolean_parameter(self, get_resolved_alias_name_mock):
+    def test_sam_function_with_deployment_preference_intrinsic_ref_enabled_boolean_parameter(self, get_resolved_alias_name_mock):
         alias_name = "AliasName"
         enabled = {"Ref": "MyEnabledFlag"}
         deploy_preference_dict = {"Type": "LINEAR", "Enabled": enabled}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -23,8 +23,9 @@ from samtranslator.translator.transform import transform
 from mock import Mock, MagicMock, patch
 
 
-input_folder = 'tests/translator/input'
-output_folder = 'tests/translator/output'
+BASE_PATH = os.path.dirname(__file__)
+INPUT_FOLDER = os.path.join(BASE_PATH, 'input')
+OUTPUT_FOLDER = os.path.join(BASE_PATH, 'output')
 
 
 def deep_sort_lists(value):
@@ -168,11 +169,11 @@ class TestTranslatorEndToEnd(TestCase):
         partition = partition_with_region[0]
         region = partition_with_region[1]
 
-        manifest = yaml_parse(open(os.path.join(input_folder, testcase + '.yaml'), 'r'))
+        manifest = yaml_parse(open(os.path.join(INPUT_FOLDER, testcase + '.yaml'), 'r'))
         # To uncover unicode-related bugs, convert dict to JSON string and parse JSON back to dict
         manifest = json.loads(json.dumps(manifest))
         partition_folder = partition if partition != "aws" else ""
-        expected = json.load(open(os.path.join(output_folder,partition_folder, testcase + '.json'), 'r'))
+        expected = json.load(open(os.path.join(OUTPUT_FOLDER,partition_folder, testcase + '.json'), 'r'))
 
         old_region = os.environ.get("AWS_DEFAULT_REGION", "")
         os.environ["AWS_DEFAULT_REGION"] = region
@@ -307,8 +308,8 @@ class TestTranslatorEndToEnd(TestCase):
     'error_function_with_invalid_policy_statement'
 ])
 def test_transform_invalid_document(testcase):
-    manifest = yaml.load(open(os.path.join(input_folder, testcase + '.yaml'), 'r'))
-    expected = json.load(open(os.path.join(output_folder, testcase + '.json'), 'r'))
+    manifest = yaml.load(open(os.path.join(INPUT_FOLDER, testcase + '.yaml'), 'r'))
+    expected = json.load(open(os.path.join(OUTPUT_FOLDER, testcase + '.json'), 'r'))
 
     mock_policy_loader = MagicMock()
     parameter_values = get_template_parameter_values()


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If aws-cli is not configured with a region name, many tests used to fail because boto3 uses this configuration to resolve the region name. Additionally, some tests were overriding the environment variable `AWS_DEFAULT_REGION` (set by aws-cli and picked up by boto3) to test for different regions. This PR removes the dependency on having a correct aws-cli configuration for boto3 as well as these overrides in the tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
