### PR TITLE
PR for issue #585 Add IAM Read only permissions to SAM Policy templates 

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1311,6 +1311,25 @@
           }
         ]
       }
+    },
+    "IAMListUserAccessKeyPolicy": {
+      "Description": "Gives permissions to list users and their access keys",
+      "Parameters": {
+
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "iam:ListAccessKeys",
+              "iam:GetAccessKeyLastUsed",
+              "iam:ListUsers"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
     }
   }
 }

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -120,3 +120,5 @@ Resources:
             PinpointApplicationId: id
 
         - RekognitionDetectOnlyPolicy: {}
+        
+        - IAMListUserAccessKeyPolicy: {}

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1003,7 +1003,23 @@
                 }
               ]
             }
-          }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "iam:ListAccessKeys",
+                    "iam:GetAccessKeyLastUsed",
+                    "iam:ListUsers"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }		 
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1003,7 +1003,23 @@
                 }
               ]
             }
-          }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "iam:ListAccessKeys",
+                    "iam:GetAccessKeyLastUsed",
+                    "iam:ListUsers"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          }		  
         ],
         "AssumeRolePolicyDocument": {
           "Version": "2012-10-17", 

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1004,6 +1004,22 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "iam:ListAccessKeys",
+                    "iam:GetAccessKeyLastUsed",
+                    "iam:ListUsers"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {


### PR DESCRIPTION
*Issue #, if available:* Issue ID 585

I am creating a serverless app that will validate whether a specified AccessKey is valid or not and if valid , it will return some metadata like accesskeycreatedate ,lastuseddate and so on.

This requires the following permissions -
{
"Action":[
"iam:ListAccessKeys",
"iam:GetAccessKeyLastUsed",
"iam:ListUsers"
],
"Effect":"Allow",
"Resource":"*"
}

Currently there is no Policy template is SAM which provides IAM Readonly permissions .

*Description of changes:*

Added the following permissions as part of a new policy in all required files 
{  
                     "Sid":"IAMPermissions",
                     "Action":[  
                        "iam:ListAccessKeys",
                        "iam:GetAccessKeyLastUsed",
                        "iam:ListUsers"
                     ],
                     "Effect":"Allow",
                     "Resource":"*"
                  }

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
