### PR TITLE
adding SES Bulk Templated Policy Template

### DIFF
--- a/examples/2016-10-31/policy_templates/all_policy_templates.yaml
+++ b/examples/2016-10-31/policy_templates/all_policy_templates.yaml
@@ -71,6 +71,9 @@ Resources:
         - SESCrudPolicy:
             IdentityName: name
 
+        - SESBulkTemplatedCrudPolicy:
+            IdentityName: name
+
         - SNSCrudPolicy:
             TopicName: name
 

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -697,6 +697,39 @@
         ]
       }
     },
+    "SESBulkTemplatedCrudPolicy": {
+      "Description": "Gives permission to send email, templated email, templated bulk emails and verify identity",
+      "Parameters": {
+        "IdentityName": {
+          "Description": "Identity to give permissions to"
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "ses:GetIdentityVerificationAttributes",
+              "ses:SendEmail",
+              "ses:SendRawEmail",
+              "ses:SendTemplatedEmail",
+              "ses:SendBulkTemplatedEmail",
+              "ses:VerifyEmailIdentity"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
+                {
+                  "identityName": {
+                    "Ref": "IdentityName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
     "SNSCrudPolicy": {
       "Description": "Gives permissions to create, publish and subscribe to SNS topics",
       "Parameters": {

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -70,6 +70,9 @@ Resources:
 
         - SESCrudPolicy:
             IdentityName: name
+        
+        - SESBulkTemplatedCrudPolicy:
+            IdentityName: name
 
         - SNSCrudPolicy:
             TopicName: name

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1117,6 +1117,32 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy47",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "ses:GetIdentityVerificationAttributes",
+                    "ses:SendEmail",
+                    "ses:SendRawEmail",
+                    "ses:SendTemplatedEmail",
+                    "ses:SendBulkTemplatedEmail",
+                    "ses:VerifyEmailIdentity"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
+                      {
+                        "identityName": "name"
+                      }
+                    ]
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1116,6 +1116,32 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy47",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "ses:GetIdentityVerificationAttributes",
+                    "ses:SendEmail",
+                    "ses:SendRawEmail",
+                    "ses:SendTemplatedEmail",
+                    "ses:SendBulkTemplatedEmail",
+                    "ses:VerifyEmailIdentity"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
+                      {
+                        "identityName": "name"
+                      }
+                    ]
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1117,6 +1117,32 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy47",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "ses:GetIdentityVerificationAttributes",
+                    "ses:SendEmail",
+                    "ses:SendRawEmail",
+                    "ses:SendTemplatedEmail",
+                    "ses:SendBulkTemplatedEmail",
+                    "ses:VerifyEmailIdentity"
+                  ],
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:ses:${AWS::Region}:${AWS::AccountId}:identity/${identityName}",
+                      {
+                        "identityName": "name"
+                      }
+                    ]
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {


### PR DESCRIPTION
*Description of changes:*
Add SESBulkTemplatedCrudPolicy which grants the user access to:
- `ses:SendTemplatedEmail`
- `ses:SendBulkTemplatedEmail`

*Use case:*
As a developer I'd like to be able to instantly deploy a serverless component from SAR that can send templated emails and bulk templated emails.
I have published three SAR components for sending emails, two of which are now labeled as having Custom IAM roles, as there isn't a policy template that enables them to use `ses:SendTemplatedEmail` and `ses:SendBulkTemplatedEmail`. 

Here are the links to SAR components:
- [api-lambda-send-templated-email-ses](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:375983427419:applications~api-lambda-send-templated-email-ses)
- [api-lambda-send-bulk-templated-email-ses](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:375983427419:applications~api-lambda-send-bulk-templated-email-ses)

Thank you for taking this into consideration. I would be interested in adding more in the future.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
