### PR TITLE
Remove comment about CodeUri being unsupported in Globals

### DIFF
--- a/docs/globals.rst
+++ b/docs/globals.rst
@@ -53,7 +53,6 @@ Currently, the following resources and properties are being supported:
       # Properties of AWS::Serverless::Function
       Handler:
       Runtime:
-      # Specifying CodeUri on Globals is not yet supported by 'CloudFormation package' https://docs.aws.amazon.com/cli/latest/reference/cloudformation/package.html
       CodeUri: 
       DeadLetterQueue:
       Description:


### PR DESCRIPTION
CodeUri in Globals seems to be supported by at least sam-cli 0.6.1, making the comment about it being unsupported obsolete.

*Description of changes:*
Remove comment about CodeUri being unsupported in Globals

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
