### PR TITLE
Fix s3 examples

### DIFF
--- a/examples/apps/rekognition-python/template.yaml
+++ b/examples/apps/rekognition-python/template.yaml
@@ -2,8 +2,9 @@ AWSTemplateFormatVersion: '2010-09-09'
 Transform: 'AWS::Serverless-2016-10-31'
 Description: An Amazon S3 trigger that uses rekognition APIs to detect faces
 Parameters:
-  BucketNameParameter:
+  BucketNamePrefix:
     Type: String
+    Default: sam-example
   CollectionIdParameter:
     Type: String
 Resources:
@@ -18,7 +19,7 @@ Resources:
       Timeout: 3
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref BucketNameParameter
+            BucketName: !Sub "${BucketNamePrefix}-rekognition"
         - RekognitionNoDataAccessPolicy:
             CollectionId: !Ref CollectionIdParameter
         - RekognitionWriteOnlyAccessPolicy:
@@ -33,3 +34,5 @@ Resources:
               - 's3:ObjectCreated:*'
   Bucket1:
     Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Sub "${BucketNamePrefix}-rekognition"

--- a/examples/apps/s3-get-object-python/template.yaml
+++ b/examples/apps/s3-get-object-python/template.yaml
@@ -4,8 +4,9 @@ Description: >-
   An Amazon S3 trigger that retrieves metadata for the object that has been
   updated.
 Parameters:
-  BucketNameParameter:
+  BucketNamePrefix:
     Type: String
+    Default: sam-example
 Resources:
   s3getobjectpython:
     Type: 'AWS::Serverless::Function'
@@ -20,7 +21,7 @@ Resources:
       Timeout: 3
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref BucketNameParameter
+            BucketName: !Sub "${BucketNamePrefix}-get-object-python"
       Events:
         BucketEvent1:
           Type: S3
@@ -31,3 +32,5 @@ Resources:
               - 's3:ObjectCreated:*'
   Bucket1:
     Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Sub "${BucketNamePrefix}-get-object-python"

--- a/examples/apps/s3-get-object-python3/template.yaml
+++ b/examples/apps/s3-get-object-python3/template.yaml
@@ -4,8 +4,9 @@ Description: >-
   An Amazon S3 trigger that retrieves metadata for the object that has been
   updated.
 Parameters:
-  BucketNameParameter:
+  BucketNamePrefix:
     Type: String
+    Default: sam-example
 Resources:
   s3getobjectpython3:
     Type: 'AWS::Serverless::Function'
@@ -20,7 +21,7 @@ Resources:
       Timeout: 3
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref BucketNameParameter
+            BucketName: !Sub "${BucketNamePrefix}-get-object-python3"
       Events:
         BucketEvent1:
           Type: S3
@@ -31,3 +32,5 @@ Resources:
               - 's3:ObjectCreated:*'
   Bucket1:
     Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Sub "${BucketNamePrefix}-get-object-python3"

--- a/examples/apps/s3-get-object/template.yaml
+++ b/examples/apps/s3-get-object/template.yaml
@@ -4,8 +4,9 @@ Description: >-
   An Amazon S3 trigger that retrieves metadata for the object that has been
   updated.
 Parameters:
-  BucketNameParameter:
+  BucketNamePrefix:
     Type: String
+    Default: sam-example
 Resources:
   s3getobject:
     Type: 'AWS::Serverless::Function'
@@ -20,14 +21,15 @@ Resources:
       Timeout: 3
       Policies:
         - S3CrudPolicy:
-            BucketName: !Ref BucketNameParameter
+            BucketName: !Sub "${BucketNamePrefix}-get-object"
       Events:
         BucketEvent1:
           Type: S3
           Properties:
-            Bucket:
-              Ref: Bucket1
+            Bucket: !Ref Bucket1
             Events:
               - 's3:ObjectCreated:*'
   Bucket1:
     Type: 'AWS::S3::Bucket'
+    Properties:
+      BucketName: !Sub "${BucketNamePrefix}-get-object"


### PR DESCRIPTION
*Issue #, if available:*
#618 
*Description of changes:*
Modified examples to create and grant read access to S3 Buckets created, these examples now can work out of the box. Needed to use !Sub and Prefix to get around circular dependency issues.

Based solution on method described [here](https://aws.amazon.com/premiumsupport/knowledge-center/unable-validate-circular-dependency-cloudformation/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
