### PR TITLE
WIP: fix: support intrinsics in Location property of Serverless Application

### DIFF
--- a/tests/translator/input/basic_application.yaml
+++ b/tests/translator/input/basic_application.yaml
@@ -1,3 +1,8 @@
+Parameters:
+  AppS3Location:
+    Type: String
+    Default: s3://sam-bucket/template.yaml
+
 Resources:
   BasicApplication:
     Type: 'AWS::Serverless::Application'
@@ -33,4 +38,9 @@ Resources:
     Properties:
       Location:
         ApplicationId: arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world
-        SemanticVersion: 1.0.2        
+        SemanticVersion: 1.0.2
+
+  ApplicationWithLocationParameter:
+    Type: 'AWS::Serverless::Application'
+    Properties:
+      Location: !Ref AppS3Location

--- a/tests/translator/output/aws-cn/basic_application.json
+++ b/tests/translator/output/aws-cn/basic_application.json
@@ -1,5 +1,42 @@
 {
+  "Parameters": {
+    "AppS3Location": {
+      "Default": "s3://sam-bucket/template.yaml",
+      "Type": "String"
+    }
+  },
   "Resources": {
+    "NormalApplication": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "NotificationArns": [
+          "arn:aws:sns:us-east-1:123456789012:sns-arn"
+        ],
+        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
+        "TimeoutInMinutes": 15,
+        "Parameters": {
+          "IdentityNameParameter": "IdentityName"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          },
+          {
+            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world",
+            "Key": "serverlessrepo:applicationId"
+          },
+          {
+            "Value": "1.0.2",
+            "Key": "serverlessrepo:semanticVersion"
+          },
+          {
+            "Value": "TagValue",
+            "Key": "TagName"
+          }
+        ]
+      }
+    },
     "BasicApplication": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
@@ -20,39 +57,6 @@
         ]
       }
     },
-    "NormalApplication": {
-      "Type": "AWS::CloudFormation::Stack",
-      "Properties": {
-        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          },
-          {
-            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world",
-            "Key": "serverlessrepo:applicationId"
-          },
-          {
-            "Value": "1.0.2",
-            "Key": "serverlessrepo:semanticVersion"
-          },
-          {
-            "Value": "TagValue",
-            "Key": "TagName"
-          }
-        ],
-        "Parameters":
-        {
-          "IdentityNameParameter": "IdentityName"
-        },
-        "NotificationArns":
-        [
-          "arn:aws:sns:us-east-1:123456789012:sns-arn"
-        ],
-        "TimeoutInMinutes": 15
-      }
-    },
     "ApplicationWithLocationUrl": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
@@ -65,6 +69,20 @@
           {
             "Value": "TagValue2",
             "Key": "TagName2"
+          }
+        ]
+      }
+    },
+    "ApplicationWithLocationParameter": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "TemplateURL": {
+          "Ref": "AppS3Location"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
           }
         ]
       }
@@ -92,3 +110,4 @@
     }
   }
 }
+

--- a/tests/translator/output/aws-us-gov/basic_application.json
+++ b/tests/translator/output/aws-us-gov/basic_application.json
@@ -1,5 +1,42 @@
 {
+  "Parameters": {
+    "AppS3Location": {
+      "Default": "s3://sam-bucket/template.yaml",
+      "Type": "String"
+    }
+  },
   "Resources": {
+    "NormalApplication": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "NotificationArns": [
+          "arn:aws:sns:us-east-1:123456789012:sns-arn"
+        ],
+        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
+        "TimeoutInMinutes": 15,
+        "Parameters": {
+          "IdentityNameParameter": "IdentityName"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          },
+          {
+            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world",
+            "Key": "serverlessrepo:applicationId"
+          },
+          {
+            "Value": "1.0.2",
+            "Key": "serverlessrepo:semanticVersion"
+          },
+          {
+            "Value": "TagValue",
+            "Key": "TagName"
+          }
+        ]
+      }
+    },
     "BasicApplication": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
@@ -20,39 +57,6 @@
         ]
       }
     },
-    "NormalApplication": {
-      "Type": "AWS::CloudFormation::Stack",
-      "Properties": {
-        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          },
-          {
-            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world",
-            "Key": "serverlessrepo:applicationId"
-          },
-          {
-            "Value": "1.0.2",
-            "Key": "serverlessrepo:semanticVersion"
-          },
-          {
-            "Value": "TagValue",
-            "Key": "TagName"
-          }
-        ],
-        "Parameters":
-        {
-          "IdentityNameParameter": "IdentityName"
-        },
-        "NotificationArns":
-        [
-          "arn:aws:sns:us-east-1:123456789012:sns-arn"
-        ],
-        "TimeoutInMinutes": 15
-      }
-    },
     "ApplicationWithLocationUrl": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
@@ -65,6 +69,20 @@
           {
             "Value": "TagValue2",
             "Key": "TagName2"
+          }
+        ]
+      }
+    },
+    "ApplicationWithLocationParameter": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "TemplateURL": {
+          "Ref": "AppS3Location"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
           }
         ]
       }
@@ -92,3 +110,4 @@
     }
   }
 }
+

--- a/tests/translator/output/basic_application.json
+++ b/tests/translator/output/basic_application.json
@@ -1,5 +1,42 @@
 {
+  "Parameters": {
+    "AppS3Location": {
+      "Default": "s3://sam-bucket/template.yaml",
+      "Type": "String"
+    }
+  },
   "Resources": {
+    "NormalApplication": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "NotificationArns": [
+          "arn:aws:sns:us-east-1:123456789012:sns-arn"
+        ],
+        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
+        "TimeoutInMinutes": 15,
+        "Parameters": {
+          "IdentityNameParameter": "IdentityName"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          },
+          {
+            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world",
+            "Key": "serverlessrepo:applicationId"
+          },
+          {
+            "Value": "1.0.2",
+            "Key": "serverlessrepo:semanticVersion"
+          },
+          {
+            "Value": "TagValue",
+            "Key": "TagName"
+          }
+        ]
+      }
+    },
     "BasicApplication": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
@@ -20,39 +57,6 @@
         ]
       }
     },
-    "NormalApplication": {
-      "Type": "AWS::CloudFormation::Stack",
-      "Properties": {
-        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          },
-          {
-            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world",
-            "Key": "serverlessrepo:applicationId"
-          },
-          {
-            "Value": "1.0.2",
-            "Key": "serverlessrepo:semanticVersion"
-          },
-          {
-            "Value": "TagValue",
-            "Key": "TagName"
-          }
-        ],
-        "Parameters":
-        {
-          "IdentityNameParameter": "IdentityName"
-        },
-        "NotificationArns":
-        [
-          "arn:aws:sns:us-east-1:123456789012:sns-arn"
-        ],
-        "TimeoutInMinutes": 15
-      }
-    },
     "ApplicationWithLocationUrl": {
       "Type": "AWS::CloudFormation::Stack",
       "Properties": {
@@ -65,6 +69,20 @@
           {
             "Value": "TagValue2",
             "Key": "TagName2"
+          }
+        ]
+      }
+    },
+    "ApplicationWithLocationParameter": {
+      "Type": "AWS::CloudFormation::Stack",
+      "Properties": {
+        "TemplateURL": {
+          "Ref": "AppS3Location"
+        },
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
           }
         ]
       }
@@ -92,3 +110,4 @@
     }
   }
 }
+


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/serverless-application-model/issues/694
*Description of changes:*
Support intrinsics such as Ref and Sub in the Location parameter for s3 strings.

This does not add support for intrinsics in ApplicationId or SemanticVersion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
