### PR TITLE
Add `Type: AWS::Serverless::Application` to the 2016-10-31.md 

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -279,6 +279,7 @@ Outputs.*ApplicationOutputName* | The value of the stack output with name *Appli
 ```yaml
 Resources:
   MyApplication:
+    Type: AWS::Serverless::Application
     Properties:
       Location:
         ApplicationId: 'arn:aws:serverlessrepo:us-east-1:012345678901:applications/my-application'
@@ -287,6 +288,7 @@ Resources:
         StringParameter: parameter-value
         IntegerParameter: 2
   MyOtherApplication:
+    Type: AWS::Serverless::Application
     Properties:
       Location: https://s3-us-east-1.amazonaws.com/demo-bucket/template.yaml
 Outputs:


### PR DESCRIPTION
*Description of changes:*
Adding missed resource `Type` in the documentation example for Nested Apps.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
