### PR TITLE
Add Resource Groups readonly policy to SAM

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1560,6 +1560,24 @@
           }
         ]
       }
+    },
+    "ResourceGroupsReadOnlyAccessPolicy": {
+      "Description": "Gives readonly permissions to AWS Resource Groups and list group contents",
+      "Parameters": {},
+      "Definition": {
+        "Statement": [{
+          "Effect": "Allow",
+          "Action": [
+            "resource-groups:Get*",
+            "resource-groups:List*",
+            "resource-groups:Search*",
+            "tag:Get*",
+            "cloudformation:DescribeStacks",
+            "cloudformation:ListStackResources"
+          ],
+          "Resource": "*"
+        }]
+      }
     }
   }
 }

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -143,3 +143,5 @@ Resources:
 
         - SSMParameterReadPolicy:
             ParameterName: name
+
+        - ResourceGroupsReadOnlyAccessPolicy: {}

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1213,6 +1213,25 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy49",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "resource-groups:Get*", 
+                    "resource-groups:List*", 
+                    "resource-groups:Search*", 
+                    "tag:Get*", 
+                    "cloudformation:DescribeStacks", 
+                    "cloudformation:ListStackResources"
+                  ], 
+                  "Resource": "*", 
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1212,6 +1212,25 @@
                 }
               ]
             }
+          }, 
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy49", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "resource-groups:Get*", 
+                    "resource-groups:List*", 
+                    "resource-groups:Search*", 
+                    "tag:Get*", 
+                    "cloudformation:DescribeStacks", 
+                    "cloudformation:ListStackResources"
+                  ], 
+                  "Resource": "*", 
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1213,6 +1213,25 @@
                 }
               ]
             }
+          }, 
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy49", 
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "resource-groups:Get*", 
+                    "resource-groups:List*", 
+                    "resource-groups:Search*", 
+                    "tag:Get*", 
+                    "cloudformation:DescribeStacks", 
+                    "cloudformation:ListStackResources"
+                  ], 
+                  "Resource": "*", 
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {


### PR DESCRIPTION
*Description of changes:*
Adding read-only permissions for AWS Resource Groups to allow examples including Resource Groups.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
