### PR TITLE
Lambda@Edge Role Required

### DIFF
--- a/examples/2016-10-31/lambda_edge/README.md
+++ b/examples/2016-10-31/lambda_edge/README.md
@@ -21,22 +21,22 @@ We must also create a custom IAM Role which allows `lambda.amazonaws.com` and `e
 
 ```yaml
 LambdaEdgeFunctionRole:
-      Type: "AWS::IAM::Role"
-      Properties:
-          Path: "/"
-          ManagedPolicyArns:
-              - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-          AssumeRolePolicyDocument:
-            Version: "2012-10-17"
-            Statement:
-              - Sid: "AllowLambdaServiceToAssumeRole"
-                Effect: "Allow"
-                Action:
-                  - "sts:AssumeRole"
-                Principal:
-                  Service:
-                    - "lambda.amazonaws.com"
-                    - "edgelambda.amazonaws.com"
+    Type: "AWS::IAM::Role"
+    Properties:
+        Path: "/"
+        ManagedPolicyArns:
+            - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Sid: "AllowLambdaServiceToAssumeRole"
+              Effect: "Allow"
+              Action:
+                - "sts:AssumeRole"
+              Principal:
+                Service:
+                  - "lambda.amazonaws.com"
+                  - "edgelambda.amazonaws.com"
 ```
 
 We can now configure our [Cloudfront Distribution Lambda Association Property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-lambdafunctionassociation.html) to always reference the latest available Lambda Function Version ARN:

--- a/examples/2016-10-31/lambda_edge/README.md
+++ b/examples/2016-10-31/lambda_edge/README.md
@@ -11,9 +11,32 @@ LambdaEdgeFunctionSample:
         CodeUri: src/
         Runtime: nodejs6.10
         Handler: index.handler
+        Role: !GetAtt LambdaEdgeFunctionRole.Arn
         Timeout: 5
         # More info at https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst
         AutoPublishAlias: live 
+```
+
+We must also create a custom IAM Role which allows `lambda.amazonaws.com` and `edgelambda.amazonaws.com` services to assume the role and execute the function.
+
+```yaml
+LambdaEdgeFunctionRole:
+      Type: "AWS::IAM::Role"
+      Properties:
+          Path: "/"
+          ManagedPolicyArns:
+              - "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+          AssumeRolePolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Sid: "AllowLambdaServiceToAssumeRole"
+                Effect: "Allow"
+                Action:
+                  - "sts:AssumeRole"
+                Principal:
+                  Service:
+                    - "lambda.amazonaws.com"
+                    - "edgelambda.amazonaws.com"
 ```
 
 We can now configure our [Cloudfront Distribution Lambda Association Property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cloudfront-distribution-lambdafunctionassociation.html) to always reference the latest available Lambda Function Version ARN:


### PR DESCRIPTION
*Description of changes:*
This PR makes it clearer to a reader looking for Lambda@Edge examples that a custom IAM role is required without the user needing to look deeper into the `stack.yml` file. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
