### PR TITLE
fix: initialize the the sar boto3 client only if it's needed

### DIFF
--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -48,10 +48,7 @@ class ServerlessAppPlugin(BasePlugin):
         super(ServerlessAppPlugin, self).__init__(ServerlessAppPlugin.__name__)
         self._applications = {}
         self._in_progress_templates = []
-        if sar_client:
-            self._sar_client = sar_client
-        else:
-            self._sar_client = boto3.client('serverlessrepo')
+        self._sar_client = sar_client
         self._wait_for_template_active_status = wait_for_template_active_status
         self._validate_only = validate_only
 
@@ -89,6 +86,9 @@ class ServerlessAppPlugin(BasePlugin):
             key = (app_id, semver)
             if key not in self._applications:
                 try:
+                    # Lazy initialization of the client- create it when it is needed
+                    if not self._sar_client:
+                        self._sar_client = boto3.client('serverlessrepo')
                     service_call(app_id, semver, key, logical_id)
                 except InvalidResourceException as e:
                     # Catch all InvalidResourceExceptions, raise those in the before_resource_transform target.


### PR DESCRIPTION
*Description of changes:*
The SAR client should only be initialized if a) it is passed into the plugin or b) it is necessary for the transform. Otherwise, SAM shouldn't worry about setting up the client.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
