### PR TITLE
Update Schema by including a validation rule for the Api Gateway Path

### DIFF
--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -311,6 +311,11 @@
           "type": "string"
         },
         "Path": {
+          "patternProperties": {
+            "^[a-zA-Z0-9\\-\\_\\.\/\\{\\}\\+]+$": {
+              "type": "string"
+            }
+          },
           "type": "string"
         },
         "RestApiId": {


### PR DESCRIPTION
*Issue #, if available:*
Follows a previous discussion in a Pull Request for SAM CLI: https://github.com/awslabs/aws-sam-cli/pull/767

*Description of changes:*
When using SAM CLI, if using a not valid Api Gateway path (for instance `/~hello`) , SAM CLI succeeds during dev and fails during deploy. By adding this rule in SAM, the cli should automatically pick up the rule, and we should be able to alert the user earlier in the process and improve the developer experience. 

Note: I am not sure about how to test this change. I tried adding a file with a broken rule in the `tests/translator/input` for TDD but the test failed because no output was present (which I was assuming the test would generate for me). Would you be able to provide some help on how I can do that?

Thanks a lot for your help 🙏 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
