### PR TITLE
Event source disabled

### DIFF
--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -19,7 +19,8 @@ class PullEventSource(ResourceMacro):
         'Stream': PropertyType(False, is_str()),
         'Queue': PropertyType(False, is_str()),
         'BatchSize': PropertyType(False, is_type(int)),
-        'StartingPosition': PropertyType(False, is_str())
+        'StartingPosition': PropertyType(False, is_str()),
+        'Enabled': PropertyType(False, is_type(bool))
     }
 
     def get_policy_arn(self):
@@ -61,6 +62,7 @@ class PullEventSource(ResourceMacro):
         lambda_eventsourcemapping.EventSourceArn = self.Stream or self.Queue
         lambda_eventsourcemapping.StartingPosition = self.StartingPosition
         lambda_eventsourcemapping.BatchSize = self.BatchSize
+        lambda_eventsourcemapping.Enabled = self.Enabled
 
         if 'role' in kwargs:
             self._link_policy(kwargs['role'])

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -394,6 +394,9 @@
         },
         "Stream": {
           "type": "string"
+        },
+        "Enabled": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -512,6 +515,9 @@
         },
         "Stream": {
           "type": "string"
+        },
+        "Enabled": {
+          "type": "boolean"
         }
       },
       "required": [
@@ -534,6 +540,9 @@
               "type": "object"
             }
           ]
+        },
+        "Enabled": {
+          "type": "boolean"
         }
       },
       "required": [

--- a/tests/translator/input/sqs.yaml
+++ b/tests/translator/input/sqs.yaml
@@ -11,3 +11,4 @@ Resources:
           Properties:
             Queue: arn:aws:sqs:us-west-2:012345678901:my-queue
             BatchSize: 10
+            Enabled: false

--- a/tests/translator/input/streams.yaml
+++ b/tests/translator/input/streams.yaml
@@ -12,6 +12,7 @@ Resources:
             Stream: arn:aws:kinesis:us-west-2:012345678901:stream/my-stream
             BatchSize: 100
             StartingPosition: TRIM_HORIZON
+            Enabled: false
   DynamoDBFunction:
     Type: 'AWS::Serverless::Function'
     Properties:

--- a/tests/translator/output/aws-cn/sqs.json
+++ b/tests/translator/output/aws-cn/sqs.json
@@ -48,6 +48,7 @@
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "BatchSize": 10,
+        "Enabled": false,
         "EventSourceArn": "arn:aws:sqs:us-west-2:012345678901:my-queue",
         "FunctionName": {
           "Ref": "SQSFunction"

--- a/tests/translator/output/aws-cn/streams.json
+++ b/tests/translator/output/aws-cn/streams.json
@@ -80,6 +80,7 @@
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "BatchSize": 100,
+        "Enabled": false,
         "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream",
         "FunctionName": {
           "Ref": "KinesisFunction"

--- a/tests/translator/output/aws-us-gov/sqs.json
+++ b/tests/translator/output/aws-us-gov/sqs.json
@@ -48,6 +48,7 @@
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "BatchSize": 10,
+        "Enabled": false,
         "EventSourceArn": "arn:aws:sqs:us-west-2:012345678901:my-queue",
         "FunctionName": {
           "Ref": "SQSFunction"

--- a/tests/translator/output/aws-us-gov/streams.json
+++ b/tests/translator/output/aws-us-gov/streams.json
@@ -80,6 +80,7 @@
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "BatchSize": 100,
+        "Enabled": false,
         "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream",
         "FunctionName": {
           "Ref": "KinesisFunction"

--- a/tests/translator/output/sqs.json
+++ b/tests/translator/output/sqs.json
@@ -48,6 +48,7 @@
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "BatchSize": 10,
+        "Enabled": false,
         "EventSourceArn": "arn:aws:sqs:us-west-2:012345678901:my-queue",
         "FunctionName": {
           "Ref": "SQSFunction"

--- a/tests/translator/output/streams.json
+++ b/tests/translator/output/streams.json
@@ -80,6 +80,7 @@
       "Type": "AWS::Lambda::EventSourceMapping",
       "Properties": {
         "BatchSize": 100,
+        "Enabled": false,
         "EventSourceArn": "arn:aws:kinesis:us-west-2:012345678901:stream/my-stream",
         "FunctionName": {
           "Ref": "KinesisFunction"

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -351,6 +351,7 @@ Property Name | Type | Description
 Stream | `string` | **Required.** ARN of the Amazon Kinesis stream.
 StartingPosition | `string` | **Required.** One of `TRIM_HORIZON` or `LATEST`.
 BatchSize | `integer` | Maximum number of stream records to process per function invocation.
+Enabled | `boolean` | Indicates whether Lambda begins polling the event source.
 
 ##### Example: Kinesis event source object
 
@@ -360,6 +361,7 @@ Properties:
   Stream: arn:aws:kinesis:us-east-1:123456789012:stream/my-stream
   StartingPosition: TRIM_HORIZON
   BatchSize: 10
+  Enabled: false
 ```
 
 #### DynamoDB
@@ -373,6 +375,7 @@ Property Name | Type | Description
 Stream | `string` | **Required.** ARN of the DynamoDB stream.
 StartingPosition | `string` | **Required.** One of `TRIM_HORIZON` or `LATEST`.
 BatchSize | `integer` | Maximum number of stream records to process per function invocation.
+Enabled | `boolean` | Indicates whether Lambda begins polling the event source.
 
 ##### Example: DynamoDB event source object
 
@@ -382,6 +385,7 @@ Properties:
   Stream: arn:aws:dynamodb:us-east-1:123456789012:table/TestTable/stream/2016-08-11T21:21:33.291
   StartingPosition: TRIM_HORIZON
   BatchSize: 10
+  Enabled: false
 ```
 
 #### SQS
@@ -394,6 +398,7 @@ Property Name | Type | Description
 ---|:---:|---
 Queue | `string` | **Required.** ARN of the SQS queue.
 BatchSize | `integer` | Maximum number of messages to process per function invocation.
+Enabled | `boolean` | Indicates whether Lambda begins polling the event source.
 
 ##### Example: SQS event source object
 
@@ -402,6 +407,7 @@ Type: SQS
 Properties:
   Queue: arn:aws:sqs:us-west-2:012345678901:my-queue # NOTE: FIFO SQS Queues are not yet supported
   BatchSize: 10
+  Enabled: false
 ```
 
 #### Api


### PR DESCRIPTION
Issue #669 

*Description of changes:*
Added Enabled boolean option for SQS, DynamoDB and Kinesis events.
Updated documentation to show support for this property addition.
Modified translator tests to verify that cloudformation templates generate with Enabled as part of AWS::Lambda::EventSourceMapping.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
