### PR TITLE
fix: Removes trailing slashes from APIGW permissions

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -477,7 +477,7 @@ class Api(PushEventSource):
         return permissions
 
     def _get_permission(self, resources_to_link, stage, suffix):
-        # It turns out that APIGW doesn't like tailing slashes in paths (#665)
+        # It turns out that APIGW doesn't like trailing slashes in paths (#665)
         # and removes as a part of their behaviour, but this isn't documented.
         # The regex removes the tailing slash to ensure the permission works as intended
         path = re.sub(r'([\w:{}\$-/]+)([\/]$)', r'\1', self.Path)

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -479,7 +479,7 @@ class Api(PushEventSource):
     def _get_permission(self, resources_to_link, stage, suffix):
         # It turns out that APIGW doesn't like trailing slashes in paths (#665)
         # and removes as a part of their behaviour, but this isn't documented.
-        # The regex removes the tailing slash to ensure the permission works as intended
+        # The regex removes the trailing slash to ensure the permission works as intended
         path = re.sub(r'([\w:{}\$-/]+)([\/]$)', r'\1', self.Path)
 
         if not stage or not suffix:

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -1,4 +1,5 @@
 import copy
+import re
 from six import string_types
 from samtranslator.model import ResourceMacro, PropertyType
 from samtranslator.model.types import is_type, list_of, dict_of, one_of, is_str
@@ -476,11 +477,15 @@ class Api(PushEventSource):
         return permissions
 
     def _get_permission(self, resources_to_link, stage, suffix):
+        # It turns out that APIGW doesn't like tailing slashes in paths (#665)
+        # and removes as a part of their behaviour, but this isn't documented.
+        # The regex removes the tailing slash to ensure the permission works as intended
+        path = re.sub(r'([\w:{}\$-/]+)([\/]$)', r'\1', self.Path)
 
         if not stage or not suffix:
             raise RuntimeError("Could not add permission to lambda function.")
 
-        path = self.Path.replace('{proxy+}', '*')
+        path = path.replace('{proxy+}', '*')
         method = '*' if self.Method.lower() == 'any' else self.Method.upper()
 
         api_id = self.RestApiId

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -479,8 +479,8 @@ class Api(PushEventSource):
     def _get_permission(self, resources_to_link, stage, suffix):
         # It turns out that APIGW doesn't like trailing slashes in paths (#665)
         # and removes as a part of their behaviour, but this isn't documented.
-        # The regex removes the trailing slash to ensure the permission works as intended
-        path = re.sub(r'([\w:{}\$-/]+)([\/]$)', r'\1', self.Path)
+        # The regex removes the tailing slash to ensure the permission works as intended
+        path = re.sub(r'^(.+)/$', r'\1', self.Path)
 
         if not stage or not suffix:
             raise RuntimeError("Could not add permission to lambda function.")

--- a/tests/model/eventsources/test_api_event_source.py
+++ b/tests/model/eventsources/test_api_event_source.py
@@ -62,18 +62,3 @@ class ApiEventSource(TestCase):
             raise AttributeError("Arn not found")
 
         return arn
-
-# {
-#     'Type': 'AWS::Lambda::Permission',
-#     'Properties': {
-#         'Action': 'lambda:invokeFunction',
-#         'FunctionName': {'Ref': 'func'},
-#         'Principal': 'apigateway.amazonaws.com',
-#         'SourceArn': {
-#             'Fn::Sub': [
-#                 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo',
-#                 {'__ApiId__': 'abc123', '__Stage__': '*'}
-#             ]
-#         }
-#     }
-# }

--- a/tests/model/eventsources/test_api_event_source.py
+++ b/tests/model/eventsources/test_api_event_source.py
@@ -51,6 +51,20 @@ class ApiEventSource(TestCase):
 
         self.assertEqual(arn, "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo")
 
+    @patch("boto3.session.Session.region_name", "eu-west-2")
+    def test_get_permission_with_just_slash(self):
+        self.api_event_source.Path = "/"
+        cfn = self.api_event_source.to_cloudformation(function=self.func, explicit_api={})
+
+        perm = cfn[0]
+        self.assertIsInstance(perm, LambdaPermission)
+
+        try:
+            arn = self._extract_path_from_arn("{}PermissionTest".format(self.logical_id), perm)
+        except AttributeError:
+            self.fail("Permission class isn't valid")
+
+        self.assertEqual(arn, "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/")
 
     def _extract_path_from_arn(self, logical_id, perm):
         arn = perm.to_dict().get(logical_id, {}) \

--- a/tests/model/eventsources/test_api_event_source.py
+++ b/tests/model/eventsources/test_api_event_source.py
@@ -1,0 +1,79 @@
+from mock import Mock, patch
+from unittest import TestCase
+
+from samtranslator.model.eventsources.push import Api
+from samtranslator.model.lambda_ import LambdaFunction, LambdaPermission
+
+class ApiEventSource(TestCase):
+
+    def setUp(self):
+        self.logical_id = "Api"
+
+        self.api_event_source = Api(self.logical_id)
+        self.api_event_source.Path = "/foo"
+        self.api_event_source.Method = "GET"
+        self.api_event_source.RestApiId = "abc123"
+
+        self.permission = Mock()
+        self.permission.logicial_id = "ApiPermission"
+
+        self.func = LambdaFunction("func")
+
+        self.stage = "Prod"
+        self.suffix = "123"
+
+    @patch("boto3.session.Session.region_name", "eu-west-2")
+    def test_get_permission_without_trailing_slash(self):
+        cfn = self.api_event_source.to_cloudformation(function=self.func, explicit_api={})
+
+        perm = cfn[0]
+        self.assertIsInstance(perm, LambdaPermission)
+
+        try:
+            arn = self._extract_path_from_arn("{}PermissionTest".format(self.logical_id), perm)
+        except AttributeError:
+            self.fail("Permission class isn't valid")
+
+        self.assertEqual(arn, "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo")
+
+    @patch("boto3.session.Session.region_name", "eu-west-2")
+    def test_get_permission_with_trailing_slash(self):
+        self.api_event_source.Path = "/foo/"
+        cfn = self.api_event_source.to_cloudformation(function=self.func, explicit_api={})
+
+        perm = cfn[0]
+        self.assertIsInstance(perm, LambdaPermission)
+
+        try:
+            arn = self._extract_path_from_arn("{}PermissionTest".format(self.logical_id), perm)
+        except AttributeError:
+            self.fail("Permission class isn't valid")
+
+        self.assertEqual(arn, "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo")
+
+
+    def _extract_path_from_arn(self, logical_id, perm):
+        arn = perm.to_dict().get(logical_id, {}) \
+                            .get("Properties", {}) \
+                            .get("SourceArn", {}) \
+                            .get("Fn::Sub", [])[0]
+
+        if arn is None:
+            raise AttributeError("Arn not found")
+
+        return arn
+
+# {
+#     'Type': 'AWS::Lambda::Permission',
+#     'Properties': {
+#         'Action': 'lambda:invokeFunction',
+#         'FunctionName': {'Ref': 'func'},
+#         'Principal': 'apigateway.amazonaws.com',
+#         'SourceArn': {
+#             'Fn::Sub': [
+#                 'arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo',
+#                 {'__ApiId__': 'abc123', '__Stage__': '*'}
+#             ]
+#         }
+#     }
+# }


### PR DESCRIPTION
*Issue #, if available:* #665

*Description of changes:*
Adds a regex sub to remove the trailing slash from the path of the Api event source


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
