### PR TITLE
Add support for X-Ray to AWS::Serverless::Api

### DIFF
--- a/docs/cloudformation_compatibility.rst
+++ b/docs/cloudformation_compatibility.rst
@@ -168,6 +168,7 @@ EndpointConfiguration               All
 MethodSettings                      All
 BinaryMediaTypes                    All
 Cors                                All
+TracingEnabled                      All
 ================================== ======================== ========================
 
 

--- a/docs/globals.rst
+++ b/docs/globals.rst
@@ -81,6 +81,7 @@ Currently, the following resources and properties are being supported:
       Cors:
       AccessLogSetting:
       CanarySetting:
+      TracingEnabled:
 
     SimpleTable:
       # Properties of AWS::Serverless::SimpleTable

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -23,7 +23,7 @@ AuthProperties.__new__.__defaults__ = (None, None)
 
 class ApiGenerator(object):
 
-    def __init__(self, logical_id, cache_cluster_enabled, cache_cluster_size, variables, depends_on, definition_body, definition_uri, name, stage_name, endpoint_configuration=None, method_settings=None, binary_media=None, cors=None, auth=None, access_log_setting=None, canary_setting=None):
+    def __init__(self, logical_id, cache_cluster_enabled, cache_cluster_size, variables, depends_on, definition_body, definition_uri, name, stage_name, endpoint_configuration=None, method_settings=None, binary_media=None, cors=None, auth=None, access_log_setting=None, canary_setting=None, tracing_enabled=None):
         """Constructs an API Generator class that generates API Gateway resources
 
         :param logical_id: Logical id of the SAM API Resource
@@ -37,6 +37,7 @@ class ApiGenerator(object):
         :param stage_name: Name of the Stage
         :param access_log_setting: Whether to send access logs and where for Stage
         :param canary_setting: Canary Setting for Stage
+        :param tracing_enabled: Whether active tracing with X-ray is enabled
         """
         self.logical_id = logical_id
         self.cache_cluster_enabled = cache_cluster_enabled
@@ -54,6 +55,7 @@ class ApiGenerator(object):
         self.auth = auth
         self.access_log_setting = access_log_setting
         self.canary_setting = canary_setting
+        self.tracing_enabled = tracing_enabled
 
     def _construct_rest_api(self):
         """Constructs and returns the ApiGateway RestApi.
@@ -154,6 +156,7 @@ class ApiGenerator(object):
         stage.MethodSettings = self.method_settings
         stage.AccessLogSetting = self.access_log_setting
         stage.CanarySetting = self.canary_setting
+        stage.TracingEnabled = self.tracing_enabled
 
         if swagger is not None:
             deployment.make_auto_deployable(stage, swagger)

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -37,6 +37,7 @@ class ApiGatewayStage(Resource):
             'Description': PropertyType(False, is_str()),
             'RestApiId': PropertyType(True, is_str()),
             'StageName': PropertyType(True, one_of(is_str(), is_type(dict))),
+            'TracingEnabled': PropertyType(False, is_type(bool)),
             'Variables': PropertyType(False, is_type(dict)),
             "MethodSettings": PropertyType(False, is_type(list))
     }

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -480,7 +480,8 @@ class SamApi(SamResourceMacro):
         'Cors': PropertyType(False, one_of(is_str(), is_type(dict))),
         'Auth': PropertyType(False, is_type(dict)),
         'AccessLogSetting': PropertyType(False, is_type(dict)),
-        'CanarySetting': PropertyType(False, is_type(dict))
+        'CanarySetting': PropertyType(False, is_type(dict)),
+        'TracingEnabled': PropertyType(False, is_type(bool))
     }
 
     referable_properties = {
@@ -513,7 +514,8 @@ class SamApi(SamResourceMacro):
                                      cors=self.Cors,
                                      auth=self.Auth,
                                      access_log_setting=self.AccessLogSetting,
-                                     canary_setting=self.CanarySetting)
+                                     canary_setting=self.CanarySetting,
+                                     tracing_enabled=self.TracingEnabled)
 
         rest_api, deployment, stage, permissions = api_generator.to_cloudformation()
 

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -46,7 +46,8 @@ class Globals(object):
             "BinaryMediaTypes",
             "Cors",
             "AccessLogSetting",
-            "CanarySetting"
+            "CanarySetting",
+            "TracingEnabled"
         ],
 
         SamResourceType.SimpleTable.value: [

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -68,6 +68,9 @@
                 }
               ]
             },
+            "TracingEnabled": {
+              "type": "boolean"
+            },
             "Variables": {
               "additionalProperties": false,
               "patternProperties": {

--- a/tests/translator/input/api_with_xray_tracing.yaml
+++ b/tests/translator/input/api_with_xray_tracing.yaml
@@ -1,0 +1,21 @@
+Resources:
+  HtmlFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs4.3
+      Events:
+        GetHtml:
+          Type: Api
+          Properties:
+            RestApiId: HtmlApi
+            Path: /
+            Method: get
+
+  HtmlApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      DefinitionUri: s3://sam-demo-bucket/webpage_swagger.json
+      TracingEnabled: true

--- a/tests/translator/output/api_with_xray_tracing.json
+++ b/tests/translator/output/api_with_xray_tracing.json
@@ -1,0 +1,121 @@
+{
+  "Resources": {
+    "HtmlFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "HtmlApiDeploymentf117c932f7"
+        },
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "Prod",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "*",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "StageName": "Stage"
+      }
+    },
+    "HtmlApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "webpage_swagger.json"
+        }
+      }
+    },
+    "HtmlFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "member_portal.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "HtmlFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs4.3",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_xray_tracing.json
+++ b/tests/translator/output/aws-cn/api_with_xray_tracing.json
@@ -98,7 +98,7 @@
           "Key": "webpage_swagger.json"
         },
         "Parameters": {
-          "endpointConfigurationTypes": "REGIONAL",
+          "endpointConfigurationTypes": "REGIONAL"
         }
       }
     },

--- a/tests/translator/output/aws-cn/api_with_xray_tracing.json
+++ b/tests/translator/output/aws-cn/api_with_xray_tracing.json
@@ -1,0 +1,129 @@
+{
+  "Resources": {
+    "HtmlFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "HtmlApiDeploymentf117c932f7"
+        },
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "Prod",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "*",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "StageName": "Stage"
+      }
+    },
+    "HtmlApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "webpage_swagger.json"
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL",
+        }
+      }
+    },
+    "HtmlFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "member_portal.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "HtmlFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs4.3",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_with_xray_tracing.json
+++ b/tests/translator/output/aws-us-gov/api_with_xray_tracing.json
@@ -98,7 +98,7 @@
           "Key": "webpage_swagger.json"
         },
         "Parameters": {
-          "endpointConfigurationTypes": "REGIONAL",
+          "endpointConfigurationTypes": "REGIONAL"
         }
       }
     },

--- a/tests/translator/output/aws-us-gov/api_with_xray_tracing.json
+++ b/tests/translator/output/aws-us-gov/api_with_xray_tracing.json
@@ -1,0 +1,129 @@
+{
+  "Resources": {
+    "HtmlFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "HtmlApiDeploymentf117c932f7"
+        },
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "StageName": "Prod",
+        "TracingEnabled": true
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "Prod",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
+            {
+              "__Stage__": "*",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "StageName": "Stage"
+      }
+    },
+    "HtmlApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "webpage_swagger.json"
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL",
+        }
+      }
+    },
+    "HtmlFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "member_portal.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "HtmlFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs4.3",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/error_globals_api_with_stage_name.json
+++ b/tests/translator/output/error_globals_api_with_stage_name.json
@@ -4,5 +4,5 @@
       "errorMessage": "'Globals' section is invalid. 'StageName' is not a supported property of 'Api'. Must be one of the following values - ['Name', 'DefinitionUri', 'CacheClusterEnabled', 'CacheClusterSize', 'Variables', 'EndpointConfiguration', 'MethodSettings', 'BinaryMediaTypes', 'Cors', 'AccessLogSetting', 'CanarySetting']"
     }
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. 'Globals' section is invalid. 'StageName' is not a supported property of 'Api'. Must be one of the following values - ['Name', 'DefinitionUri', 'CacheClusterEnabled', 'CacheClusterSize', 'Variables', 'EndpointConfiguration', 'MethodSettings', 'BinaryMediaTypes', 'Cors', 'AccessLogSetting', 'CanarySetting']"
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. 'Globals' section is invalid. 'StageName' is not a supported property of 'Api'. Must be one of the following values - ['Name', 'DefinitionUri', 'CacheClusterEnabled', 'CacheClusterSize', 'Variables', 'EndpointConfiguration', 'MethodSettings', 'BinaryMediaTypes', 'Cors', 'AccessLogSetting', 'CanarySetting', 'TracingEnabled']"
 }

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -119,6 +119,7 @@ class TestTranslatorEndToEnd(TestCase):
         'api_cache',
         'api_with_access_log_setting',
         'api_with_canary_setting',
+        'api_with_xray_tracing',
         's3',
         's3_create_remove',
         's3_existing_lambda_notification_configuration',

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -221,6 +221,7 @@ Cors | `string` or [Cors Configuration](#cors-configuration) | Enable CORS for a
 Auth | [API Auth Object](#api-auth-object) | Auth configuration for this API. Define Lambda and Cognito `Authorizers` and specify a `DefaultAuthorizer` for this API.
 AccessLogSetting | [CloudFormation AccessLogSetting property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-accesslogsetting.html) | Configures Access Log Setting for a stage. This value is passed through to CloudFormation, so any value supported by `AccessLogSetting` is supported here.
 CanarySetting | [CloudFormation CanarySetting property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigateway-stage-canarysetting.html) | Configure a Canary Setting to a Stage of a regular deployment. This value is passed through to Cloudformation, so any value supported by `CanarySetting` is supported here.
+TracingEnabled | `boolean` | Indicates whether active tracing with X-Ray is enabled for the stage.
 
 ##### Return values
 


### PR DESCRIPTION
CloudFormation recently got the ability to enable active tracing with X-Ray for API Gateway stages. This PR adds that ability to `AWS::Serverless::Api`.

I hope I updated it in all necessary places, including documentation etc., but if I didn't, please just tell me where it's missing and I'll update the PR accordingly. :smiley: 

Fixes #581

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
