### PR TITLE
Fix s3 link in application docs example

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -292,7 +292,7 @@ Resources:
   MyOtherApplication:
     Type: AWS::Serverless::Application
     Properties:
-      Location: https://s3-us-east-1.amazonaws.com/demo-bucket/template.yaml
+      Location: https://s3.amazonaws.com/demo-bucket/template.yaml
 Outputs:
   MyNestedApplicationOutput:
     Value: !GetAtt MyApplication.Outputs.ApplicationOutputName


### PR DESCRIPTION
*Description of changes:*
The current s3 link in the example implies that you must have RegionName in the url for an Application Resource's Location. This will give you an error implying that you are trying to use an application from the serverless application repository which is confusing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
