### PR TITLE
fix: layer logical ids now change when referenced parameters change

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -1,4 +1,6 @@
 """ CloudFormation Resource serialization, deserialization, and validation """
+from six import string_types
+
 import re
 import inspect
 from samtranslator.model.exceptions import InvalidResourceException
@@ -423,6 +425,16 @@ class SamResourceMacro(ResourceMacro):
             raise InvalidResourceException(self.logical_id, reserved_tag_name + " is a reserved Tag key name and "
                                                                                 "cannot be set on your resource. "
                                                                                 "Please change the tag key in the input.")
+
+    def _resolve_string_parameter(self, intrinsics_resolver, parameter_value, parameter_name):
+        if not parameter_value:
+            return parameter_value
+        value = intrinsics_resolver.resolve_parameter_refs(parameter_value)
+        if not isinstance(value, string_types):
+            raise InvalidResourceException(self.logical_id,
+                                           "Could not resolve parameter for '{}' or parameter is not a String."
+                                           .format(parameter_name))
+        return value
 
 
 class ResourceTypeResolver(object):

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -629,7 +629,15 @@ class SamLayerVersion(SamResourceMacro):
         :returns: a list containing the Lambda function and execution role resources
         :rtype: list
         """
-        retention_policy_value = self._get_retention_policy_value(intrinsics_resolver)
+        # Resolve intrinsics if applicable:
+        self.LayerName = self._resolve_string_parameter(intrinsics_resolver, self.LayerName, 'LayerName')
+        self.LicenseInfo = self._resolve_string_parameter(intrinsics_resolver, self.LicenseInfo, 'LicenseInfo')
+        self.Description = self._resolve_string_parameter(intrinsics_resolver, self.Description, 'Description')
+        self.RetentionPolicy = self._resolve_string_parameter(intrinsics_resolver, self.RetentionPolicy, 'RetentionPolicy')
+
+        # Would it make sense to resolve ContentUri and CompatibleRuntimes as well?
+
+        retention_policy_value = self._get_retention_policy_value()
 
         attributes = self.get_passthrough_resource_attributes()
         if attributes is None:
@@ -662,19 +670,12 @@ class SamLayerVersion(SamResourceMacro):
 
         return lambda_layer
 
-    def _get_retention_policy_value(self, intrinsics_resolver):
+    def _get_retention_policy_value(self):
         """
         Sets the deletion policy on this resource. The default is 'Retain'.
 
         :return: value for the DeletionPolicy attribute.
         """
-        if isinstance(self.RetentionPolicy, dict):
-            self.RetentionPolicy = intrinsics_resolver.resolve_parameter_refs(self.RetentionPolicy)
-            # If it's still not a string, throw an exception
-            if not isinstance(self.RetentionPolicy, string_types):
-                raise InvalidResourceException(self.logical_id,
-                                               "Could not resolve parameter for '{}' or parameter is not a String."
-                                               .format('RetentionPolicy'))
 
         if self.RetentionPolicy is None or self.RetentionPolicy.lower() == self.RETAIN.lower():
             return self.RETAIN
@@ -684,3 +685,5 @@ class SamLayerVersion(SamResourceMacro):
             raise InvalidResourceException(self.logical_id,
                                            "'{}' must be one of the following options: {}."
                                            .format('RetentionPolicy', [self.RETAIN, self.DELETE]))
+
+

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -635,8 +635,6 @@ class SamLayerVersion(SamResourceMacro):
         self.Description = self._resolve_string_parameter(intrinsics_resolver, self.Description, 'Description')
         self.RetentionPolicy = self._resolve_string_parameter(intrinsics_resolver, self.RetentionPolicy, 'RetentionPolicy')
 
-        # Would it make sense to resolve ContentUri and CompatibleRuntimes as well?
-
         retention_policy_value = self._get_retention_policy_value()
 
         attributes = self.get_passthrough_resource_attributes()

--- a/tests/translator/input/layers_with_intrinsics.yaml
+++ b/tests/translator/input/layers_with_intrinsics.yaml
@@ -1,4 +1,7 @@
 Parameters:
+  LayerNameParam:
+    Type: String
+    Default: SomeLayerName
   LayerLicenseInfo:
     Type: String
     Default: MIT-0 License
@@ -18,3 +21,9 @@ Resources:
       ContentUri: s3://sam-demo-bucket/layer.zip
       CompatibleRuntimes:
         Ref: LayerRuntimeList
+
+  LayerWithNameIntrinsic:
+    Type: AWS::Serverless::LayerVersion
+    Properties:
+      ContentUri: s3://sam-demo-bucket/layer.zip
+      LayerName: !Ref LayerNameParam

--- a/tests/translator/input/layers_with_intrinsics.yaml
+++ b/tests/translator/input/layers_with_intrinsics.yaml
@@ -27,3 +27,4 @@ Resources:
     Properties:
       ContentUri: s3://sam-demo-bucket/layer.zip
       LayerName: !Ref LayerNameParam
+

--- a/tests/translator/output/aws-cn/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-cn/layers_with_intrinsics.json
@@ -1,41 +1,55 @@
 {
   "Parameters": {
     "LayerLicenseInfo": {
-      "Type": "String",
-      "Default": "MIT-0 License"
-    },
+      "Default": "MIT-0 License", 
+      "Type": "String"
+    }, 
     "LayerRuntimeList": {
       "Type": "CommaDelimitedList"
+    }, 
+    "LayerNameParam": {
+      "Default": "SomeLayerName", 
+      "Type": "String"
     }
-  },
+  }, 
   "Resources": {
-    "LayerWithLicenseIntrinsic16287c50c8": {
-      "Type": "AWS::Lambda::LayerVersion",
-      "DeletionPolicy": "Retain",
+    "LayerWithNameIntrinsiccf8baed8b9": {
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket",
+          "S3Bucket": "sam-demo-bucket", 
           "S3Key": "layer.zip"
-        },
-        "LayerName": "LayerWithLicenseIntrinsic",
-        "LicenseInfo": {
-          "Ref": "LayerLicenseInfo"
-        }
+        }, 
+        "LayerName": "SomeLayerName"
       }
-    },
+    }, 
     "LayerWithRuntimesIntrinsic1a006faa85": {
-      "Type": "AWS::Lambda::LayerVersion",
-      "DeletionPolicy": "Retain",
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket",
+          "S3Bucket": "sam-demo-bucket", 
           "S3Key": "layer.zip"
-        },
-        "LayerName": "LayerWithRuntimesIntrinsic",
+        }, 
+        "LayerName": "LayerWithRuntimesIntrinsic", 
         "CompatibleRuntimes": {
           "Ref": "LayerRuntimeList"
         }
       }
+    }, 
+    "LayerWithLicenseIntrinsic965c8d0c9b": {
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::LayerVersion", 
+      "Properties": {
+        "Content": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "layer.zip"
+        }, 
+        "LayerName": "LayerWithLicenseIntrinsic", 
+        "LicenseInfo": "MIT-0 License"
+      }
     }
   }
 }
+

--- a/tests/translator/output/aws-cn/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-cn/layers_with_intrinsics.json
@@ -1,52 +1,52 @@
 {
   "Parameters": {
     "LayerLicenseInfo": {
-      "Default": "MIT-0 License", 
+      "Default": "MIT-0 License",
       "Type": "String"
-    }, 
+    },
     "LayerRuntimeList": {
       "Type": "CommaDelimitedList"
-    }, 
+    },
     "LayerNameParam": {
-      "Default": "SomeLayerName", 
+      "Default": "SomeLayerName",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "LayerWithNameIntrinsiccf8baed8b9": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::LayerVersion", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "layer.zip"
-        }, 
+        },
         "LayerName": "SomeLayerName"
       }
-    }, 
+    },
     "LayerWithRuntimesIntrinsic1a006faa85": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::LayerVersion", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "layer.zip"
-        }, 
-        "LayerName": "LayerWithRuntimesIntrinsic", 
+        },
+        "LayerName": "LayerWithRuntimesIntrinsic",
         "CompatibleRuntimes": {
           "Ref": "LayerRuntimeList"
         }
       }
-    }, 
+    },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::LayerVersion", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "layer.zip"
-        }, 
-        "LayerName": "LayerWithLicenseIntrinsic", 
+        },
+        "LayerName": "LayerWithLicenseIntrinsic",
         "LicenseInfo": "MIT-0 License"
       }
     }

--- a/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
@@ -1,41 +1,55 @@
 {
   "Parameters": {
     "LayerLicenseInfo": {
-      "Type": "String",
-      "Default": "MIT-0 License"
-    },
+      "Default": "MIT-0 License", 
+      "Type": "String"
+    }, 
     "LayerRuntimeList": {
       "Type": "CommaDelimitedList"
+    }, 
+    "LayerNameParam": {
+      "Default": "SomeLayerName", 
+      "Type": "String"
     }
-  },
+  }, 
   "Resources": {
-    "LayerWithLicenseIntrinsic16287c50c8": {
-      "Type": "AWS::Lambda::LayerVersion",
-      "DeletionPolicy": "Retain",
+    "LayerWithNameIntrinsiccf8baed8b9": {
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket",
+          "S3Bucket": "sam-demo-bucket", 
           "S3Key": "layer.zip"
-        },
-        "LayerName": "LayerWithLicenseIntrinsic",
-        "LicenseInfo": {
-          "Ref": "LayerLicenseInfo"
-        }
+        }, 
+        "LayerName": "SomeLayerName"
       }
-    },
+    }, 
     "LayerWithRuntimesIntrinsic1a006faa85": {
-      "Type": "AWS::Lambda::LayerVersion",
-      "DeletionPolicy": "Retain",
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket",
+          "S3Bucket": "sam-demo-bucket", 
           "S3Key": "layer.zip"
-        },
-        "LayerName": "LayerWithRuntimesIntrinsic",
+        }, 
+        "LayerName": "LayerWithRuntimesIntrinsic", 
         "CompatibleRuntimes": {
           "Ref": "LayerRuntimeList"
         }
       }
+    }, 
+    "LayerWithLicenseIntrinsic965c8d0c9b": {
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::LayerVersion", 
+      "Properties": {
+        "Content": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "layer.zip"
+        }, 
+        "LayerName": "LayerWithLicenseIntrinsic", 
+        "LicenseInfo": "MIT-0 License"
+      }
     }
   }
 }
+

--- a/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
@@ -1,52 +1,52 @@
 {
   "Parameters": {
     "LayerLicenseInfo": {
-      "Default": "MIT-0 License", 
+      "Default": "MIT-0 License",
       "Type": "String"
-    }, 
+    },
     "LayerRuntimeList": {
       "Type": "CommaDelimitedList"
-    }, 
+    },
     "LayerNameParam": {
-      "Default": "SomeLayerName", 
+      "Default": "SomeLayerName",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "LayerWithNameIntrinsiccf8baed8b9": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::LayerVersion", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "layer.zip"
-        }, 
+        },
         "LayerName": "SomeLayerName"
       }
-    }, 
+    },
     "LayerWithRuntimesIntrinsic1a006faa85": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::LayerVersion", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "layer.zip"
-        }, 
-        "LayerName": "LayerWithRuntimesIntrinsic", 
+        },
+        "LayerName": "LayerWithRuntimesIntrinsic",
         "CompatibleRuntimes": {
           "Ref": "LayerRuntimeList"
         }
       }
-    }, 
+    },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::LayerVersion", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "layer.zip"
-        }, 
-        "LayerName": "LayerWithLicenseIntrinsic", 
+        },
+        "LayerName": "LayerWithLicenseIntrinsic",
         "LicenseInfo": "MIT-0 License"
       }
     }

--- a/tests/translator/output/layers_with_intrinsics.json
+++ b/tests/translator/output/layers_with_intrinsics.json
@@ -1,41 +1,55 @@
 {
   "Parameters": {
     "LayerLicenseInfo": {
-      "Type": "String",
-      "Default": "MIT-0 License"
-    },
+      "Default": "MIT-0 License", 
+      "Type": "String"
+    }, 
     "LayerRuntimeList": {
       "Type": "CommaDelimitedList"
+    }, 
+    "LayerNameParam": {
+      "Default": "SomeLayerName", 
+      "Type": "String"
     }
-  },
+  }, 
   "Resources": {
-    "LayerWithLicenseIntrinsic16287c50c8": {
-      "Type": "AWS::Lambda::LayerVersion",
-      "DeletionPolicy": "Retain",
+    "LayerWithNameIntrinsiccf8baed8b9": {
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket",
+          "S3Bucket": "sam-demo-bucket", 
           "S3Key": "layer.zip"
-        },
-        "LayerName": "LayerWithLicenseIntrinsic",
-        "LicenseInfo": {
-          "Ref": "LayerLicenseInfo"
-        }
+        }, 
+        "LayerName": "SomeLayerName"
       }
-    },
+    }, 
     "LayerWithRuntimesIntrinsic1a006faa85": {
-      "Type": "AWS::Lambda::LayerVersion",
-      "DeletionPolicy": "Retain",
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket",
+          "S3Bucket": "sam-demo-bucket", 
           "S3Key": "layer.zip"
-        },
-        "LayerName": "LayerWithRuntimesIntrinsic",
+        }, 
+        "LayerName": "LayerWithRuntimesIntrinsic", 
         "CompatibleRuntimes": {
           "Ref": "LayerRuntimeList"
         }
       }
+    }, 
+    "LayerWithLicenseIntrinsic965c8d0c9b": {
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::LayerVersion", 
+      "Properties": {
+        "Content": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "layer.zip"
+        }, 
+        "LayerName": "LayerWithLicenseIntrinsic", 
+        "LicenseInfo": "MIT-0 License"
+      }
     }
   }
 }
+

--- a/tests/translator/output/layers_with_intrinsics.json
+++ b/tests/translator/output/layers_with_intrinsics.json
@@ -1,52 +1,52 @@
 {
   "Parameters": {
     "LayerLicenseInfo": {
-      "Default": "MIT-0 License", 
+      "Default": "MIT-0 License",
       "Type": "String"
-    }, 
+    },
     "LayerRuntimeList": {
       "Type": "CommaDelimitedList"
-    }, 
+    },
     "LayerNameParam": {
-      "Default": "SomeLayerName", 
+      "Default": "SomeLayerName",
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "LayerWithNameIntrinsiccf8baed8b9": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::LayerVersion", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "layer.zip"
-        }, 
+        },
         "LayerName": "SomeLayerName"
       }
-    }, 
+    },
     "LayerWithRuntimesIntrinsic1a006faa85": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::LayerVersion", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "layer.zip"
-        }, 
-        "LayerName": "LayerWithRuntimesIntrinsic", 
+        },
+        "LayerName": "LayerWithRuntimesIntrinsic",
         "CompatibleRuntimes": {
           "Ref": "LayerRuntimeList"
         }
       }
-    }, 
+    },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
-      "DeletionPolicy": "Retain", 
-      "Type": "AWS::Lambda::LayerVersion", 
+      "DeletionPolicy": "Retain",
+      "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "layer.zip"
-        }, 
-        "LayerName": "LayerWithLicenseIntrinsic", 
+        },
+        "LayerName": "LayerWithLicenseIntrinsic",
         "LicenseInfo": "MIT-0 License"
       }
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/serverless-application-model/issues/703
*Description of changes:*
Support reading intrinsics in LayerName, LicenseInfo, and Description

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
