### PR TITLE
BillingMode: PAY_PER_REQUEST default #696

### DIFF
--- a/samtranslator/model/dynamodb.py
+++ b/samtranslator/model/dynamodb.py
@@ -10,11 +10,12 @@ class DynamoDBTable(Resource):
             'GlobalSecondaryIndexes': PropertyType(False, list_of(is_type(dict))),
             'KeySchema': PropertyType(False, list_of(is_type(dict))),
             'LocalSecondaryIndexes': PropertyType(False, list_of(is_type(dict))),
-            'ProvisionedThroughput': PropertyType(True, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),
+            'ProvisionedThroughput': PropertyType(False, dict_of(is_str(), one_of(is_type(int), is_type(dict)))),
             'StreamSpecification': PropertyType(False, is_type(dict)),
             'TableName': PropertyType(False, one_of(is_str(), is_type(dict))),
             'Tags': PropertyType(False, list_of(is_type(dict))),
-            'SSESpecification': PropertyType(False, is_type(dict))
+            'SSESpecification': PropertyType(False, is_type(dict)),
+            'BillingMode': PropertyType(False, is_str())
     }
 
     runtime_attrs = {

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -517,11 +517,9 @@ class SamSimpleTable(SamResourceMacro):
         }]
 
         if self.ProvisionedThroughput:
-            provisioned_throughput = self.ProvisionedThroughput
+            dynamodb_table.ProvisionedThroughput = self.ProvisionedThroughput
         else:
-            provisioned_throughput = {'ReadCapacityUnits': 5, 'WriteCapacityUnits': 5}
-
-        dynamodb_table.ProvisionedThroughput = provisioned_throughput
+            dynamodb_table.BillingMode = 'PAY_PER_REQUEST'
 
         if self.SSESpecification:
             dynamodb_table.SSESpecification = self.SSESpecification

--- a/tests/translator/output/aws-cn/depends_on.json
+++ b/tests/translator/output/aws-cn/depends_on.json
@@ -114,10 +114,7 @@
     "MySamTable": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/aws-cn/globals_for_simpletable.json
+++ b/tests/translator/output/aws-cn/globals_for_simpletable.json
@@ -3,10 +3,7 @@
       "MinimalTable": {
         "Type": "AWS::DynamoDB::Table", 
         "Properties": {
-          "ProvisionedThroughput": {
-            "WriteCapacityUnits": 5, 
-            "ReadCapacityUnits": 5
-          },
+          "BillingMode": "PAY_PER_REQUEST",
           "SSESpecification": {
               "SSEEnabled": true
           },

--- a/tests/translator/output/aws-cn/simple_table_with_extra_tags.json
+++ b/tests/translator/output/aws-cn/simple_table_with_extra_tags.json
@@ -3,10 +3,7 @@
     "MinimalTableWithTags": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/aws-cn/simple_table_with_table_name.json
+++ b/tests/translator/output/aws-cn/simple_table_with_table_name.json
@@ -4,10 +4,7 @@
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
         "TableName": "MySimpleTable",
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",
@@ -28,10 +25,7 @@
         "TableName": {
           "Ref": "MySimpleTableParameter"
         },
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",
@@ -52,10 +46,7 @@
         "TableName": {
           "Fn::Sub": "${AWS::StackName}MySimpleTable"
         },
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/aws-cn/simpletable.json
+++ b/tests/translator/output/aws-cn/simpletable.json
@@ -3,10 +3,7 @@
     "MinimalTable": {
       "Type": "AWS::DynamoDB::Table", 
       "Properties": {
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5, 
-          "ReadCapacityUnits": 5
-        }, 
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id", 

--- a/tests/translator/output/aws-cn/simpletable_with_sse.json
+++ b/tests/translator/output/aws-cn/simpletable_with_sse.json
@@ -3,10 +3,7 @@
       "TableWithSSE": {
         "Type": "AWS::DynamoDB::Table", 
         "Properties": {
-          "ProvisionedThroughput": {
-            "WriteCapacityUnits": 5, 
-            "ReadCapacityUnits": 5
-          }, 
+          "BillingMode": "PAY_PER_REQUEST",
           "SSESpecification": {
             "SSEEnabled": true
           },

--- a/tests/translator/output/aws-us-gov/depends_on.json
+++ b/tests/translator/output/aws-us-gov/depends_on.json
@@ -114,10 +114,7 @@
     "MySamTable": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/aws-us-gov/globals_for_simpletable.json
+++ b/tests/translator/output/aws-us-gov/globals_for_simpletable.json
@@ -3,10 +3,7 @@
       "MinimalTable": {
         "Type": "AWS::DynamoDB::Table", 
         "Properties": {
-          "ProvisionedThroughput": {
-            "WriteCapacityUnits": 5, 
-            "ReadCapacityUnits": 5
-          },
+          "BillingMode": "PAY_PER_REQUEST",
           "SSESpecification": {
               "SSEEnabled": true
           },

--- a/tests/translator/output/aws-us-gov/simple_table_with_extra_tags.json
+++ b/tests/translator/output/aws-us-gov/simple_table_with_extra_tags.json
@@ -3,10 +3,7 @@
     "MinimalTableWithTags": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/aws-us-gov/simple_table_with_table_name.json
+++ b/tests/translator/output/aws-us-gov/simple_table_with_table_name.json
@@ -4,10 +4,7 @@
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
         "TableName": "MySimpleTable",
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",
@@ -28,10 +25,7 @@
         "TableName": {
           "Ref": "MySimpleTableParameter"
         },
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",
@@ -52,10 +46,7 @@
         "TableName": {
           "Fn::Sub": "${AWS::StackName}MySimpleTable"
         },
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/aws-us-gov/simpletable.json
+++ b/tests/translator/output/aws-us-gov/simpletable.json
@@ -3,10 +3,7 @@
     "MinimalTable": {
       "Type": "AWS::DynamoDB::Table", 
       "Properties": {
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5, 
-          "ReadCapacityUnits": 5
-        }, 
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id", 

--- a/tests/translator/output/aws-us-gov/simpletable_with_sse.json
+++ b/tests/translator/output/aws-us-gov/simpletable_with_sse.json
@@ -3,10 +3,7 @@
       "TableWithSSE": {
         "Type": "AWS::DynamoDB::Table", 
         "Properties": {
-          "ProvisionedThroughput": {
-            "WriteCapacityUnits": 5, 
-            "ReadCapacityUnits": 5
-          }, 
+          "BillingMode": "PAY_PER_REQUEST",
           "SSESpecification": {
             "SSEEnabled": true
           },

--- a/tests/translator/output/depends_on.json
+++ b/tests/translator/output/depends_on.json
@@ -106,10 +106,7 @@
     "MySamTable": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/globals_for_simpletable.json
+++ b/tests/translator/output/globals_for_simpletable.json
@@ -3,10 +3,7 @@
       "MinimalTable": {
         "Type": "AWS::DynamoDB::Table", 
         "Properties": {
-          "ProvisionedThroughput": {
-            "WriteCapacityUnits": 5, 
-            "ReadCapacityUnits": 5
-          },
+          "BillingMode": "PAY_PER_REQUEST",
           "SSESpecification": {
               "SSEEnabled": true
           },

--- a/tests/translator/output/simple_table_with_extra_tags.json
+++ b/tests/translator/output/simple_table_with_extra_tags.json
@@ -3,10 +3,7 @@
     "MinimalTableWithTags": {
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/simple_table_with_table_name.json
+++ b/tests/translator/output/simple_table_with_table_name.json
@@ -4,10 +4,7 @@
       "Type": "AWS::DynamoDB::Table",
       "Properties": {
         "TableName": "MySimpleTable",
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",
@@ -28,10 +25,7 @@
         "TableName": {
           "Ref": "MySimpleTableParameter"
         },
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",
@@ -52,10 +46,7 @@
         "TableName": {
           "Fn::Sub": "${AWS::StackName}MySimpleTable"
         },
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5,
-          "ReadCapacityUnits": 5
-        },
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id",

--- a/tests/translator/output/simpletable.json
+++ b/tests/translator/output/simpletable.json
@@ -3,10 +3,7 @@
     "MinimalTable": {
       "Type": "AWS::DynamoDB::Table", 
       "Properties": {
-        "ProvisionedThroughput": {
-          "WriteCapacityUnits": 5, 
-          "ReadCapacityUnits": 5
-        }, 
+        "BillingMode": "PAY_PER_REQUEST",
         "AttributeDefinitions": [
           {
             "AttributeName": "id", 

--- a/tests/translator/output/simpletable_with_sse.json
+++ b/tests/translator/output/simpletable_with_sse.json
@@ -3,10 +3,7 @@
       "TableWithSSE": {
         "Type": "AWS::DynamoDB::Table", 
         "Properties": {
-          "ProvisionedThroughput": {
-            "WriteCapacityUnits": 5, 
-            "ReadCapacityUnits": 5
-          }, 
+          "BillingMode": "PAY_PER_REQUEST",
           "SSESpecification": {
             "SSEEnabled": true
           },

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -306,7 +306,7 @@ The `AWS::Serverless::SimpleTable` resource creates a DynamoDB table with a sing
 Property Name | Type | Description
 ---|:---:|---
 PrimaryKey | [Primary Key Object](#primary-key-object) | Attribute name and type to be used as the table's primary key. **This cannot be modified without replacing the resource.** Defaults to `String` attribute named ID.
-ProvisionedThroughput | [Provisioned Throughput Object](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html) | Read and write throughput provisioning information. Defaults to 5 read and 5 write capacity units per second.
+ProvisionedThroughput | [Provisioned Throughput Object](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html) | Read and write throughput provisioning information. If ProvisionedThroughput is not specified BillingMode will be specified as PAY_PER_REQUEST
 Tags | Map of `string` to `string` | A map (string to string) that specifies the tags to be added to this table. Keys and values are limited to alphanumeric characters. 
 TableName | `string` | Name for the DynamoDB Table
 SSESpecification | [DynamoDB SSESpecification](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-table-ssespecification.html) | Specifies the settings to enable server-side encryption.


### PR DESCRIPTION
*Issue #696 *

*Description of changes:*

Made BillingMode: PAY_PER_REQUEST default for AWS::Serverless::SimpleTable
Adjusted 6 test cases (x3=18 for all regional tests)
Added the default to the documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
