### PR TITLE
docs: fix 'latest version' alarm in safe deployments guide

### DIFF
--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -133,9 +133,11 @@ resource:
       ComparisonOperator: GreaterThanThreshold
       Dimensions:
         - Name: Resource
-          Value: !Ref MyLambdaFunction.Version
+          Value: !Sub "${MyLambdaFunction}:live"
         - Name: FunctionName
           Value: !Ref MyLambdaFunction
+        - Name: ExecutedVersion
+          Value: !GetAtt MyLambdaFunction.Version.Version
       EvaluationPeriods: 2
       MetricName: Errors
       Namespace: AWS/Lambda


### PR DESCRIPTION
The current example configuration for `LatestVersionErrorMetricGreaterThanZeroAlarm` will always be in "Insufficient Data" state with no data if invoking against the 'live' alias as described in the guide.  This change fixes the alarm to point to the 'live' alias and the ExecutedVersion dimension.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
