### PR TITLE
Update 2016-10-31.md to remove mention of !GetAtt for Serverless API

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -243,7 +243,7 @@ DefinitionUri: swagger.yml
 
 ###### Referencing generated resources - Stage & Deployment
 
-SAM will generate an API Gateway Stage and API Gateway Deployment for every `AWS::Serverless::Api` resource. If you want to refer to these properties in an intrinsic function such as Ref or Fn::GetAtt, you can append `.Stage` and `.Deployment` suffix to the API's Logical ID. SAM will convert it to the correct Logical ID of the auto-generated Stage or Deployment resource respectively.
+SAM will generate an API Gateway Stage and API Gateway Deployment for every `AWS::Serverless::Api` resource. If you want to refer to these properties with the intrinsic function !Ref, you can append `.Stage` and `.Deployment` suffix to the API's Logical ID. SAM will convert it to the correct Logical ID of the auto-generated Stage or Deployment resource respectively.
 
 #### AWS::Serverless::Application
 


### PR DESCRIPTION
*Description of changes:*

`AWS::Serverless::Api` does not support `!GetAtt`. Using as suggested in the docs results in an error:

```
Failed to create the changeset: Waiter ChangeSetCreateComplete failed: Waiter encountered a terminal failure state Status: FAILED. Reason: Template error: resource {Resource Name} does not support attribute type Stage in Fn::GetAtt
```

This is additionally confusing because the convention of `Resource.Attribute` in CloudFormation is normally for `!GetAtt` and not `!Ref`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
