### PR TITLE
fix: conditionally install enum34 based on python version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto3~=1.5
-enum34~=1.1
+enum34~=1.1; python_version<"3.4"
 jsonschema~=2.6
 six~=1.11
 


### PR DESCRIPTION
Fix Installation of aws-sam-translator using python3.7 when trying to do a vanilla install without using any previously built binaries.

enum34 Issue: https://bitbucket.org/stoneleaf/enum34/issues/21/setuppy-should-no-op-for-python-34

Command to use under a python 3.7 virtualenv

```
pip install -v --no-binary :all: --ignore-installed .
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
