### PR TITLE
Added VersionDescription property on  Serverless::Function

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -53,7 +53,8 @@ class SamFunction(SamResourceMacro):
         'Layers': PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
 
         # Intrinsic functions in value of Alias property are not supported, yet
-        'AutoPublishAlias': PropertyType(False, one_of(is_str()))
+        'AutoPublishAlias': PropertyType(False, one_of(is_str())),
+        'VersionDescription': PropertyType(False, is_str())
     }
     event_resolver = ResourceTypeResolver(samtranslator.model.eventsources, samtranslator.model.eventsources.pull,
                                           samtranslator.model.eventsources.push,
@@ -359,6 +360,7 @@ class SamFunction(SamResourceMacro):
 
         lambda_version = LambdaVersion(logical_id=logical_id, attributes=attributes)
         lambda_version.FunctionName = function.get_runtime_attr('name')
+        lambda_version.Description = self.VersionDescription
 
         return lambda_version
 

--- a/tests/model/test_sam_resources.py
+++ b/tests/model/test_sam_resources.py
@@ -4,7 +4,7 @@ import pytest
 
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.model import InvalidResourceException
-from samtranslator.model.lambda_ import LambdaFunction
+from samtranslator.model.lambda_ import LambdaFunction, LambdaVersion
 from samtranslator.model.sam_resources import SamFunction
 
 
@@ -22,6 +22,7 @@ class TestCodeUri(TestCase):
         function = SamFunction("foo")
         function.CodeUri = "s3://foobar/foo.zip"
 
+
         cfnResources = function.to_cloudformation(**self.kwargs)
         generatedFunctionList = [x for x in cfnResources if isinstance(x, LambdaFunction)]
         self.assertEqual(generatedFunctionList.__len__(), 1)
@@ -29,6 +30,7 @@ class TestCodeUri(TestCase):
             "S3Key": "foo.zip",
             "S3Bucket": "foobar",
         })
+
 
     @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     def test_with_zip_file(self):
@@ -46,3 +48,25 @@ class TestCodeUri(TestCase):
         function = SamFunction("foo")
         with pytest.raises(InvalidResourceException):
             function.to_cloudformation(**self.kwargs)
+
+class TestVersionDescription(TestCase):
+    kwargs = {
+        'intrinsics_resolver': IntrinsicsResolver({}),
+        'event_resources': [],
+        'managed_policy_map': {
+            "foo": "bar"
+        }
+    }
+
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
+    def test_with_version_description(self):
+        function = SamFunction("foo")
+        test_description = "foobar"
+
+        function.CodeUri = "s3://foobar/foo.zip"
+        function.VersionDescription = test_description
+        function.AutoPublishAlias = "live"
+
+        cfnResources = function.to_cloudformation(**self.kwargs)
+        generateFunctionVersion = [x for x in cfnResources if isinstance(x, LambdaVersion)]
+        self.assertEqual(generateFunctionVersion[0].Description, test_description)

--- a/tests/translator/input/function_with_alias.yaml
+++ b/tests/translator/input/function_with_alias.yaml
@@ -6,4 +6,5 @@ Resources:
       Handler: hello.handler
       Runtime: python2.7
       AutoPublishAlias: live
+      VersionDescription: sam-testing
 

--- a/tests/translator/output/aws-cn/function_with_alias.json
+++ b/tests/translator/output/aws-cn/function_with_alias.json
@@ -4,6 +4,7 @@
       "DeletionPolicy": "Retain", 
       "Type": "AWS::Lambda::Version", 
       "Properties": {
+        "Description": "sam-testing",
         "FunctionName": {
           "Ref": "MinimalFunction"
         }

--- a/tests/translator/output/aws-us-gov/function_with_alias.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias.json
@@ -4,6 +4,7 @@
       "DeletionPolicy": "Retain", 
       "Type": "AWS::Lambda::Version", 
       "Properties": {
+        "Description": "sam-testing",
         "FunctionName": {
           "Ref": "MinimalFunction"
         }

--- a/tests/translator/output/function_with_alias.json
+++ b/tests/translator/output/function_with_alias.json
@@ -4,6 +4,7 @@
       "DeletionPolicy": "Retain", 
       "Type": "AWS::Lambda::Version", 
       "Properties": {
+        "Description": "sam-testing",
         "FunctionName": {
           "Ref": "MinimalFunction"
         }

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -124,6 +124,7 @@ DeadLetterQueue | `map` <span>&#124;</span> [DeadLetterQueue Object](#deadletter
 DeploymentPreference | [DeploymentPreference Object](#deploymentpreference-object) | Settings to enable Safe Lambda Deployments. Read the [usage guide](../docs/safe_lambda_deployments.rst) for detailed information.
 Layers | list of `string` | List of LayerVersion ARNs that should be used by this function. The order specified here is the order that they will be imported when running the Lambda function. 
 AutoPublishAlias | `string` | Name of the Alias. Read [AutoPublishAlias Guide](../docs/safe_lambda_deployments.rst#instant-traffic-shifting-using-lambda-aliases) for how it works
+VersionDescription | `string` | A string that specifies the Description field which will be added on the new lambda version
 ReservedConcurrentExecutions | `integer` | The maximum of concurrent executions you want to reserve for the function. For more information see [AWS Documentation on managing concurrency](https://docs.aws.amazon.com/lambda/latest/dg/concurrent-executions.html)
 
 ##### Return values


### PR DESCRIPTION
*Issue #, if available:*
[#823](https://github.com/awslabs/serverless-application-model/issues/823l)
*Description of changes:*
This PR Add an Additional `VersionDescription` property on Serverless::Function.  
*Description of how you validated changes:*
I validated the changes by creating an instance of `SamFunction` and then setting the `VersionDescription` property of the instance. after this i called the `to_cloudformation` method of `SamFunction` and validated that the string passed in `VersionDescription` is proprly set on the instance of `LambdaVersion` class under `Description` property.

*Checklist:*

- [ x] Write/update tests
- [ x] `make pr` passes
- [ ] Update documentation:   For the Documentation I was not sure which part to update. I though i need to add this inside the `Version/2016-10-31` . but i thought asked this explicitly will be better.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
