### PR TITLE
Use correct path for SES notifications Lambda

### DIFF
--- a/examples/apps/ses-notification-nodejs/index.js
+++ b/examples/apps/ses-notification-nodejs/index.js
@@ -5,7 +5,7 @@ exports.handler = (event, context, callback) => {
     //console.log('Received event:', JSON.stringify(event, null, 2));
     const message = JSON.parse(event.Records[0].Sns.Message);
     
-    switch(message.notificationType) {
+    switch(message.eventType) {
         case 'Bounce':
             handleBounce(message);
             break;

--- a/examples/apps/ses-notification-nodejs/index.js
+++ b/examples/apps/ses-notification-nodejs/index.js
@@ -16,7 +16,7 @@ exports.handler = (event, context, callback) => {
             handleDelivery(message);
             break;
         default:
-            callback(`Unknown notification type: ${message.notificationType}`);
+            callback(`Unknown notification type: ${message.eventType}`);
     }
 };
 


### PR DESCRIPTION
SES Notifications coming via SNS do not actually have the `notificationType` param on the `message` object. Instead there is an `eventType` one. At least on the events we've tested.

*Issue #, if available:*

*Description of changes:*
This PR changes the name of the path parameter to the correct one actually supplied by SNS.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
