### PR TITLE
example [lambda_safe_deployments] use nodejs8.10 for the PreTraffic hook

### DIFF
--- a/examples/2016-10-31/lambda_safe_deployments/src/preTrafficHook.js
+++ b/examples/2016-10-31/lambda_safe_deployments/src/preTrafficHook.js
@@ -8,7 +8,7 @@ exports.handler = async (event, context, callback) => {
 
     console.log("Entering PreTraffic Hook!");
     console.log(JSON.stringify(event));
-	
+
     //Read the DeploymentId from the event payload.
     let deploymentId = event.DeploymentId;
     console.log("deploymentId=" + deploymentId);
@@ -20,7 +20,7 @@ exports.handler = async (event, context, callback) => {
     /*
       [Perform validation or prewarming steps here]
     */
-	
+
     // Prepare the validation test results with the deploymentId and
     // the lifecycleEventHookExecutionId for AWS CodeDeploy.
     let params = {
@@ -28,7 +28,7 @@ exports.handler = async (event, context, callback) => {
         lifecycleEventHookExecutionId: lifecycleEventHookExecutionId,
         status: 'Succeeded' // status can be 'Succeeded' or 'Failed'
     };
-	
+
     try {
       await codedeploy.putLifecycleEventHookExecutionStatus(params).promise();
       console.log("putLifecycleEventHookExecutionStatus done. executionStatus=[" + params.status + "]");
@@ -36,7 +36,7 @@ exports.handler = async (event, context, callback) => {
     }
     catch (err) {
       console.log("putLifecycleEventHookExecutionStatus ERROR: " + err);
-      return 'Validation test failed'
+      throw new Error('Validation test failed')
     }
 
 }

--- a/examples/2016-10-31/lambda_safe_deployments/src/preTrafficHook.js
+++ b/examples/2016-10-31/lambda_safe_deployments/src/preTrafficHook.js
@@ -1,47 +1,44 @@
+// @ts-check
 'use strict';
 
 const aws = require('aws-sdk');
 const codedeploy = new aws.CodeDeploy({apiVersion: '2014-10-06'});
 
-exports.handler = (event, context, callback) => {
+exports.handler = async (event, context, callback) => {
 
-	console.log("Entering PreTraffic Hook!");
-	console.log(JSON.stringify(event));
+    console.log("Entering PreTraffic Hook!");
+    console.log(JSON.stringify(event));
 	
-	//Read the DeploymentId from the event payload.
-    var deploymentId = event.DeploymentId;
-	console.log(deploymentId);
+    //Read the DeploymentId from the event payload.
+    let deploymentId = event.DeploymentId;
+    console.log("deploymentId=" + deploymentId);
 
     //Read the LifecycleEventHookExecutionId from the event payload
-	var lifecycleEventHookExecutionId = event.LifecycleEventHookExecutionId;
-	console.log(lifecycleEventHookExecutionId);
+    let lifecycleEventHookExecutionId = event.LifecycleEventHookExecutionId;
+    console.log("lifecycleEventHookExecutionId=" + lifecycleEventHookExecutionId);
 
-	/*
-		[Perform validation or prewarming steps here]
-	*/
+    /*
+      [Perform validation or prewarming steps here]
+    */
 	
-	// Prepare the validation test results with the deploymentId and
+    // Prepare the validation test results with the deploymentId and
     // the lifecycleEventHookExecutionId for AWS CodeDeploy.
-    var params = {
+    let params = {
         deploymentId: deploymentId,
         lifecycleEventHookExecutionId: lifecycleEventHookExecutionId,
         status: 'Succeeded' // status can be 'Succeeded' or 'Failed'
     };
 	
-	// Pass AWS CodeDeploy the prepared validation test results.
-    codedeploy.putLifecycleEventHookExecutionStatus(params, function(err, data) {
-        if (err) {
-			// Validation failed.
-			console.log('Validation test failed');
-			console.log(err);
-			console.log(data);
-            callback('Validation test failed');
-        } else {
-			// Validation succeeded.
-			console.log('Validation test succeeded');
-            callback(null, 'Validation test succeeded');
-        }
-	});
+    try {
+      await codedeploy.putLifecycleEventHookExecutionStatus(params).promise();
+      console.log("putLifecycleEventHookExecutionStatus done. executionStatus=[" + params.status + "]");
+      return 'Validation test succeeded'
+    }
+    catch (err) {
+      console.log("putLifecycleEventHookExecutionStatus ERROR: " + err);
+      return 'Validation test failed'
+    }
+
 }
 
 // See more: https://docs.aws.amazon.com/codedeploy/latest/userguide/reference-appspec-file-structure-hooks.html#reference-appspec-file-structure-hooks-section-structure-lambda-sample-function

--- a/examples/2016-10-31/lambda_safe_deployments/src/safeTest.js
+++ b/examples/2016-10-31/lambda_safe_deployments/src/safeTest.js
@@ -1,7 +1,8 @@
 'use strict';
 
 
-exports.handler = (event, context, callback) => {
+exports.handler = async (event, context, callback) => {
+
 	console.log("Function loaded! " + context.functionName  +  ":"  +  context.functionVersion);
 
 	callback(null, "Success");

--- a/examples/2016-10-31/lambda_safe_deployments/template.yaml
+++ b/examples/2016-10-31/lambda_safe_deployments/template.yaml
@@ -9,7 +9,7 @@ Resources:
     Properties:
       Handler: safeTest.handler
       CodeUri: src/
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       AutoPublishAlias: live
       DeploymentPreference:
           Type: Linear10PercentEvery1Minute
@@ -35,7 +35,7 @@ Resources:
             Action:
               - "lambda:InvokeFunction"
             Resource: !Ref safeTest.Version
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       FunctionName: 'CodeDeployHook_preTrafficHook'
       DeploymentPreference:
         Enabled: false


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

PreTrafficHook example now uses NodeJS 8.10 runtime


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

