### PR TITLE
chore: change assertEquals to assertEqual to remove py3 warnings

### DIFF
--- a/tests/intrinsics/test_actions.py
+++ b/tests/intrinsics/test_actions.py
@@ -81,45 +81,45 @@ class TestAction(TestCase):
         input = "LogicalId.Property"
         expected = ("LogicalId", "Property")
 
-        self.assertEquals(expected, Action._parse_resource_reference(input))
+        self.assertEqual(expected, Action._parse_resource_reference(input))
 
     def test_parse_resource_references_with_multiple_properties(self):
         input = "LogicalId.Property1.Property2.Property3"
         expected = ("LogicalId", "Property1.Property2.Property3")
 
-        self.assertEquals(expected, Action._parse_resource_reference(input))
+        self.assertEqual(expected, Action._parse_resource_reference(input))
 
     def test_parse_resource_references_with_other_special_characters(self):
         input = "some logical id . some value"
         expected = ("some logical id ", " some value")
 
-        self.assertEquals(expected, Action._parse_resource_reference(input))
+        self.assertEqual(expected, Action._parse_resource_reference(input))
 
     def test_parse_resource_references_with_empty_property(self):
         # Just a dot at the end! This is equivalent of no property
         input = "LogicalId."
         expected = (None, None)
 
-        self.assertEquals(expected, Action._parse_resource_reference(input))
+        self.assertEqual(expected, Action._parse_resource_reference(input))
 
     def test_parse_resource_references_with_empty_logical_id(self):
         # Just a dot at the beginning! This is equivalent of no LogicalId
         input = ".Property"
         expected = (None, None)
 
-        self.assertEquals(expected, Action._parse_resource_reference(input))
+        self.assertEqual(expected, Action._parse_resource_reference(input))
 
     def test_parse_resource_references_with_no_property(self):
         input = "LogicalId"
         expected = (None, None)
 
-        self.assertEquals(expected, Action._parse_resource_reference(input))
+        self.assertEqual(expected, Action._parse_resource_reference(input))
 
     def test_parse_resource_references_not_string(self):
         input = {"not a": "string"}
         expected = (None, None)
 
-        self.assertEquals(expected, Action._parse_resource_reference(input))
+        self.assertEqual(expected, Action._parse_resource_reference(input))
 
 class TestRefCanResolveParameterRefs(TestCase):
 
@@ -132,7 +132,7 @@ class TestRefCanResolveParameterRefs(TestCase):
         }
 
         ref = RefAction()
-        self.assertEquals(parameters["key"], ref.resolve_parameter_refs(input, parameters))
+        self.assertEqual(parameters["key"], ref.resolve_parameter_refs(input, parameters))
 
     def test_unknown_ref(self):
         parameters = {
@@ -146,7 +146,7 @@ class TestRefCanResolveParameterRefs(TestCase):
         }
 
         ref = RefAction()
-        self.assertEquals(expected, ref.resolve_parameter_refs(input, parameters))
+        self.assertEqual(expected, ref.resolve_parameter_refs(input, parameters))
 
     def test_must_ignore_invalid_value(self):
         parameters = {
@@ -160,7 +160,7 @@ class TestRefCanResolveParameterRefs(TestCase):
         }
 
         ref = RefAction()
-        self.assertEquals(expected, ref.resolve_parameter_refs(input, parameters))
+        self.assertEqual(expected, ref.resolve_parameter_refs(input, parameters))
 
     @patch.object(RefAction, "can_handle")
     def test_return_value_if_cannot_handle(self, can_handle_mock):
@@ -176,7 +176,7 @@ class TestRefCanResolveParameterRefs(TestCase):
 
         ref = RefAction()
         can_handle_mock.return_value = False # Simulate failure to handle the input. Result should be same as input
-        self.assertEquals(expected, ref.resolve_parameter_refs(input, parameters))
+        self.assertEqual(expected, ref.resolve_parameter_refs(input, parameters))
 
 
 class TestRefCanResolveResourceRefs(TestCase):
@@ -199,7 +199,7 @@ class TestRefCanResolveResourceRefs(TestCase):
 
         output = self.ref.resolve_resource_refs(input, self.supported_resource_refs_mock)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
         self.supported_resource_refs_mock.get.assert_called_once_with("LogicalId", "Property")
         _parse_resource_reference_mock.assert_called_once_with("LogicalId.Property")
 
@@ -216,7 +216,7 @@ class TestRefCanResolveResourceRefs(TestCase):
         self.supported_resource_refs_mock.get.return_value = None
 
         output = self.ref.resolve_resource_refs(input, self.supported_resource_refs_mock)
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
         self.supported_resource_refs_mock.get.assert_called_once_with("LogicalId", "Property")
         _parse_resource_reference_mock.assert_called_once_with("LogicalId.Property")
 
@@ -233,7 +233,7 @@ class TestRefCanResolveResourceRefs(TestCase):
 
         output = self.ref.resolve_resource_refs(input, self.supported_resource_refs_mock)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
         self.supported_resource_refs_mock.get.assert_not_called()
         _parse_resource_reference_mock.assert_called_once_with("some value")
 
@@ -248,7 +248,7 @@ class TestRefCanResolveResourceRefs(TestCase):
 
         ref = RefAction()
         can_handle_mock.return_value = False # Simulate failure to handle the input. Result should be same as input
-        self.assertEquals(expected, ref.resolve_resource_refs(input, self.supported_resource_refs_mock))
+        self.assertEqual(expected, ref.resolve_resource_refs(input, self.supported_resource_refs_mock))
 
 
 class TestRefCanResolveResourceIdRefs(TestCase):
@@ -269,7 +269,7 @@ class TestRefCanResolveResourceIdRefs(TestCase):
 
         output = self.ref.resolve_resource_id_refs(input, self.supported_resource_id_refs_mock)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
         self.supported_resource_id_refs_mock.get.assert_called_once_with("LogicalId")
 
     def test_handle_unsupported_references(self):
@@ -283,7 +283,7 @@ class TestRefCanResolveResourceIdRefs(TestCase):
         self.supported_resource_id_refs_mock.get.return_value = None
 
         output = self.ref.resolve_resource_id_refs(input, self.supported_resource_id_refs_mock)
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
         self.supported_resource_id_refs_mock.get.assert_not_called()
 
     @patch.object(RefAction, "can_handle")
@@ -297,7 +297,7 @@ class TestRefCanResolveResourceIdRefs(TestCase):
 
         ref = RefAction()
         can_handle_mock.return_value = False # Simulate failure to handle the input. Result should be same as input
-        self.assertEquals(expected, ref.resolve_resource_id_refs(input, self.supported_resource_id_refs_mock))
+        self.assertEqual(expected, ref.resolve_resource_id_refs(input, self.supported_resource_id_refs_mock))
 
 class TestSubCanResolveParameterRefs(TestCase):
 
@@ -348,7 +348,7 @@ class TestSubCanResolveParameterRefs(TestCase):
 
         sub = SubAction()
         can_handle_mock.return_value = False # Simulate failure to handle the input. Result should be same as input
-        self.assertEquals(expected, sub.resolve_parameter_refs(input, parameters))
+        self.assertEqual(expected, sub.resolve_parameter_refs(input, parameters))
 
     def test_sub_all_refs_multiple_references(self):
         parameters = {
@@ -573,7 +573,7 @@ class TestSubCanResolveResourceRefs(TestCase):
 
         sub = SubAction()
         can_handle_mock.return_value = False # Simulate failure to handle the input. Result should be same as input
-        self.assertEquals(expected, sub.resolve_resource_refs(input, parameters))
+        self.assertEqual(expected, sub.resolve_resource_refs(input, parameters))
 
 class TestSubCanResolveResourceIdRefs(TestCase):
 
@@ -662,7 +662,7 @@ class TestSubCanResolveResourceIdRefs(TestCase):
 
         sub = SubAction()
         can_handle_mock.return_value = False # Simulate failure to handle the input. Result should be same as input
-        self.assertEquals(expected, sub.resolve_resource_id_refs(input, parameters))
+        self.assertEqual(expected, sub.resolve_resource_id_refs(input, parameters))
 
 
 class TestGetAttCanResolveParameterRefs(TestCase):
@@ -695,7 +695,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_refs(input, self.supported_resource_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_resolve_refs_with_many_attributes(self):
         input = {
@@ -709,7 +709,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_refs(input, self.supported_resource_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_resolve_with_splitted_resource_refs(self):
         input = {
@@ -724,7 +724,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_refs(input, self.supported_resource_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_ignore_refs_without_attributes(self):
         input = {
@@ -739,7 +739,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_refs(input, self.supported_resource_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_ignore_refs_without_attributes_in_concatenated_form(self):
         input = {
@@ -754,7 +754,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_refs(input, self.supported_resource_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_ignore_invalid_value_array(self):
         input = {
@@ -769,7 +769,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_refs(input, self.supported_resource_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_ignore_invalid_value_type(self):
         input = {
@@ -784,7 +784,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_refs(input, self.supported_resource_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_ignore_missing_properties_with_dot_after(self):
         input = {
@@ -797,7 +797,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_refs(input, self.supported_resource_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_ignore_missing_properties_with_dot_before(self):
         input = {
@@ -810,7 +810,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_refs(input, self.supported_resource_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     @patch.object(GetAttAction, "can_handle")
     def test_return_value_if_cannot_handle(self, can_handle_mock):
@@ -823,7 +823,7 @@ class TestGetAttCanResolveResourceRefs(TestCase):
 
         getatt = GetAttAction()
         can_handle_mock.return_value = False # Simulate failure to handle the input. Result should be same as input
-        self.assertEquals(expected, getatt.resolve_resource_refs(input, self.supported_resource_refs))
+        self.assertEqual(expected, getatt.resolve_resource_refs(input, self.supported_resource_refs))
 
 
 class TestGetAttCanResolveResourceIdRefs(TestCase):
@@ -844,7 +844,7 @@ class TestGetAttCanResolveResourceIdRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_id_refs(input, self.supported_resource_id_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_resolve_refs_with_many_attributes(self):
         input = {
@@ -858,7 +858,7 @@ class TestGetAttCanResolveResourceIdRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_id_refs(input, self.supported_resource_id_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_ignore_invalid_value_array(self):
         input = {
@@ -873,7 +873,7 @@ class TestGetAttCanResolveResourceIdRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_id_refs(input, self.supported_resource_id_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_ignore_invalid_value_type(self):
         input = {
@@ -888,7 +888,7 @@ class TestGetAttCanResolveResourceIdRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_id_refs(input, self.supported_resource_id_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     def test_must_ignore_missing_properties_with_dot_before(self):
         input = {
@@ -901,7 +901,7 @@ class TestGetAttCanResolveResourceIdRefs(TestCase):
         getatt = GetAttAction()
         output = getatt.resolve_resource_id_refs(input, self.supported_resource_id_refs)
 
-        self.assertEquals(expected, output)
+        self.assertEqual(expected, output)
 
     @patch.object(GetAttAction, "can_handle")
     def test_return_value_if_cannot_handle(self, can_handle_mock):
@@ -914,4 +914,4 @@ class TestGetAttCanResolveResourceIdRefs(TestCase):
 
         getatt = GetAttAction()
         can_handle_mock.return_value = False # Simulate failure to handle the input. Result should be same as input
-        self.assertEquals(expected, getatt.resolve_resource_id_refs(input, self.supported_resource_id_refs))
+        self.assertEqual(expected, getatt.resolve_resource_id_refs(input, self.supported_resource_id_refs))

--- a/tests/intrinsics/test_resolver.py
+++ b/tests/intrinsics/test_resolver.py
@@ -36,7 +36,7 @@ class TestParameterReferenceResolution(TestCase):
         }
 
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_must_resolve_nested_refs(self):
         input = {
@@ -64,21 +64,21 @@ class TestParameterReferenceResolution(TestCase):
         }
 
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_must_resolve_direct_refs(self):
         input = {"Ref": "param1"}
         expected = self.parameter_values["param1"]
 
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_must_resolve_array_refs(self):
         input = ["foo", 1, 2, {"Ref": "param1"}]
         expected = ["foo", 1, 2, self.parameter_values["param1"]]
 
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_must_skip_unknown_refs(self):
         input = {
@@ -98,7 +98,7 @@ class TestParameterReferenceResolution(TestCase):
         }
 
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_must_resolve_inside_sub_strings(self):
         input = {
@@ -110,7 +110,7 @@ class TestParameterReferenceResolution(TestCase):
         }
 
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_must_skip_over_sub_literals(self):
         input = {
@@ -122,7 +122,7 @@ class TestParameterReferenceResolution(TestCase):
         }
 
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_must_resolve_refs_inside_other_intrinsics(self):
         input = {
@@ -138,7 +138,7 @@ class TestParameterReferenceResolution(TestCase):
         }
 
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_skip_invalid_values_for_ref(self):
         input = {
@@ -149,7 +149,7 @@ class TestParameterReferenceResolution(TestCase):
             "Ref": ["ref cannot have list value"]
         }
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_skip_invalid_values_for_sub(self):
         input = {
@@ -162,7 +162,7 @@ class TestParameterReferenceResolution(TestCase):
         }
 
         output = self.resolver.resolve_parameter_refs(input)
-        self.assertEquals(output, expected)
+        self.assertEqual(output, expected)
 
     def test_throw_on_empty_parameters(self):
         with self.assertRaises(TypeError):
@@ -178,7 +178,7 @@ class TestParameterReferenceResolution(TestCase):
         input = {"Ref": "foo"}
         expected = {"Ref": "foo"}
 
-        self.assertEquals(resolver.resolve_parameter_refs(input), expected)
+        self.assertEqual(resolver.resolve_parameter_refs(input), expected)
         resolver._try_resolve_parameter_refs.assert_not_called()
 
 class TestResourceReferenceResolution(TestCase):
@@ -216,7 +216,7 @@ class TestResourceReferenceResolution(TestCase):
         supported_refs = Mock()
 
         result = self.resolver._try_resolve_sam_resource_refs(input, supported_refs)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         action_mock.resolve_sam_resource_refs.assert_not_called()
 
     def test_short_circuit_on_empty_parameters(self):
@@ -225,7 +225,7 @@ class TestResourceReferenceResolution(TestCase):
         input = {"Ref": "foo"}
         expected = {"Ref": "foo"}
 
-        self.assertEquals(resolver.resolve_sam_resource_refs(input, {}), expected)
+        self.assertEqual(resolver.resolve_sam_resource_refs(input, {}), expected)
         resolver._try_resolve_sam_resource_refs.assert_not_called()
 
 class TestSupportedIntrinsics(TestCase):
@@ -234,7 +234,7 @@ class TestSupportedIntrinsics(TestCase):
         resolver = IntrinsicsResolver({})
 
         # This needs to be updated when new intrinsics are added
-        self.assertEquals(3, len(resolver.supported_intrinsics))
+        self.assertEqual(3, len(resolver.supported_intrinsics))
         self.assertTrue("Ref" in resolver.supported_intrinsics)
         self.assertTrue("Fn::Sub" in resolver.supported_intrinsics)
         self.assertTrue("Fn::GetAtt" in resolver.supported_intrinsics)
@@ -249,7 +249,7 @@ class TestSupportedIntrinsics(TestCase):
         }
         resolver = IntrinsicsResolver({}, supported_intrinsics)
 
-        self.assertEquals(resolver.supported_intrinsics, {
+        self.assertEqual(resolver.supported_intrinsics, {
             "ThisCanBeAnyIntrinsicName": action
         })
 

--- a/tests/intrinsics/test_resource_refs.py
+++ b/tests/intrinsics/test_resource_refs.py
@@ -17,7 +17,7 @@ class TestSupportedResourceReferences(TestCase):
             "property3": "value3"
         }
 
-        self.assertEquals(expected, resource_refs.get_all("logicalId"))
+        self.assertEqual(expected, resource_refs.get_all("logicalId"))
 
     def test_add_multiple_logical_ids(self):
         resource_refs = SupportedResourceReferences()
@@ -26,9 +26,9 @@ class TestSupportedResourceReferences(TestCase):
         resource_refs.add("logicalId2", "property2", "value2")
         resource_refs.add("logicalId3", "property3", "value3")
 
-        self.assertEquals({"property1": "value1"}, resource_refs.get_all("logicalId1"))
-        self.assertEquals({"property2": "value2"}, resource_refs.get_all("logicalId2"))
-        self.assertEquals({"property3": "value3"}, resource_refs.get_all("logicalId3"))
+        self.assertEqual({"property1": "value1"}, resource_refs.get_all("logicalId1"))
+        self.assertEqual({"property2": "value2"}, resource_refs.get_all("logicalId2"))
+        self.assertEqual({"property3": "value3"}, resource_refs.get_all("logicalId3"))
 
     def test_add_must_error_on_duplicate_value(self):
 
@@ -64,7 +64,7 @@ class TestSupportedResourceReferences(TestCase):
 
         resource_refs.add("logicalId", "property", "value1")
 
-        self.assertEquals(None, resource_refs.get_all("some logical id"))
+        self.assertEqual(None, resource_refs.get_all("some logical id"))
 
     def test_get_must_return_correct_value(self):
         resource_refs = SupportedResourceReferences()
@@ -73,16 +73,16 @@ class TestSupportedResourceReferences(TestCase):
         resource_refs.add("logicalId1", "property2", "value2")
         resource_refs.add("newLogicalId", "newProperty", "newValue")
 
-        self.assertEquals("value1", resource_refs.get("logicalId1", "property1"))
-        self.assertEquals("value2", resource_refs.get("logicalId1", "property2"))
-        self.assertEquals("newValue", resource_refs.get("newLogicalId", "newProperty"))
+        self.assertEqual("value1", resource_refs.get("logicalId1", "property1"))
+        self.assertEqual("value2", resource_refs.get("logicalId1", "property2"))
+        self.assertEqual("newValue", resource_refs.get("newLogicalId", "newProperty"))
 
     def test_get_on_non_existent_property(self):
         resource_refs = SupportedResourceReferences()
 
         resource_refs.add("logicalId1", "property1", "value1")
-        self.assertEquals(None, resource_refs.get("logicalId1", "SomeProperty"))
-        self.assertEquals(None, resource_refs.get("SomeLogicalId", "property1"))
+        self.assertEqual(None, resource_refs.get("logicalId1", "SomeProperty"))
+        self.assertEqual(None, resource_refs.get("SomeLogicalId", "property1"))
 
 
     def test_len_single_resource(self):
@@ -90,11 +90,11 @@ class TestSupportedResourceReferences(TestCase):
 
         resource_refs.add("logicalId1", "property1", "value1")
         resource_refs.add("logicalId1", "property2", "value2")
-        self.assertEquals(1, len(resource_refs))  # Each unique logicalId adds one to the len
+        self.assertEqual(1, len(resource_refs))  # Each unique logicalId adds one to the len
 
     def test_len_multiple_resources(self):
         resource_refs = SupportedResourceReferences()
 
         resource_refs.add("logicalId1", "property1", "value1")
         resource_refs.add("logicalId2", "property2", "value2")
-        self.assertEquals(2, len(resource_refs))
+        self.assertEqual(2, len(resource_refs))

--- a/tests/model/eventsources/test_cloudwatchlogs_event_source.py
+++ b/tests/model/eventsources/test_cloudwatchlogs_event_source.py
@@ -26,23 +26,23 @@ class CloudWatchLogsEventSource(TestCase):
         source_arn = self.cloudwatch_logs_event_source.get_source_arn()
         expected_source_arn = {'Fn::Sub': [
             'arn:aws:logs:${AWS::Region}:${AWS::AccountId}:log-group:${__LogGroupName__}:*', {'__LogGroupName__': 'MyLogGroup'}]}
-        self.assertEquals(source_arn, expected_source_arn)
+        self.assertEqual(source_arn, expected_source_arn)
 
     def test_get_subscription_filter(self):
         subscription_filter = self.cloudwatch_logs_event_source.get_subscription_filter(
             self.function, self.permission)
-        self.assertEquals(subscription_filter.LogGroupName, 'MyLogGroup')
-        self.assertEquals(subscription_filter.FilterPattern, 'Fizbo')
-        self.assertEquals(subscription_filter.DestinationArn, 'arn:aws:mock')
+        self.assertEqual(subscription_filter.LogGroupName, 'MyLogGroup')
+        self.assertEqual(subscription_filter.FilterPattern, 'Fizbo')
+        self.assertEqual(subscription_filter.DestinationArn, 'arn:aws:mock')
 
     @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_to_cloudformation_returns_permission_and_subscription_filter_resources(self):
         resources = self.cloudwatch_logs_event_source.to_cloudformation(
             function=self.function)
-        self.assertEquals(len(resources), 2)
-        self.assertEquals(resources[0].resource_type,
+        self.assertEqual(len(resources), 2)
+        self.assertEqual(resources[0].resource_type,
                           'AWS::Lambda::Permission')
-        self.assertEquals(resources[1].resource_type,
+        self.assertEqual(resources[1].resource_type,
                           'AWS::Logs::SubscriptionFilter')
 
     def test_to_cloudformation_throws_when_no_function(self):

--- a/tests/model/eventsources/test_sns_event_source.py
+++ b/tests/model/eventsources/test_sns_event_source.py
@@ -21,16 +21,16 @@ class SnsEventSource(TestCase):
     def test_to_cloudformation_returns_permission_and_subscription_resources(self):
         resources = self.sns_event_source.to_cloudformation(
             function=self.function)
-        self.assertEquals(len(resources), 2)
-        self.assertEquals(resources[0].resource_type,
+        self.assertEqual(len(resources), 2)
+        self.assertEqual(resources[0].resource_type,
                           'AWS::Lambda::Permission')
-        self.assertEquals(resources[1].resource_type,
+        self.assertEqual(resources[1].resource_type,
                           'AWS::SNS::Subscription')
 
         subscription = resources[1]
-        self.assertEquals(subscription.TopicArn, 'arn:aws:sns:MyTopic')
-        self.assertEquals(subscription.Protocol, 'lambda')
-        self.assertEquals(subscription.Endpoint, 'arn:aws:lambda:mock')
+        self.assertEqual(subscription.TopicArn, 'arn:aws:sns:MyTopic')
+        self.assertEqual(subscription.Protocol, 'lambda')
+        self.assertEqual(subscription.Endpoint, 'arn:aws:lambda:mock')
         self.assertIsNone(subscription.FilterPolicy)
 
     def test_to_cloudformation_passes_the_filter_policy(self):
@@ -43,11 +43,11 @@ class SnsEventSource(TestCase):
 
         resources = self.sns_event_source.to_cloudformation(
             function=self.function)
-        self.assertEquals(len(resources), 2)
-        self.assertEquals(resources[1].resource_type,
+        self.assertEqual(len(resources), 2)
+        self.assertEqual(resources[1].resource_type,
                           'AWS::SNS::Subscription')
         subscription = resources[1]
-        self.assertEquals(subscription.FilterPolicy, filterPolicy)
+        self.assertEqual(subscription.FilterPolicy, filterPolicy)
 
     def test_to_cloudformation_throws_when_no_function(self):
         self.assertRaises(TypeError, self.sns_event_source.to_cloudformation)

--- a/tests/model/tags/test_resource_tagging.py
+++ b/tests/model/tags/test_resource_tagging.py
@@ -9,7 +9,7 @@ class TestResourceTagging(TestCase):
         tag_list = get_tag_list(None)
         expected_tag_list = []
 
-        self.assertEquals(tag_list, expected_tag_list)
+        self.assertEqual(tag_list, expected_tag_list)
 
 
     def test_get_tag_list_with_tag_dictionary_with_key_only(self):
@@ -17,11 +17,11 @@ class TestResourceTagging(TestCase):
         expected_tag_list = [{"Key": "key",
                               "Value": ""}]
 
-        self.assertEquals(tag_list, expected_tag_list)
+        self.assertEqual(tag_list, expected_tag_list)
 
     def test_get_tag_list_with_tag_dictionary(self):
         tag_list = get_tag_list({"AnotherKey": "This time with a value"})
         expected_tag_list = [{"Key": "AnotherKey",
                               "Value": "This time with a value"}]
 
-        self.assertEquals(tag_list, expected_tag_list)
+        self.assertEqual(tag_list, expected_tag_list)

--- a/tests/model/test_function_policies.py
+++ b/tests/model/test_function_policies.py
@@ -23,7 +23,7 @@ class TestFunctionPolicies(TestCase):
         function_policies = FunctionPolicies(resource_properties, self.policy_template_processor_mock)
 
         get_policies_mock.assert_called_once_with(resource_properties)
-        self.assertEquals(expected_length, len(function_policies))
+        self.assertEqual(expected_length, len(function_policies))
 
 
     @patch.object(FunctionPolicies, "_get_policies")
@@ -37,7 +37,7 @@ class TestFunctionPolicies(TestCase):
         function_policies = FunctionPolicies(resource_properties, self.policy_template_processor_mock)
 
         # `list()` will implicitly call the `get()` repeatedly because it is a generator
-        self.assertEquals(list(function_policies.get()), expected_results)
+        self.assertEqual(list(function_policies.get()), expected_results)
 
 
     @patch.object(FunctionPolicies, "_get_policies")
@@ -51,7 +51,7 @@ class TestFunctionPolicies(TestCase):
         function_policies = FunctionPolicies(resource_properties, self.policy_template_processor_mock)
 
         # `list()` will implicitly call the `get()` repeatedly because it is a generator
-        self.assertEquals(list(function_policies.get()), expected_result)
+        self.assertEqual(list(function_policies.get()), expected_result)
 
     def test_contains_policies_must_work_for_valid_input(self):
         resource_properties = {
@@ -90,7 +90,7 @@ class TestFunctionPolicies(TestCase):
         expected = PolicyTypes.MANAGED_POLICY
 
         result = self.function_policies._get_type(policy)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     @patch("samtranslator.model.function_policies.is_instrinsic")
     def test_get_type_must_work_for_managed_policy_with_intrinsics(self, is_intrinsic_mock):
@@ -101,7 +101,7 @@ class TestFunctionPolicies(TestCase):
         is_intrinsic_mock.return_value = True
 
         result = self.function_policies._get_type(policy)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_type_must_work_for_policy_statements(self):
         policy = {
@@ -110,7 +110,7 @@ class TestFunctionPolicies(TestCase):
         expected = PolicyTypes.POLICY_STATEMENT
 
         result = self.function_policies._get_type(policy)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_type_must_work_for_policy_templates(self):
         policy = {
@@ -120,7 +120,7 @@ class TestFunctionPolicies(TestCase):
         expected = PolicyTypes.POLICY_TEMPLATE
 
         result = self.function_policies._get_type(policy)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_type_must_ignore_invalid_policy(self):
         policy = {
@@ -131,7 +131,7 @@ class TestFunctionPolicies(TestCase):
         expected = PolicyTypes.UNKNOWN
 
         result = self.function_policies._get_type(policy)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_type_must_ignore_invalid_policy_value_list(self):
         policy = ["invalid", "policy"]
@@ -140,7 +140,7 @@ class TestFunctionPolicies(TestCase):
         self.is_policy_template_mock.return_value = False
 
         result = self.function_policies._get_type(policy)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         self.is_policy_template_mock.assert_called_once_with(policy)
 
     def test_get_policies_must_return_all_policies(self):
@@ -165,7 +165,7 @@ class TestFunctionPolicies(TestCase):
         ]
 
         result = self.function_policies._get_policies(resource_properties)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_policies_must_ignore_if_resource_does_not_contain_policy(self):
         resource_properties = {
@@ -173,7 +173,7 @@ class TestFunctionPolicies(TestCase):
         expected = []
 
         result = self.function_policies._get_policies(resource_properties)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_policies_must_ignore_if_policies_is_empty(self):
         resource_properties = {
@@ -182,7 +182,7 @@ class TestFunctionPolicies(TestCase):
         expected = []
 
         result = self.function_policies._get_policies(resource_properties)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_policies_must_work_for_single_policy_string(self):
         resource_properties = {
@@ -193,7 +193,7 @@ class TestFunctionPolicies(TestCase):
         ]
 
         result = self.function_policies._get_policies(resource_properties)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_policies_must_work_for_single_dict_with_managed_policy_intrinsic(self):
         resource_properties = {
@@ -206,7 +206,7 @@ class TestFunctionPolicies(TestCase):
         ]
 
         result = self.function_policies._get_policies(resource_properties)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_policies_must_work_for_single_dict_with_policy_statement(self):
         resource_properties = {
@@ -219,7 +219,7 @@ class TestFunctionPolicies(TestCase):
         ]
 
         result = self.function_policies._get_policies(resource_properties)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_get_policies_must_work_for_single_dict_of_policy_template(self):
         resource_properties = {
@@ -233,7 +233,7 @@ class TestFunctionPolicies(TestCase):
         ]
 
         result = self.function_policies._get_policies(resource_properties)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         self.is_policy_template_mock.assert_called_once_with(resource_properties["Policies"])
 
     def test_get_policies_must_work_for_single_dict_of_invalid_policy_template(self):
@@ -248,7 +248,7 @@ class TestFunctionPolicies(TestCase):
         ]
 
         result = self.function_policies._get_policies(resource_properties)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         self.is_policy_template_mock.assert_called_once_with({"InvalidPolicyTemplate": "some template"})
 
     def test_get_policies_must_work_for_unknown_policy_types(self):
@@ -266,7 +266,7 @@ class TestFunctionPolicies(TestCase):
         self.is_policy_template_mock.return_value = False
 
         result = self.function_policies._get_policies(resource_properties)
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
 
     def test_is_policy_template_must_detect_valid_policy_templates(self):
         template_name = "template_name"

--- a/tests/plugins/api/test_default_definition_body_plugin.py
+++ b/tests/plugins/api/test_default_definition_body_plugin.py
@@ -16,7 +16,7 @@ class TestDefaultDefinitionBodyPlugin_init(TestCase):
         # Name is the class name
         expected_name = "DefaultDefinitionBodyPlugin"
 
-        self.assertEquals(self.plugin.name, expected_name)
+        self.assertEqual(self.plugin.name, expected_name)
 
     def test_plugin_must_be_instance_of_base_plugin_class(self):
         self.assertTrue(isinstance(self.plugin, BasePlugin))

--- a/tests/plugins/api/test_implicit_api_plugin.py
+++ b/tests/plugins/api/test_implicit_api_plugin.py
@@ -53,7 +53,7 @@ class TestImplicitApiPlugin_init(TestCase):
         # Name is the class name
         expected_name = "ImplicitApiPlugin"
 
-        self.assertEquals(self.plugin.name, expected_name)
+        self.assertEqual(self.plugin.name, expected_name)
 
     def test_plugin_must_be_instance_of_base_plugin_class(self):
         self.assertTrue(isinstance(self.plugin, BasePlugin))
@@ -165,15 +165,15 @@ class TestImplicitApiPlugin_on_before_transform_template(TestCase):
         # Verify the content of exception. There are two exceptions embedded one inside another
         #   InvalidDocumentException -> InvalidResourceException -> contains the msg from InvalidEventException
         causes = context.exception.causes
-        self.assertEquals(3, len(causes))
+        self.assertEqual(3, len(causes))
         for index, cause in enumerate(causes):
             self.assertTrue(isinstance(cause, InvalidResourceException))
 
             # Resource's logicalID must be correctly passed
-            self.assertEquals(function_resources[index][0], cause._logical_id)
+            self.assertEqual(function_resources[index][0], cause._logical_id)
 
             # Message must directly come from InvalidEventException
-            self.assertEquals(api_event_errors[index].message, cause._message)
+            self.assertEqual(api_event_errors[index].message, cause._message)
 
         # Must cleanup even if there an exception
         self.plugin._maybe_remove_implicit_api.assert_called_with(sam_template)
@@ -226,7 +226,7 @@ class TestImplicitApiPlugin_get_api_events(TestCase):
             }
         }
         result = self.plugin._get_api_events(function)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_must_work_with_no_api_events(self):
 
@@ -258,7 +258,7 @@ class TestImplicitApiPlugin_get_api_events(TestCase):
 
         expected = {}
         result = self.plugin._get_api_events(function)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_must_skip_with_bad_events_structure(self):
 
@@ -271,7 +271,7 @@ class TestImplicitApiPlugin_get_api_events(TestCase):
 
         expected = {}
         result = self.plugin._get_api_events(function)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_must_skip_if_no_events_property(self):
 
@@ -284,7 +284,7 @@ class TestImplicitApiPlugin_get_api_events(TestCase):
 
         expected = {}
         result = self.plugin._get_api_events(function)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_must_skip_if_no_property_dictionary(self):
 
@@ -295,7 +295,7 @@ class TestImplicitApiPlugin_get_api_events(TestCase):
 
         expected = {}
         result = self.plugin._get_api_events(function)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_must_return_reference_to_event_dict(self):
         function = SamResource({
@@ -335,7 +335,7 @@ class TestImplicitApiPlugin_get_api_events(TestCase):
 
         expected = {}
         result = self.plugin._get_api_events(function)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
 
 class TestImplicitApiPlugin_process_api_events(TestCase):
@@ -449,12 +449,12 @@ class TestImplicitApiPlugin_process_api_events(TestCase):
         self.plugin._process_api_events(function, api_events, template)
 
         # Side effect must be visible after call returns on the input object
-        self.assertEquals(api_events["Api1"]["Properties"], {"a": "b", "Key": "Value"})
-        self.assertEquals(api_events["Api2"]["Properties"], {"c": "d", "Key": "Value"})
+        self.assertEqual(api_events["Api1"]["Properties"], {"a": "b", "Key": "Value"})
+        self.assertEqual(api_events["Api2"]["Properties"], {"c": "d", "Key": "Value"})
 
         # Every Event object inside the SamResource class must be entirely replaced by input api_events with side effect
-        self.assertEquals(function.properties["Events"]["Api1"]["Properties"], {"a": "b", "Key": "Value"})
-        self.assertEquals(function.properties["Events"]["Api2"]["Properties"], {"c": "d", "Key": "Value"})
+        self.assertEqual(function.properties["Events"]["Api1"]["Properties"], {"a": "b", "Key": "Value"})
+        self.assertEqual(function.properties["Events"]["Api2"]["Properties"], {"c": "d", "Key": "Value"})
 
         # Subsequent calls must be made with the side effect. This is important.
         self.plugin._add_api_to_swagger.assert_has_calls([
@@ -486,7 +486,7 @@ class TestImplicitApiPlugin_add_implicit_api_id_if_necessary(TestCase):
         }
 
         self.plugin._add_implicit_api_id_if_necessary(input)
-        self.assertEquals(input, expected)
+        self.assertEqual(input, expected)
 
 
     def test_must_skip_if_present(self):
@@ -502,7 +502,7 @@ class TestImplicitApiPlugin_add_implicit_api_id_if_necessary(TestCase):
         }
 
         self.plugin._add_implicit_api_id_if_necessary(input)
-        self.assertEquals(input, expected)
+        self.assertEqual(input, expected)
 
 
 class TestImplicitApiPlugin_add_api_to_swagger(TestCase):
@@ -546,7 +546,7 @@ class TestImplicitApiPlugin_add_api_to_swagger(TestCase):
         template_mock.get.assert_called_with('restid')
         editor_mock.add_path("/hello", "GET")
         template_mock.set.assert_called_with("restid", mock_api)
-        self.assertEquals(mock_api.properties["DefinitionBody"], updated_swagger)
+        self.assertEqual(mock_api.properties["DefinitionBody"], updated_swagger)
 
     @patch("samtranslator.plugins.api.implicit_api_plugin.SwaggerEditor")
     def test_must_work_with_rest_api_id_as_string(self, SwaggerEditorMock):
@@ -585,7 +585,7 @@ class TestImplicitApiPlugin_add_api_to_swagger(TestCase):
         template_mock.get.assert_called_with('restid')
         editor_mock.add_path("/hello", "GET")
         template_mock.set.assert_called_with("restid", mock_api)
-        self.assertEquals(mock_api.properties["DefinitionBody"], updated_swagger)
+        self.assertEqual(mock_api.properties["DefinitionBody"], updated_swagger)
 
     def test_must_raise_when_api_is_not_found(self):
         event_id = "id"
@@ -602,7 +602,7 @@ class TestImplicitApiPlugin_add_api_to_swagger(TestCase):
         with self.assertRaises(InvalidEventException) as context:
             self.plugin._add_api_to_swagger(event_id, properties, template_mock)
 
-        self.assertEquals(event_id, context.exception._event_id)
+        self.assertEqual(event_id, context.exception._event_id)
 
     def test_must_raise_when_api_id_is_intrinsic(self):
         event_id = "id"
@@ -619,7 +619,7 @@ class TestImplicitApiPlugin_add_api_to_swagger(TestCase):
         with self.assertRaises(InvalidEventException) as context:
             self.plugin._add_api_to_swagger(event_id, properties, template_mock)
 
-        self.assertEquals(event_id, context.exception._event_id)
+        self.assertEqual(event_id, context.exception._event_id)
 
     @patch("samtranslator.plugins.api.implicit_api_plugin.SwaggerEditor")
     def test_must_skip_invalid_swagger(self, SwaggerEditorMock):

--- a/tests/plugins/application/test_serverless_app_plugin.py
+++ b/tests/plugins/application/test_serverless_app_plugin.py
@@ -65,27 +65,27 @@ class TestServerlessAppPlugin_init(TestCase):
     def test_plugin_must_setup_correct_name(self):
         # Name is the class name
         expected_name = "ServerlessAppPlugin"
-        self.assertEquals(self.plugin.name, expected_name)
+        self.assertEqual(self.plugin.name, expected_name)
 
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
     def test_plugin_default_values(self):
-        self.assertEquals(self.plugin._wait_for_template_active_status, False)
-        self.assertEquals(self.plugin._validate_only, False)
+        self.assertEqual(self.plugin._wait_for_template_active_status, False)
+        self.assertEqual(self.plugin._validate_only, False)
         self.assertTrue(self.plugin._sar_client is not None)
         # For some reason, `isinstance` or comparing classes did not work here
-        self.assertEquals(str(self.plugin._sar_client.__class__), str(boto3.client('serverlessrepo').__class__))
+        self.assertEqual(str(self.plugin._sar_client.__class__), str(boto3.client('serverlessrepo').__class__))
 
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
     def test_plugin_accepts_different_sar_client(self):
         client = boto3.client('serverlessrepo', endpoint_url = 'https://example.com')
         self.plugin = ServerlessAppPlugin(sar_client=client)
-        self.assertEquals(self.plugin._sar_client, client)
-        self.assertEquals(self.plugin._sar_client._endpoint, client._endpoint)
+        self.assertEqual(self.plugin._sar_client, client)
+        self.assertEqual(self.plugin._sar_client._endpoint, client._endpoint)
 
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
     def test_plugin_accepts_flags(self):
         self.plugin = ServerlessAppPlugin(wait_for_template_active_status=True)
-        self.assertEquals(self.plugin._wait_for_template_active_status, True)
+        self.assertEqual(self.plugin._wait_for_template_active_status, True)
 
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
     def test_plugin_invalid_configuration_raises_exception(self):
@@ -192,7 +192,7 @@ class TestServerlessAppPlugin_on_before_transform_template_translate(TestCase):
         app_id = 'app_id'
         semver = '1.0.0'
         response = self.plugin._sar_service_call(service_call_lambda, logical_id, app_id, semver)
-        self.assertEquals(app_id, response['ApplicationId'])
+        self.assertEqual(app_id, response['ApplicationId'])
 
 
 class ApplicationResource(object):

--- a/tests/plugins/globals/test_globals.py
+++ b/tests/plugins/globals/test_globals.py
@@ -395,7 +395,7 @@ class TestGlobalPropertiesMerge(TestCase):
         global_properties = GlobalProperties(configuration["global"])
         actual = global_properties.merge(configuration["local"])
 
-        self.assertEquals(actual, configuration["expected_output"])
+        self.assertEqual(actual, configuration["expected_output"])
 
 class TestGlobalsPropertiesEdgeCases(TestCase):
 
@@ -445,9 +445,9 @@ class TestGlobalsObject(TestCase):
         parsed_globals = globals._parse(self.template["Globals"])
 
         self.assertTrue("prefix_type1" in parsed_globals)
-        self.assertEquals(self.template["Globals"]["type1"], parsed_globals["prefix_type1"].global_properties)
+        self.assertEqual(self.template["Globals"]["type1"], parsed_globals["prefix_type1"].global_properties)
         self.assertTrue("prefix_type2" in parsed_globals)
-        self.assertEquals(self.template["Globals"]["type2"], parsed_globals["prefix_type2"].global_properties)
+        self.assertEqual(self.template["Globals"]["type2"], parsed_globals["prefix_type2"].global_properties)
 
 
     def test_parse_should_error_if_globals_is_not_dict(self):
@@ -511,7 +511,7 @@ class TestGlobalsObject(TestCase):
         parsed = globals._parse(template["Globals"])
 
         self.assertTrue("prefix_type1" in parsed)
-        self.assertEquals({}, parsed["prefix_type1"].global_properties)
+        self.assertEqual({}, parsed["prefix_type1"].global_properties)
 
     def test_init_without_globals_section_in_template(self):
 
@@ -520,14 +520,14 @@ class TestGlobalsObject(TestCase):
         }
 
         global_obj = Globals(template)
-        self.assertEquals({}, global_obj.template_globals)
+        self.assertEqual({}, global_obj.template_globals)
 
     def test_del_section_with_globals_section_in_template(self):
         template = self.template
         expected = {}
 
         Globals.del_section(template)
-        self.assertEquals(expected, template)
+        self.assertEqual(expected, template)
 
     def test_del_section_with_no_globals_section_in_template(self):
         template = {
@@ -539,7 +539,7 @@ class TestGlobalsObject(TestCase):
         }
 
         Globals.del_section(template)
-        self.assertEquals(expected, template)
+        self.assertEqual(expected, template)
 
     @patch.object(Globals, "_parse")
     def test_merge_must_actually_do_merge(self, parse_mock):
@@ -559,7 +559,7 @@ class TestGlobalsObject(TestCase):
         globals = Globals(self.template)
         result = globals.merge("type1", local_properties)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
         type1_mock.merge.assert_called_with(local_properties)
         type2_mock.merge.assert_not_called()
 
@@ -579,7 +579,7 @@ class TestGlobalsObject(TestCase):
         # Since type is not available in the globals, nothing should happen
         result = globals.merge("some random type", local_properties)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
         type1_mock.merge.assert_not_called()
 
     @patch.object(Globals, "_parse")
@@ -596,7 +596,7 @@ class TestGlobalsObject(TestCase):
         # Since type is not available in the globals, nothing should happen
         result = globals.merge("some random type", local_properties)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_merge_end_to_end_on_known_type1(self):
 
@@ -617,7 +617,7 @@ class TestGlobalsObject(TestCase):
         globals = Globals(self.template)
         result = globals.merge(type, properties)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_merge_end_to_end_on_known_type2(self):
 
@@ -637,7 +637,7 @@ class TestGlobalsObject(TestCase):
         globals = Globals(self.template)
         result = globals.merge(type, properties)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_merge_end_to_end_unknown_type(self):
 
@@ -656,4 +656,4 @@ class TestGlobalsObject(TestCase):
         globals = Globals(self.template)
         result = globals.merge(type, properties)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)

--- a/tests/plugins/globals/test_globals_plugin.py
+++ b/tests/plugins/globals/test_globals_plugin.py
@@ -18,7 +18,7 @@ class TestGlobalsPlugin(TestCase):
         # Name is the class name
         expected_name = "GlobalsPlugin"
 
-        self.assertEquals(self.plugin.name, expected_name)
+        self.assertEqual(self.plugin.name, expected_name)
 
     def test_plugin_must_be_instance_of_base_plugin_class(self):
         self.assertTrue(isinstance(self.plugin, BasePlugin))
@@ -37,7 +37,7 @@ class TestGlobalsPlugin(TestCase):
             self.plugin.on_before_transform_template(template)
 
         ex = context.exception
-        self.assertEquals(1, len(ex.causes))
-        self.assertEquals(ex.causes[0], globals_ex)
+        self.assertEqual(1, len(ex.causes))
+        self.assertEqual(ex.causes[0], globals_ex)
 
     # Skipping test for the happy case because the end-to-end unit tests capture a lot of the Globals Plugin's logic.

--- a/tests/plugins/policies/test_policy_templates_plugin.py
+++ b/tests/plugins/policies/test_policy_templates_plugin.py
@@ -18,7 +18,7 @@ class TestPolicyTemplatesForFunctionPlugin(TestCase):
         # Name is the class name
         expected_name = "PolicyTemplatesForFunctionPlugin"
 
-        self.assertEquals(self.plugin.name, expected_name)
+        self.assertEqual(self.plugin.name, expected_name)
 
     def test_plugin_must_be_instance_of_base_plugin_class(self):
         self.assertTrue(isinstance(self.plugin, BasePlugin))
@@ -74,7 +74,7 @@ class TestPolicyTemplatesForFunctionPlugin(TestCase):
         self.plugin.on_before_transform_resource("logicalId", "resource_type", resource_properties)
 
         # This will overwrite the resource_properties input array
-        self.assertEquals(expected, resource_properties["Policies"])
+        self.assertEqual(expected, resource_properties["Policies"])
         function_policies_obj_mock.get.assert_called_once_with()
         self._policy_template_processor_mock.convert.assert_has_calls([
             call("MyTemplate1", {"Param1": "value1"}),
@@ -126,7 +126,7 @@ class TestPolicyTemplatesForFunctionPlugin(TestCase):
         self.plugin.on_before_transform_resource("logicalId", "resource_type", resource_properties)
 
         # This will overwrite the resource_properties input array
-        self.assertEquals(expected, resource_properties["Policies"])
+        self.assertEqual(expected, resource_properties["Policies"])
         function_policies_obj_mock.get.assert_called_once_with()
         self._policy_template_processor_mock.convert.assert_has_calls([
             call("MyTemplate1", {"Param1": "value1"}),
@@ -167,7 +167,7 @@ class TestPolicyTemplatesForFunctionPlugin(TestCase):
             self.plugin.on_before_transform_resource("logicalId", "resource_type", resource_properties)
 
         # Make sure the input was not changed
-        self.assertEquals(resource_properties, {"Policies": {"MyTemplate1": { "Param1": "value1"}}})
+        self.assertEqual(resource_properties, {"Policies": {"MyTemplate1": { "Param1": "value1"}}})
 
     @patch("samtranslator.plugins.policies.policy_templates_plugin.FunctionPolicies")
     def test_on_before_transform_must_raise_on_invalid_parameter_values(self, function_policies_class_mock):
@@ -201,7 +201,7 @@ class TestPolicyTemplatesForFunctionPlugin(TestCase):
             self.plugin.on_before_transform_resource("logicalId", "resource_type", resource_properties)
 
         # Make sure the input was not changed
-        self.assertEquals(resource_properties, {"Policies": {"MyTemplate1": { "Param1": "value1"}}})
+        self.assertEqual(resource_properties, {"Policies": {"MyTemplate1": { "Param1": "value1"}}})
 
     @patch("samtranslator.plugins.policies.policy_templates_plugin.FunctionPolicies")
     def test_on_before_transform_must_bubble_exception(self, function_policies_class_mock):
@@ -235,7 +235,7 @@ class TestPolicyTemplatesForFunctionPlugin(TestCase):
             self.plugin.on_before_transform_resource("logicalId", "resource_type", resource_properties)
 
         # Make sure the input was not changed
-        self.assertEquals(resource_properties, {"Policies": {"MyTemplate1": { "Param1": "value1"}}})
+        self.assertEqual(resource_properties, {"Policies": {"MyTemplate1": { "Param1": "value1"}}})
 
     def test_on_before_transform_resource_must_skip_unsupported_resources(self):
 
@@ -248,7 +248,7 @@ class TestPolicyTemplatesForFunctionPlugin(TestCase):
         self.plugin.on_before_transform_resource(data_mock, data_mock, data_mock)
 
         # Make sure none of the data elements were accessed, because the method returned immediately
-        self.assertEquals([], data_mock.method_calls)
+        self.assertEqual([], data_mock.method_calls)
 
     @patch("samtranslator.plugins.policies.policy_templates_plugin.FunctionPolicies")
     def test_on_before_transform_resource_must_skip_function_with_no_policies(self, function_policies_class_mock):

--- a/tests/policy_template_processor/test_processor.py
+++ b/tests/policy_template_processor/test_processor.py
@@ -59,11 +59,11 @@ class TestPolicyTemplateProcessor(TestCase):
 
         processor = PolicyTemplatesProcessor(policy_templates_dict)
 
-        self.assertEquals(2, len(processor.policy_templates))
-        self.assertEquals(set(["key1", "key2"]), set(processor.policy_templates.keys()))
+        self.assertEqual(2, len(processor.policy_templates))
+        self.assertEqual(set(["key1", "key2"]), set(processor.policy_templates.keys()))
 
         # Template.from_dict must be called only once for each template entry
-        self.assertEquals(2, template_from_dict_mock.call_count)
+        self.assertEqual(2, template_from_dict_mock.call_count)
         template_from_dict_mock.assert_any_call("key1", "value1")
         template_from_dict_mock.assert_any_call("key2", "value2")
 
@@ -110,7 +110,7 @@ class TestPolicyTemplateProcessor(TestCase):
 
         processor = PolicyTemplatesProcessor(policy_templates_dict)
 
-        self.assertEquals(processor.get("key1"), template_obj)
+        self.assertEqual(processor.get("key1"), template_obj)
 
     @patch.object(PolicyTemplatesProcessor, "_is_valid_templates_dict")
     @patch.object(Template, "from_dict")
@@ -126,7 +126,7 @@ class TestPolicyTemplateProcessor(TestCase):
 
         processor = PolicyTemplatesProcessor(policy_templates_dict)
 
-        self.assertEquals(processor.get("key2"), None)
+        self.assertEqual(processor.get("key2"), None)
 
     @patch.object(PolicyTemplatesProcessor, "_is_valid_templates_dict")
     @patch.object(Template, "from_dict")
@@ -149,7 +149,7 @@ class TestPolicyTemplateProcessor(TestCase):
         processor = PolicyTemplatesProcessor(policy_templates_dict)
         result = processor.convert("key1", parameter_values)
 
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         template_obj_mock.to_statement.assert_called_once_with(parameter_values)
 
     @patch.object(PolicyTemplatesProcessor, "_is_valid_templates_dict")
@@ -241,7 +241,7 @@ class TestPolicyTemplateProcessor(TestCase):
             PolicyTemplatesProcessor._is_valid_templates_dict(policy_templates_dict)
 
         ex = cm.exception
-        self.assertEquals(str(ex), exception_msg)
+        self.assertEqual(str(ex), exception_msg)
 
     @patch.object(jsonschema, "validate")
     @patch.object(PolicyTemplatesProcessor, "_read_schema")
@@ -270,10 +270,10 @@ class TestPolicyTemplateProcessor(TestCase):
         with patch("samtranslator.policy_template_processor.processor.open", open_mock):
 
             result = PolicyTemplatesProcessor._read_json(filepath)
-            self.assertEquals(result, json_return)
+            self.assertEqual(result, json_return)
 
             open_mock.assert_called_once_with(filepath, "r")
-            self.assertEquals(1, json_loads_mock.call_count)
+            self.assertEqual(1, json_loads_mock.call_count)
 
     @patch.object(PolicyTemplatesProcessor, '_read_json')
     def test_read_schema_must_use_default_schema_location(self, _read_file_mock):
@@ -281,7 +281,7 @@ class TestPolicyTemplateProcessor(TestCase):
         _read_file_mock.return_value = expected
 
         result = PolicyTemplatesProcessor._read_schema()
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         _read_file_mock.assert_called_once_with(PolicyTemplatesProcessor.SCHEMA_LOCATION)
 
     @patch.object(PolicyTemplatesProcessor, '_read_json')
@@ -290,5 +290,5 @@ class TestPolicyTemplateProcessor(TestCase):
         _read_file_mock.return_value = expected
 
         result = PolicyTemplatesProcessor.get_default_policy_templates_json()
-        self.assertEquals(result, expected)
+        self.assertEqual(result, expected)
         _read_file_mock.assert_called_once_with(PolicyTemplatesProcessor.DEFAULT_POLICY_TEMPLATES_FILE)

--- a/tests/policy_template_processor/test_template.py
+++ b/tests/policy_template_processor/test_template.py
@@ -15,9 +15,9 @@ class TestTemplateObject(TestCase):
 
         template = Template(template_name, parameters, template_definition)
 
-        self.assertEquals(template.name, template_name)
-        self.assertEquals(template.parameters, parameters)
-        self.assertEquals(template.definition, template_definition)
+        self.assertEqual(template.name, template_name)
+        self.assertEqual(template.parameters, parameters)
+        self.assertEqual(template.definition, template_definition)
         check_parameters_exist_mock.assert_called_once_with(parameters, template_definition)
 
     @patch.object(Template, "check_parameters_exist")
@@ -34,9 +34,9 @@ class TestTemplateObject(TestCase):
         template = Template.from_dict(template_name, template_dict)
 
         self.assertTrue(isinstance(template, Template))
-        self.assertEquals(template.name, template_name)
-        self.assertEquals(template.parameters, parameters)
-        self.assertEquals(template.definition, template_definition)
+        self.assertEqual(template.name, template_name)
+        self.assertEqual(template.parameters, parameters)
+        self.assertEqual(template.definition, template_definition)
 
     @patch.object(Template, "check_parameters_exist")
     def test_from_dict_must_work_when_parameters_is_absent(self, check_parameters_exist_mock):
@@ -49,8 +49,8 @@ class TestTemplateObject(TestCase):
 
         template = Template.from_dict(template_name, template_dict)
 
-        self.assertEquals(template.parameters, {}) # Defaults to {}
-        self.assertEquals(template.definition, template_definition)
+        self.assertEqual(template.parameters, {}) # Defaults to {}
+        self.assertEqual(template.definition, template_definition)
 
     @patch.object(Template, "check_parameters_exist")
     def test_from_dict_must_work_when_template_definition_is_absent(self, check_parameters_exist_mock):
@@ -63,8 +63,8 @@ class TestTemplateObject(TestCase):
 
         template = Template.from_dict(template_name, template_dict)
 
-        self.assertEquals(template.parameters, parameters)
-        self.assertEquals(template.definition, {}) # Defaults to {}
+        self.assertEqual(template.parameters, parameters)
+        self.assertEqual(template.definition, {}) # Defaults to {}
 
     def test_missing_parameter_values_must_work_when_input_has_less_keys(self):
         template_parameters = {
@@ -79,7 +79,7 @@ class TestTemplateObject(TestCase):
         template = Template("name", template_parameters, {})
         result = template.missing_parameter_values(parameter_values)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_missing_parameter_values_must_work_when_input_has_all_keys(self):
         template_parameters = {
@@ -95,7 +95,7 @@ class TestTemplateObject(TestCase):
         template = Template("name", template_parameters, {})
         result = template.missing_parameter_values(parameter_values)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_missing_parameter_values_must_work_when_input_has_more_keys(self):
         template_parameters = {
@@ -112,7 +112,7 @@ class TestTemplateObject(TestCase):
         template = Template("name", template_parameters, {})
         result = template.missing_parameter_values(parameter_values)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_missing_parameter_values_must_raise_on_invalid_input(self):
         template_parameters = {
@@ -155,7 +155,7 @@ class TestTemplateObject(TestCase):
         template = Template("name", template_parameters, template_definition)
         result = template.to_statement(parameter_values)
 
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
         intrinsics_resolver_mock.assert_called_once_with(parameter_values, {"Ref": ANY})
         resolver_instance_mock.resolve_parameter_refs.assert_called_once_with({"Statement": {"key": "value"}})
 

--- a/tests/sdk/test_resource.py
+++ b/tests/sdk/test_resource.py
@@ -35,8 +35,8 @@ class TestSamResource(TestCase):
         }
 
         resource = SamResource(resource_dict)
-        self.assertEquals(resource.type, "foo")
-        self.assertEquals(resource.properties, {"a": "b"})
+        self.assertEqual(resource.type, "foo")
+        self.assertEqual(resource.properties, {"a": "b"})
 
     def test_init_must_default_to_empty_properties_dict(self):
         resource_dict = {
@@ -45,7 +45,7 @@ class TestSamResource(TestCase):
         }
 
         resource = SamResource(resource_dict)
-        self.assertEquals(resource.properties, {})
+        self.assertEqual(resource.properties, {})
 
     def test_valid_must_validate_sam_resources_only(self):
         self.assertTrue(SamResource({"Type": "AWS::Serverless::Api"}).valid())
@@ -69,18 +69,18 @@ class TestSamResource(TestCase):
         resource.type = "AWS::Serverless::Api"
         resource.properties = {"c": "d"}
 
-        self.assertEquals(resource.to_dict(), {"Type": "AWS::Serverless::Api", "Properties": {"c": "d"}})
+        self.assertEqual(resource.to_dict(), {"Type": "AWS::Serverless::Api", "Properties": {"c": "d"}})
 
         # Calling to_dict() has side effect of updating the original dictionary
-        self.assertEquals(resource_dict, {"Type": "AWS::Serverless::Api", "Properties": {"c": "d"}})
+        self.assertEqual(resource_dict, {"Type": "AWS::Serverless::Api", "Properties": {"c": "d"}})
 
 
 class TestSamResourceTypeEnum(TestCase):
 
     def test_contains_sam_resources(self):
-        self.assertEquals(SamResourceType.Function.value, "AWS::Serverless::Function")
-        self.assertEquals(SamResourceType.Api.value, "AWS::Serverless::Api")
-        self.assertEquals(SamResourceType.SimpleTable.value, "AWS::Serverless::SimpleTable")
+        self.assertEqual(SamResourceType.Function.value, "AWS::Serverless::Function")
+        self.assertEqual(SamResourceType.Api.value, "AWS::Serverless::Api")
+        self.assertEqual(SamResourceType.SimpleTable.value, "AWS::Serverless::SimpleTable")
 
     def test_has_value_must_work_for_sam_types(self):
 

--- a/tests/sdk/test_template.py
+++ b/tests/sdk/test_template.py
@@ -60,7 +60,7 @@ class TestSamTemplate(TestCase):
         ]
 
         actual = [(id, resource.to_dict()) for id, resource in template.iterate(type)]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_iterate_must_filter_by_layers_resource_type(self):
         template = SamTemplate(self.template_dict)
@@ -71,7 +71,7 @@ class TestSamTemplate(TestCase):
         ]
 
         actual = [(id, resource.to_dict()) for id, resource in template.iterate(type)]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_iterate_must_not_return_non_sam_resources_with_filter(self):
         template = SamTemplate(self.template_dict)
@@ -80,7 +80,7 @@ class TestSamTemplate(TestCase):
         expected = []
 
         actual = [(id, resource.to_dict()) for id, resource in template.iterate(type)]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_iterate_must_filter_with_resource_not_found(self):
         template = SamTemplate(self.template_dict)
@@ -89,21 +89,21 @@ class TestSamTemplate(TestCase):
         expected = []
 
         actual = [(id, resource.to_dict()) for id, resource in template.iterate(type)]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_set_must_add_to_template(self):
         template = SamTemplate(self.template_dict)
         template.set("NewResource", {"Type": "something"})
 
         # Set would modify the original template dictionary
-        self.assertEquals(self.template_dict["Resources"].get("NewResource"), {"Type": "something"})
+        self.assertEqual(self.template_dict["Resources"].get("NewResource"), {"Type": "something"})
 
     def test_set_must_work_with_sam_resource_input(self):
         template = SamTemplate(self.template_dict)
         template.set("NewResource", SamResource({"Type": "something"}))
 
         # Set would modify the original template dictionary
-        self.assertEquals(self.template_dict["Resources"].get("NewResource"), {"Type": "something"})
+        self.assertEqual(self.template_dict["Resources"].get("NewResource"), {"Type": "something"})
 
     def test_get_must_return_resource(self):
         expected = {
@@ -117,7 +117,7 @@ class TestSamTemplate(TestCase):
         actual = template.get("Function1")
         self.assertIsNotNone(actual)
         self.assertTrue(isinstance(actual, SamResource))
-        self.assertEquals(actual.to_dict(), expected)
+        self.assertEqual(actual.to_dict(), expected)
 
     def test_get_must_return_none_for_unknown_resource(self):
         template = SamTemplate(self.template_dict)

--- a/tests/swagger/test_swagger.py
+++ b/tests/swagger/test_swagger.py
@@ -30,7 +30,7 @@ class TestSwaggerEditor_init(TestCase):
         editor = SwaggerEditor(valid_swagger)
         self.assertIsNotNone(editor)
 
-        self.assertEquals(editor.paths, {"/foo": {}, "/bar": {}})
+        self.assertEqual(editor.paths, {"/foo": {}, "/bar": {}})
 
 
 class TestSwaggerEditor_has_path(TestCase):
@@ -158,7 +158,7 @@ class TestSwaggerEditor_add_path(TestCase):
         self.editor.add_path(path, method)
 
         self.assertTrue(self.editor.has_path(path, method), "must add for "+case)
-        self.assertEquals(self.editor.swagger["paths"][path][method], {})
+        self.assertEqual(self.editor.swagger["paths"][path][method], {})
 
     def test_must_raise_non_dict_path_values(self):
 
@@ -180,7 +180,7 @@ class TestSwaggerEditor_add_path(TestCase):
 
         self.editor.add_path(path, method)
         modified_swagger = self.editor.swagger
-        self.assertEquals(original_value, modified_swagger["paths"][path][method])
+        self.assertEqual(original_value, modified_swagger["paths"][path][method])
 
 
 class TestSwaggerEditor_add_lambda_integration(TestCase):
@@ -227,7 +227,7 @@ class TestSwaggerEditor_add_lambda_integration(TestCase):
 
         self.assertTrue(self.editor.has_path(path, method))
         actual = self.editor.swagger["paths"][path][method]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_must_add_new_integration_to_existing_path(self):
         path = "/foo"
@@ -256,7 +256,7 @@ class TestSwaggerEditor_add_lambda_integration(TestCase):
         self.editor.add_lambda_integration(path, method, integration_uri)
 
         actual = self.editor.swagger["paths"][path][method]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_must_raise_on_existing_integration(self):
 
@@ -284,7 +284,7 @@ class TestSwaggerEditor_iter_on_path(TestCase):
         expected = {"/foo", "/bar", "/baz"}
         actual = set([path for path in self.editor.iter_on_path()])
 
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
 
 class TestSwaggerEditor_add_cors(TestCase):
@@ -318,7 +318,7 @@ class TestSwaggerEditor_add_cors(TestCase):
         self.editor._options_method_response_for_cors.return_value = expected
 
         self.editor.add_cors(path, allowed_origins, allowed_headers, allowed_methods, max_age, allow_credentials)
-        self.assertEquals(expected, self.editor.swagger["paths"][path]["options"])
+        self.assertEqual(expected, self.editor.swagger["paths"][path]["options"])
         self.editor._options_method_response_for_cors.assert_called_with(allowed_origins,
                                                                          allowed_headers,
                                                                          allowed_methods,
@@ -330,7 +330,7 @@ class TestSwaggerEditor_add_cors(TestCase):
         expected = copy.deepcopy(self.original_swagger["paths"][path]["options"])
 
         self.editor.add_cors(path, "origins", "headers", "methods")
-        self.assertEquals(expected, self.editor.swagger["paths"][path]["options"])
+        self.assertEqual(expected, self.editor.swagger["paths"][path]["options"])
 
     def test_must_fail_with_bad_values_for_path(self):
         path = "/bad"
@@ -361,7 +361,7 @@ class TestSwaggerEditor_add_cors(TestCase):
 
         self.editor.add_cors(path, allowed_origins, allowed_headers, allowed_methods, max_age, allow_credentials)
 
-        self.assertEquals(expected, self.editor.swagger["paths"][path]["options"])
+        self.assertEqual(expected, self.editor.swagger["paths"][path]["options"])
 
         self.editor._options_method_response_for_cors.assert_called_with(allowed_origins,
                                                                          allowed_headers,
@@ -391,7 +391,7 @@ class TestSwaggerEditor_add_cors(TestCase):
 
         self.editor.add_cors(path, allowed_origins, allowed_headers, allowed_methods, max_age, allow_credentials)
 
-        self.assertEquals(expected, self.editor.swagger["paths"][path]["options"])
+        self.assertEqual(expected, self.editor.swagger["paths"][path]["options"])
 
         self.editor._options_method_response_for_cors.assert_called_with(allowed_origins,
                                                                          allowed_headers,
@@ -415,7 +415,7 @@ class TestSwaggerEditor_add_cors(TestCase):
         self.editor._options_method_response_for_cors.return_value = expected
 
         self.editor.add_cors(path, allowed_origins, allowed_headers, allowed_methods, max_age, allow_credentials)
-        self.assertEquals(expected, self.editor.swagger["paths"][path]["options"])
+        self.assertEqual(expected, self.editor.swagger["paths"][path]["options"])
         self.editor._options_method_response_for_cors.assert_called_with(allowed_origins,
                                                                          allowed_headers,
                                                                          allowed_methods,
@@ -485,7 +485,7 @@ class TestSwaggerEditor_options_method_response_for_cors(TestCase):
         actual = SwaggerEditor(SwaggerEditor.gen_skeleton())._options_method_response_for_cors(origins, headers,
                                                                                                methods, max_age,
                                                                                                allow_credentials)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_allow_headers_is_skipped_with_no_value(self):
         headers = None # No value
@@ -515,8 +515,8 @@ class TestSwaggerEditor_options_method_response_for_cors(TestCase):
             origins, headers, methods, allow_credentials=allow_credentials)
 
         actual = options_config[_X_INTEGRATION]["responses"]["default"]["responseParameters"]
-        self.assertEquals(expected, actual)
-        self.assertEquals(expected_headers, options_config["responses"]["200"]["headers"])
+        self.assertEqual(expected, actual)
+        self.assertEqual(expected_headers, options_config["responses"]["200"]["headers"])
 
     def test_allow_methods_is_skipped_with_no_value(self):
         headers = "headers"
@@ -534,7 +534,7 @@ class TestSwaggerEditor_options_method_response_for_cors(TestCase):
             origins, headers, methods, allow_credentials=allow_credentials)
 
         actual = options_config[_X_INTEGRATION]["responses"]["default"]["responseParameters"]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_allow_origins_is_not_skipped_with_no_value(self):
         headers = None
@@ -551,7 +551,7 @@ class TestSwaggerEditor_options_method_response_for_cors(TestCase):
             origins, headers, methods, allow_credentials=allow_credentials)
 
         actual = options_config[_X_INTEGRATION]["responses"]["default"]["responseParameters"]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_max_age_can_be_set_to_zero(self):
         headers = None
@@ -571,7 +571,7 @@ class TestSwaggerEditor_options_method_response_for_cors(TestCase):
             origins, headers, methods, max_age, allow_credentials)
 
         actual = options_config[_X_INTEGRATION]["responses"]["default"]["responseParameters"]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_allow_credentials_is_skipped_with_false_value(self):
         headers = "headers"
@@ -589,7 +589,7 @@ class TestSwaggerEditor_options_method_response_for_cors(TestCase):
             origins, headers, methods, allow_credentials=allow_credentials)
 
         actual = options_config[_X_INTEGRATION]["responses"]["default"]["responseParameters"]
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
 class TestSwaggerEditor_make_cors_allowed_methods_for_path(TestCase):
 
@@ -616,28 +616,28 @@ class TestSwaggerEditor_make_cors_allowed_methods_for_path(TestCase):
         expected = "DELETE,GET,OPTIONS,POST" # Result should be sorted alphabetically
 
         actual = self.editor._make_cors_allowed_methods_for_path(path)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_must_work_for_any_method(self):
         path = "/withany"
         expected = "DELETE,GET,HEAD,OPTIONS,PATCH,POST,PUT" # Result should be sorted alphabetically
 
         actual = self.editor._make_cors_allowed_methods_for_path(path)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_must_work_with_no_methods(self):
         path = "/nothing"
         expected = "OPTIONS"
 
         actual = self.editor._make_cors_allowed_methods_for_path(path)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
     def test_must_skip_non_existent_path(self):
         path = "/no-path"
         expected = ""
 
         actual = self.editor._make_cors_allowed_methods_for_path(path)
-        self.assertEquals(expected, actual)
+        self.assertEqual(expected, actual)
 
 
 class TestSwaggerEditor_normalize_method_name(TestCase):
@@ -651,7 +651,7 @@ class TestSwaggerEditor_normalize_method_name(TestCase):
         param([1, 2], [1, 2], "must skip non-string values"),
     ])
     def test_must_normalize(self, input, expected, msg):
-        self.assertEquals(expected, SwaggerEditor._normalize_method_name(input), msg)
+        self.assertEqual(expected, SwaggerEditor._normalize_method_name(input), msg)
 
 
 class TestSwaggerEditor_swagger_property(TestCase):
@@ -664,13 +664,13 @@ class TestSwaggerEditor_swagger_property(TestCase):
         }
 
         editor = SwaggerEditor(input)
-        self.assertEquals(input, editor.swagger) # They are equal in content
+        self.assertEqual(input, editor.swagger) # They are equal in content
         input["swagger"] = "3"
-        self.assertEquals("2.0", editor.swagger["swagger"]) # Editor works on a diff copy of input
+        self.assertEqual("2.0", editor.swagger["swagger"]) # Editor works on a diff copy of input
 
         editor.add_path("/foo", "get")
-        self.assertEquals({"/foo": {"get": {}}}, editor.swagger["paths"])
-        self.assertEquals({}, input["paths"]) # Editor works on a diff copy of input
+        self.assertEqual({"/foo": {"get": {}}}, editor.swagger["paths"])
+        self.assertEqual({}, input["paths"]) # Editor works on a diff copy of input
 
 
 class TestSwaggerEditor_is_valid(TestCase):

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -122,8 +122,8 @@ class TestResourceRuntimeAttributes(TestCase):
 
         logical_id = "SomeId"
         resource = NewResource(logical_id)
-        self.assertEquals("value1", resource.get_runtime_attr("attr1"))
-        self.assertEquals("value2", resource.get_runtime_attr("attr2"))
+        self.assertEqual("value1", resource.get_runtime_attr("attr1"))
+        self.assertEqual("value2", resource.get_runtime_attr("attr2"))
 
         with self.assertRaises(NotImplementedError):
             resource.get_runtime_attr("invalid_attribute")
@@ -135,7 +135,7 @@ class TestResourceRuntimeAttributes(TestCase):
             property_types = {}
 
         resource = NewResource("SomeId")
-        self.assertEquals(0, len(resource.runtime_attrs))
+        self.assertEqual(0, len(resource.runtime_attrs))
 
 class TestSamResourceReferableProperties(TestCase):
 
@@ -172,14 +172,14 @@ class TestSamResourceReferableProperties(TestCase):
         self.supported_resource_refs = \
             sam_resource.get_resource_references(cfn_resources, self.supported_resource_refs)
 
-        self.assertEquals("logicalId1", self.supported_resource_refs.get("SamLogicalId", "prop1"))
-        self.assertEquals("logicalId2", self.supported_resource_refs.get("SamLogicalId", "prop2"))
+        self.assertEqual("logicalId1", self.supported_resource_refs.get("SamLogicalId", "prop1"))
+        self.assertEqual("logicalId2", self.supported_resource_refs.get("SamLogicalId", "prop2"))
 
         # there is no cfn resource of for "prop3" in the cfn_resources list
-        self.assertEquals(None, self.supported_resource_refs.get("SamLogicalId", "prop3"))
+        self.assertEqual(None, self.supported_resource_refs.get("SamLogicalId", "prop3"))
 
         # Must add only for the given SAM resource
-        self.assertEquals(1, len(self.supported_resource_refs))
+        self.assertEqual(1, len(self.supported_resource_refs))
 
     def test_must_work_with_two_resources_of_same_type(self):
         class NewSamResource(SamResourceMacro):
@@ -204,12 +204,12 @@ class TestSamResourceReferableProperties(TestCase):
         self.supported_resource_refs = \
             sam_resource2.get_resource_references(cfn_resources, self.supported_resource_refs)
 
-        self.assertEquals("logicalId1", self.supported_resource_refs.get("SamLogicalId1", "prop1"))
-        self.assertEquals("logicalId2", self.supported_resource_refs.get("SamLogicalId1", "prop2"))
-        self.assertEquals("logicalId1", self.supported_resource_refs.get("SamLogicalId2", "prop1"))
-        self.assertEquals("logicalId2", self.supported_resource_refs.get("SamLogicalId2", "prop2"))
+        self.assertEqual("logicalId1", self.supported_resource_refs.get("SamLogicalId1", "prop1"))
+        self.assertEqual("logicalId2", self.supported_resource_refs.get("SamLogicalId1", "prop2"))
+        self.assertEqual("logicalId1", self.supported_resource_refs.get("SamLogicalId2", "prop1"))
+        self.assertEqual("logicalId2", self.supported_resource_refs.get("SamLogicalId2", "prop2"))
 
-        self.assertEquals(2, len(self.supported_resource_refs))
+        self.assertEqual(2, len(self.supported_resource_refs))
 
     def test_must_skip_unknown_resource_types(self):
         class NewSamResource(SamResourceMacro):
@@ -229,7 +229,7 @@ class TestSamResourceReferableProperties(TestCase):
         self.supported_resource_refs = \
             sam_resource.get_resource_references(cfn_resources, self.supported_resource_refs)
 
-        self.assertEquals(0, len(self.supported_resource_refs))
+        self.assertEqual(0, len(self.supported_resource_refs))
 
     def test_must_skip_if_no_supported_properties(self):
         class NewSamResource(SamResourceMacro):
@@ -245,7 +245,7 @@ class TestSamResourceReferableProperties(TestCase):
         self.supported_resource_refs = \
             sam_resource.get_resource_references(cfn_resources, self.supported_resource_refs)
 
-        self.assertEquals(0, len(self.supported_resource_refs))
+        self.assertEqual(0, len(self.supported_resource_refs))
 
     def test_must_skip_if_no_resources(self):
         class NewSamResource(SamResourceMacro):
@@ -260,7 +260,7 @@ class TestSamResourceReferableProperties(TestCase):
         self.supported_resource_refs = \
             sam_resource.get_resource_references(cfn_resources, self.supported_resource_refs)
 
-        self.assertEquals(0, len(self.supported_resource_refs))
+        self.assertEqual(0, len(self.supported_resource_refs))
 
     def test_must_raise_if_input_is_absent(self):
         class NewSamResource(SamResourceMacro):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -20,7 +20,7 @@ class TestSamPluginsRegistration(TestCase):
 
         self.sam_plugins.register(self.mock_plugin)
 
-        self.assertEquals(self.mock_plugin, self.sam_plugins._get(self.mock_plugin_name))
+        self.assertEqual(self.mock_plugin, self.sam_plugins._get(self.mock_plugin_name))
 
     def test_register_must_raise_on_duplicate_plugin(self):
 
@@ -50,7 +50,7 @@ class TestSamPluginsRegistration(TestCase):
 
         expected = [plugin1, plugin2, plugin3]
 
-        self.assertEquals(expected, self.sam_plugins._plugins)
+        self.assertEqual(expected, self.sam_plugins._plugins)
 
     def test_must_register_plugins_list_on_initialization(self):
 
@@ -62,7 +62,7 @@ class TestSamPluginsRegistration(TestCase):
         new_sam_plugin = SamPlugins(plugins_list)
 
         # Also make sure the plugins are in the same order as in input
-        self.assertEquals(plugins_list, new_sam_plugin._plugins)
+        self.assertEqual(plugins_list, new_sam_plugin._plugins)
 
     def test_must_register_single_plugin_on_initialization(self):
         new_sam_plugin = SamPlugins(self.mock_plugin)
@@ -76,7 +76,7 @@ class TestSamPluginsRegistration(TestCase):
         self.sam_plugins.register(plugin1)
         self.sam_plugins.register(plugin2)
 
-        self.assertEquals(2, len(self.sam_plugins))
+        self.assertEqual(2, len(self.sam_plugins))
 
     def test_is_registered_must_find_registered_plugins(self):
         self.sam_plugins.register(self.mock_plugin)
@@ -101,8 +101,8 @@ class TestSamPluginsRegistration(TestCase):
         self.sam_plugins.register(plugin1)
         self.sam_plugins.register(plugin2)
 
-        self.assertEquals(plugin1, self.sam_plugins._get(plugin1.name))
-        self.assertEquals(plugin2, self.sam_plugins._get(plugin2.name))
+        self.assertEqual(plugin1, self.sam_plugins._get(plugin1.name))
+        self.assertEqual(plugin2, self.sam_plugins._get(plugin2.name))
 
     def test_get_must_handle_no_registered_plugins(self):
 
@@ -282,7 +282,7 @@ class TestBasePlugin(TestCase):
 
         name = "some name"
         plugin = BasePlugin(name)
-        self.assertEquals(name, plugin.name)
+        self.assertEqual(name, plugin.name)
 
     def test_initialization_without_name_must_raise_exception(self):
 
@@ -299,7 +299,7 @@ class TestBasePlugin(TestCase):
         plugin.on_before_transform_resource(data_mock, data_mock, data_mock)
 
         # `method_calls` tracks calls to the mock, its methods, attributes, and *their* methods & attributes
-        self.assertEquals([], data_mock.method_calls)
+        self.assertEqual([], data_mock.method_calls)
 
 
 def _make_mock_plugin(name):

--- a/tests/translator/test_api_resource.py
+++ b/tests/translator/test_api_resource.py
@@ -136,8 +136,8 @@ class TestApiGatewayDeploymentResource(TestCase):
         deployment = ApiGatewayDeployment(logical_id=prefix)
         deployment.make_auto_deployable(stage, swagger=swagger)
 
-        self.assertEquals(deployment.logical_id, id_val)
-        self.assertEquals(deployment.Description, "RestApi deployment id: {}".format(full_hash))
+        self.assertEqual(deployment.logical_id, id_val)
+        self.assertEqual(deployment.Description, "RestApi deployment id: {}".format(full_hash))
 
         LogicalIdGeneratorMock.assert_called_once_with(prefix, str(swagger))
         generator_mock.gen.assert_called_once_with()
@@ -151,8 +151,8 @@ class TestApiGatewayDeploymentResource(TestCase):
         deployment = ApiGatewayDeployment(logical_id=prefix)
         deployment.make_auto_deployable(stage, swagger=None)
 
-        self.assertEquals(deployment.logical_id, prefix)
-        self.assertEquals(deployment.Description, None)
+        self.assertEqual(deployment.logical_id, prefix)
+        self.assertEqual(deployment.Description, None)
 
         LogicalIdGeneratorMock.assert_not_called()
         stage.update_deployment_ref.assert_not_called()

--- a/tests/translator/test_function_resources.py
+++ b/tests/translator/test_function_resources.py
@@ -55,15 +55,15 @@ class TestVersionsAndAliases(TestCase):
         resources = sam_func.to_cloudformation(**kwargs)
 
         # Function, Version, Alias, IAM Role
-        self.assertEquals(len(resources), 4)
+        self.assertEqual(len(resources), 4)
 
         aliases = [r.to_dict() for r in resources if r.resource_type == LambdaAlias.resource_type]
         versions = [r.to_dict() for r in resources if r.resource_type == LambdaVersion.resource_type]
-        self.assertEquals(len(aliases), 1)
-        self.assertEquals(len(versions), 1)
+        self.assertEqual(len(aliases), 1)
+        self.assertEqual(len(versions), 1)
 
         alias = list(aliases[0].values())[0]["Properties"]
-        self.assertEquals(alias["Name"], alias_name)
+        self.assertEqual(alias["Name"], alias_name)
         # We don't need to do any deeper validation here because there is a separate SAM template -> CFN template conversion test
         # that will care of validating all properties & connections
 
@@ -232,7 +232,7 @@ class TestVersionsAndAliases(TestCase):
 
         self.intrinsics_resolver_mock.resolve_parameter_refs.assert_called_with(enabled)
         # Function, IAM Role
-        self.assertEquals(len(resources), 2)
+        self.assertEqual(len(resources), 2)
 
     @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     @patch.object(SamFunction, "_get_resolved_alias_name")
@@ -481,7 +481,7 @@ class TestVersionsAndAliases(TestCase):
         self.intrinsics_resolver_mock.resolve_parameter_refs.return_value = alias_name
 
         result = self.sam_func._get_resolved_alias_name(property_name, alias_value, self.intrinsics_resolver_mock)
-        self.assertEquals(alias_name, result)
+        self.assertEqual(alias_name, result)
 
     def test_get_resolved_alias_name_must_error_if_intrinsics_are_not_resolved(self):
 
@@ -497,7 +497,7 @@ class TestVersionsAndAliases(TestCase):
             self.sam_func._get_resolved_alias_name(property_name, alias_value, self.intrinsics_resolver_mock)
 
         ex = raises_assert.exception
-        self.assertEquals(expected_exception_msg, ex.message)
+        self.assertEqual(expected_exception_msg, ex.message)
 
     def test_get_resolved_alias_name_must_error_if_intrinsics_are_not_resolved_with_list(self):
 
@@ -513,7 +513,7 @@ class TestVersionsAndAliases(TestCase):
             self.sam_func._get_resolved_alias_name(property_name, alias_value, self.intrinsics_resolver_mock)
 
         ex = raises_assert.exception
-        self.assertEquals(expected_exception_msg, ex.message)
+        self.assertEqual(expected_exception_msg, ex.message)
 
 
     def _make_lambda_function(self, logical_id):
@@ -545,6 +545,6 @@ class TestSupportedResourceReferences(TestCase):
     def test_must_not_break_support(self):
 
         func = SamFunction("LogicalId")
-        self.assertEquals(2, len(func.referable_properties))
-        self.assertEquals(func.referable_properties["Alias"], "AWS::Lambda::Alias")
-        self.assertEquals(func.referable_properties["Version"], "AWS::Lambda::Version")
+        self.assertEqual(2, len(func.referable_properties))
+        self.assertEqual(func.referable_properties["Alias"], "AWS::Lambda::Alias")
+        self.assertEqual(func.referable_properties["Version"], "AWS::Lambda::Version")

--- a/tests/translator/test_logical_id_generator.py
+++ b/tests/translator/test_logical_id_generator.py
@@ -18,10 +18,10 @@ class TestLogicalIdGenerator(TestCase):
 
         generator = LogicalIdGenerator(self.prefix)
 
-        self.assertEquals(self.prefix, generator.gen())
+        self.assertEqual(self.prefix, generator.gen())
 
         # Calling gen() again should return the same result
-        self.assertEquals(generator.gen(), generator.gen())
+        self.assertEqual(generator.gen(), generator.gen())
 
         stringify_mock.assert_not_called()
 

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -635,7 +635,7 @@ class TestParameterValuesHandling(TestCase):
         translator = Translator({}, sam_parser)
         result = translator._add_default_parameter_values(sam_template,
             parameter_values)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_add_default_parameter_values_must_override_user_specified_values(self):
         parameter_values = {
@@ -659,7 +659,7 @@ class TestParameterValuesHandling(TestCase):
         sam_parser = Parser()
         translator = Translator({}, sam_parser)
         result = translator._add_default_parameter_values(sam_template, parameter_values)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
     def test_add_default_parameter_values_must_skip_params_without_defaults(self):
         parameter_values = {
@@ -684,7 +684,7 @@ class TestParameterValuesHandling(TestCase):
         sam_parser = Parser()
         translator = Translator({}, sam_parser)
         result = translator._add_default_parameter_values(sam_template, parameter_values)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
 
     @parameterized.expand([
@@ -717,7 +717,7 @@ class TestParameterValuesHandling(TestCase):
         translator = Translator({}, sam_parser)
         result = translator._add_default_parameter_values(
             sam_template, parameter_values)
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
 
 
 class TestTemplateValidation(TestCase):
@@ -768,7 +768,7 @@ class TestPluginsUsage(TestCase):
         make_policy_template_for_function_plugin_mock.return_value = plugin_instance
 
         sam_plugins = prepare_plugins([])
-        self.assertEquals(5, len(sam_plugins))
+        self.assertEqual(5, len(sam_plugins))
 
     @patch("samtranslator.translator.translator.make_policy_template_for_function_plugin")
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
@@ -779,13 +779,13 @@ class TestPluginsUsage(TestCase):
 
         custom_plugin = BasePlugin("someplugin")
         sam_plugins = prepare_plugins([custom_plugin])
-        self.assertEquals(6, len(sam_plugins))
+        self.assertEqual(6, len(sam_plugins))
 
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
     def test_prepare_plugins_must_handle_empty_input(self):
 
         sam_plugins = prepare_plugins(None)
-        self.assertEquals(5, len(sam_plugins))
+        self.assertEqual(5, len(sam_plugins))
 
     @patch("samtranslator.translator.translator.PolicyTemplatesProcessor")
     @patch("samtranslator.translator.translator.PolicyTemplatesForFunctionPlugin")
@@ -806,7 +806,7 @@ class TestPluginsUsage(TestCase):
 
         result = make_policy_template_for_function_plugin()
 
-        self.assertEquals(plugin_instance, result)
+        self.assertEqual(plugin_instance, result)
 
         policy_templates_processor_mock.get_default_policy_templates_json.assert_called_once_with()
         policy_templates_processor_mock.assert_called_once_with(default_templates)


### PR DESCRIPTION
*Issue #, if available:*
None
*Description of changes:*
Python3 was giving a warning for using `assertEquals`, so changed tests to use `assertEqual`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
