### PR TITLE
Add GSIs to DynamoDBReadPolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -163,16 +163,28 @@
               "dynamodb:BatchGetItem",
               "dynamodb:DescribeTable"
             ],
-            "Resource": {
-              "Fn::Sub": [
-                "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
-                {
-                  "tableName": {
-                    "Ref": "TableName"
+            "Resource": [
+              {
+                "Fn::Sub": [
+                  "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
+                  {
+                    "tableName": {
+                      "Ref": "TableName"
+                    }
                   }
-                }
-              ]
-            }
+                ]
+              },
+              {
+                "Fn::Sub": [
+                  "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/index/*",
+                  {
+                    "tableName": {
+                      "Ref": "TableName"
+                    }
+                  }
+                ]
+              }
+            ]
           }
         ]
       }

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -158,14 +158,24 @@
                     "dynamodb:BatchGetItem",
                     "dynamodb:DescribeTable"
                   ],
-                  "Resource": {
-                    "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
-                      {
-                        "tableName": "name"
-                      }
-                    ]
-                  },
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
+                        {
+                          "tableName": "name"
+                        }
+                      ]
+                    },
+                    {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/index/*",
+                          {
+                            "tableName": "name"
+                          }
+                      ]
+                    }
+                  ],
                   "Effect": "Allow"
                 }
               ]
@@ -511,8 +521,8 @@
               "Statement": [
                 {
                   "Action": [
-                    "ses:GetIdentityVerificationAttributes", 
-                    "ses:SendEmail", 
+                    "ses:GetIdentityVerificationAttributes",
+                    "ses:SendEmail",
                     "ses:SendRawEmail",
                     "ses:VerifyEmailIdentity"
                   ],
@@ -1017,7 +1027,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy40", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1027,15 +1037,15 @@
                     "rekognition:SearchFaces",
                     "rekognition:SearchFacesByImage",
                     "rekognition:ListFaces"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "collection"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
@@ -1057,7 +1067,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy42", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [{
                 "Effect": "Allow",
@@ -1072,23 +1082,23 @@
                 "Resource": "*"
               }]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy43", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "organizations:ListAccounts"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy44", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1097,7 +1107,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "name"
                       }

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -157,14 +157,24 @@
                     "dynamodb:BatchGetItem",
                     "dynamodb:DescribeTable"
                   ],
-                  "Resource": {
-                    "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
-                      {
-                        "tableName": "name"
-                      }
-                    ]
-                  },
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
+                        {
+                          "tableName": "name"
+                        }
+                      ]
+                    },
+                    {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/index/*",
+                          {
+                            "tableName": "name"
+                          }
+                      ]
+                    }
+                  ],
                   "Effect": "Allow"
                 }
               ]
@@ -510,8 +520,8 @@
               "Statement": [
                 {
                   "Action": [
-                    "ses:GetIdentityVerificationAttributes", 
-                    "ses:SendEmail", 
+                    "ses:GetIdentityVerificationAttributes",
+                    "ses:SendEmail",
                     "ses:SendRawEmail",
                     "ses:VerifyEmailIdentity"
                   ],
@@ -1016,7 +1026,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy40", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1026,15 +1036,15 @@
                     "rekognition:SearchFaces",
                     "rekognition:SearchFacesByImage",
                     "rekognition:ListFaces"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "collection"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
@@ -1056,7 +1066,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy42", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [{
                 "Effect": "Allow",
@@ -1071,23 +1081,23 @@
                 "Resource": "*"
               }]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy43", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "organizations:ListAccounts"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy44", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1096,7 +1106,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "name"
                       }

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -157,14 +157,24 @@
                     "dynamodb:BatchGetItem",
                     "dynamodb:DescribeTable"
                   ],
-                  "Resource": {
-                    "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
-                      {
-                        "tableName": "name"
-                      }
-                    ]
-                  },
+                  "Resource": [
+                    {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
+                        {
+                          "tableName": "name"
+                        }
+                      ]
+                    },
+                    {
+                      "Fn::Sub": [
+                        "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}/index/*",
+                          {
+                            "tableName": "name"
+                          }
+                      ]
+                    }
+                  ],
                   "Effect": "Allow"
                 }
               ]
@@ -510,8 +520,8 @@
               "Statement": [
                 {
                   "Action": [
-                    "ses:GetIdentityVerificationAttributes", 
-                    "ses:SendEmail", 
+                    "ses:GetIdentityVerificationAttributes",
+                    "ses:SendEmail",
                     "ses:SendRawEmail",
                     "ses:VerifyEmailIdentity"
                   ],
@@ -1017,7 +1027,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy40", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1027,15 +1037,15 @@
                     "rekognition:SearchFaces",
                     "rekognition:SearchFacesByImage",
                     "rekognition:ListFaces"
-                  ], 
+                  ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}", 
+                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
                       {
                         "collectionId": "collection"
                       }
                     ]
-                  }, 
+                  },
                   "Effect": "Allow"
                 }
               ]
@@ -1057,7 +1067,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy42", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [{
                 "Effect": "Allow",
@@ -1072,23 +1082,23 @@
                 "Resource": "*"
               }]
             }
-          }, 
+          },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy43", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [
                 {
                   "Action": [
                     "organizations:ListAccounts"
-                  ], 
-                  "Resource": "*", 
+                  ],
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy44", 
+            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1097,7 +1107,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}", 
+                      "arn:${AWS::Partition}:dynamodb:${AWS::Region}:${AWS::AccountId}:table/${tableName}",
                       {
                         "tableName": "name"
                       }


### PR DESCRIPTION
The read-only policy should also allow indexes to be used. This is an extension of #620 

*Issue #, if available:* N/A

*Description of changes:* Added explicit access to GSIs in the `DynamoDBReadPolicy` template.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
