### PR TITLE
Removed nose from dev requirements.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -9,7 +9,6 @@ PyYAML==3.12
 pytest>=3.0.7
 py>=1.4.33
 mock>=2.0.0
-nose>=1.3.7
 parameterized>=0.6.1
 requests>=2.11.1
 


### PR DESCRIPTION
`nose` isn't needed as a dependency anymore. I'm going to look into removing `parameterized` in the future as well.

*Issue #, if available:* #628 

*Description of changes:* Removed nose as a dependency.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
