### PR TITLE
chore: include enum34 fix and surface inline code docs

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 boto3~=1.5
-enum34~=1.1
+enum34~=1.1; python_version<"3.4"
 jsonschema~=2.6
 six~=1.11
 

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -103,7 +103,8 @@ Property Name | Type | Description
 ---|:---:|---
 Handler | `string` | **Required.** Function within your code that is called to begin execution.
 Runtime | `string` | **Required.** The runtime environment.
-CodeUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | **Required.** S3 Uri or location to the function code. The S3 object this Uri references MUST be a [Lambda deployment package](http://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).
+CodeUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | **Either CodeUri or InlineCode must be specified.** S3 Uri or location to the function code. The S3 object this Uri references MUST be a [Lambda deployment package](http://docs.aws.amazon.com/lambda/latest/dg/deployment-package-v2.html).
+InlineCode | `string` | **Either CodeUri or InlineCode must be specified.** The inline code for the lambda.
 FunctionName | `string` | A name for the function. If you don't specify a name, a unique name will be generated for you. [More Info](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-lambda-function.html#cfn-lambda-function-functionname)
 Description | `string` | Description of the function.
 MemorySize | `integer` | Size of the memory allocated per invocation of the function in MB. Defaults to 128.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Reverted commit that removed documentation for inline code

Cherry picked commit that fixed the enum34 reference

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
