### PR TITLE
Feat/func/add ReservedConcurrentExecutions to globals

### DIFF
--- a/docs/globals.rst
+++ b/docs/globals.rst
@@ -68,6 +68,7 @@ Currently, the following resources and properties are being supported:
       AutoPublishAlias:
       DeploymentPreference:
       PermissionsBoundary:
+      ReservedConcurrentExecutions:
 
     Api:
       # Properties of AWS::Serverless::Api

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -30,7 +30,8 @@ class Globals(object):
             "AutoPublishAlias",
             "Layers",
             "DeploymentPreference",
-            "PermissionsBoundary"
+            "PermissionsBoundary",
+            "ReservedConcurrentExecutions"
         ],
 
         # Everything except

--- a/tests/translator/input/globals_for_function.yaml
+++ b/tests/translator/input/globals_for_function.yaml
@@ -19,6 +19,7 @@ Globals:
     PermissionsBoundary: arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary
     Layers:
       - !Sub arn:${AWS:Partition}:lambda:${AWS:Region}:${AWS:AccountId}:layer:MyLayer:1
+    ReservedConcurrentExecutions: 50
 
 Resources:
   MinimalFunction:
@@ -45,4 +46,5 @@ Resources:
       PermissionsBoundary: arn:aws:1234:iam:boundary/OverridePermissionsBoundary
       Layers:
         - !Sub arn:${AWS:Partition}:lambda:${AWS:Region}:${AWS:AccountId}:layer:MyLayer2:2
+      ReservedConcurrentExecutions: 100
 

--- a/tests/translator/output/aws-cn/globals_for_function.json
+++ b/tests/translator/output/aws-cn/globals_for_function.json
@@ -57,6 +57,7 @@
           }
         ], 
         "MemorySize": 512, 
+        "ReservedConcurrentExecutions": 100, 
         "Environment": {
           "Variables": {
             "Var1": "value1", 
@@ -146,6 +147,7 @@
           }
         ], 
         "MemorySize": 1024, 
+        "ReservedConcurrentExecutions": 50, 
         "Environment": {
           "Variables": {
             "Var1": "value1", 

--- a/tests/translator/output/aws-us-gov/globals_for_function.json
+++ b/tests/translator/output/aws-us-gov/globals_for_function.json
@@ -57,6 +57,7 @@
           }
         ], 
         "MemorySize": 512, 
+        "ReservedConcurrentExecutions": 100, 
         "Environment": {
           "Variables": {
             "Var1": "value1", 
@@ -146,6 +147,7 @@
           }
         ], 
         "MemorySize": 1024, 
+        "ReservedConcurrentExecutions": 50, 
         "Environment": {
           "Variables": {
             "Var1": "value1", 

--- a/tests/translator/output/error_globals_unsupported_property.json
+++ b/tests/translator/output/error_globals_unsupported_property.json
@@ -1,8 +1,8 @@
 {
   "errors": [
     {
-      "errorMessage": "'Globals' section is invalid. 'SomeKey' is not a supported property of 'Function'. Must be one of the following values - ['Handler', 'Runtime', 'CodeUri', 'DeadLetterQueue', 'Description', 'MemorySize', 'Timeout', 'VpcConfig', 'Environment', 'Tags', 'Tracing', 'KmsKeyArn', 'AutoPublishAlias', 'Layers', 'DeploymentPreference', 'PermissionsBoundary']"
+      "errorMessage": "'Globals' section is invalid. 'SomeKey' is not a supported property of 'Function'. Must be one of the following values - ['Handler', 'Runtime', 'CodeUri', 'DeadLetterQueue', 'Description', 'MemorySize', 'Timeout', 'VpcConfig', 'Environment', 'Tags', 'Tracing', 'KmsKeyArn', 'AutoPublishAlias', 'Layers', 'DeploymentPreference', 'PermissionsBoundary', 'ReservedConcurrentExecutions']"
     }
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. 'Globals' section is invalid. 'SomeKey' is not a supported property of 'Function'. Must be one of the following values - ['Handler', 'Runtime', 'CodeUri', 'DeadLetterQueue', 'Description', 'MemorySize', 'Timeout', 'VpcConfig', 'Environment', 'Tags', 'Tracing', 'KmsKeyArn', 'AutoPublishAlias', 'Layers', 'DeploymentPreference', 'PermissionsBoundary']"
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. 'Globals' section is invalid. 'SomeKey' is not a supported property of 'Function'. Must be one of the following values - ['Handler', 'Runtime', 'CodeUri', 'DeadLetterQueue', 'Description', 'MemorySize', 'Timeout', 'VpcConfig', 'Environment', 'Tags', 'Tracing', 'KmsKeyArn', 'AutoPublishAlias', 'Layers', 'DeploymentPreference', 'PermissionsBoundary', 'ReservedConcurrentExecutions']"
 }

--- a/tests/translator/output/globals_for_function.json
+++ b/tests/translator/output/globals_for_function.json
@@ -57,6 +57,7 @@
           }
         ], 
         "MemorySize": 512, 
+        "ReservedConcurrentExecutions": 100, 
         "Environment": {
           "Variables": {
             "Var1": "value1", 
@@ -146,6 +147,7 @@
           }
         ], 
         "MemorySize": 1024, 
+        "ReservedConcurrentExecutions": 50, 
         "Environment": {
           "Variables": {
             "Var1": "value1", 


### PR DESCRIPTION
*Issue #, if available:* #760

*Description of changes:* Added "ReservedConcurrentExecutions" to the list of supported global properties for the AWS::Serverless::Function resource. PR also includes updates to relevant tests and an update to the Globals support doc.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
