### PR TITLE
fix: add missing parameter to s3 bucket resource

### DIFF
--- a/samtranslator/model/s3.py
+++ b/samtranslator/model/s3.py
@@ -16,6 +16,7 @@ class S3Bucket(Resource):
             'LoggingConfiguration': PropertyType(False, any_type()),
             'MetricsConfigurations': PropertyType(False, any_type()),
             'NotificationConfiguration': PropertyType(False, is_type(dict)),
+            'PublicAccessBlockConfiguration': PropertyType(False, is_type(dict)),
             'ReplicationConfiguration': PropertyType(False, any_type()),
             'Tags': PropertyType(False, is_type(list)),
             'VersioningConfiguration': PropertyType(False, any_type()),

--- a/tests/translator/input/s3_multiple_functions.yaml
+++ b/tests/translator/input/s3_multiple_functions.yaml
@@ -29,3 +29,9 @@ Resources:
 
   Images:
     Type: AWS::S3::Bucket
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true

--- a/tests/translator/output/aws-cn/s3_multiple_functions.json
+++ b/tests/translator/output/aws-cn/s3_multiple_functions.json
@@ -61,6 +61,12 @@
               "Event": "s3:ObjectCreated:*"
             }
           ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
         }
       },
       "DependsOn": [

--- a/tests/translator/output/aws-us-gov/s3_multiple_functions.json
+++ b/tests/translator/output/aws-us-gov/s3_multiple_functions.json
@@ -61,6 +61,12 @@
               "Event": "s3:ObjectCreated:*"
             }
           ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
         }
       },
       "DependsOn": [

--- a/tests/translator/output/s3_multiple_functions.json
+++ b/tests/translator/output/s3_multiple_functions.json
@@ -61,6 +61,12 @@
               "Event": "s3:ObjectCreated:*"
             }
           ]
+        },
+        "PublicAccessBlockConfiguration": {
+          "BlockPublicAcls": true,
+          "BlockPublicPolicy": true,
+          "IgnorePublicAcls": true,
+          "RestrictPublicBuckets": true
         }
       },
       "DependsOn": [


### PR DESCRIPTION
This is not an ideal situation- needing to update this resource with every single new feature. We should consider a way to update our underlying design so we don't need to continually update these resources, but let them pass through parameters to CFN.

*Issue #, if available:*
https://github.com/awslabs/serverless-application-model/issues/679
*Description of changes:*
Add missing `PublicAccessBlockConfiguration` parameter to S3 buckets

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
