### PR TITLE
fix: catch error caused by improper event configuration

### DIFF
--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -136,8 +136,11 @@ class ImplicitApiPlugin(BasePlugin):
             self._add_implicit_api_id_if_necessary(event_properties)
 
             api_id = self._get_api_id(event_properties)
-            path = event_properties["Path"]
-            method = event_properties["Method"]
+            try:
+                path = event_properties["Path"]
+                method = event_properties["Method"]
+            except KeyError as e:
+                raise InvalidEventException(logicalId, "Event is missing key {}.".format(e))
             api_dict = self.api_conditions.setdefault(api_id, {})
             method_conditions = api_dict.setdefault(path, {})
             method_conditions[method] = condition

--- a/tests/plugins/api/test_implicit_api_plugin.py
+++ b/tests/plugins/api/test_implicit_api_plugin.py
@@ -398,6 +398,31 @@ class TestImplicitApiPlugin_process_api_events(TestCase):
 
         function_events_mock.update.assert_called_with(api_events)
 
+    def test_must_verify_expected_keys_exist(self):
+
+        api_events = {
+            "Api1": {
+                "Type": "Api",
+                "Properties": {
+                    "Path": "/",
+                    "Methid": "POST"
+                }
+            }
+        }
+
+        template = Mock()
+        function_events_mock = Mock()
+        function = SamResource({
+            "Type": SamResourceType.Function.value,
+            "Properties": {
+                "Events": function_events_mock
+            }
+        })
+        function_events_mock.update = Mock()
+
+        with self.assertRaises(InvalidEventException) as context:
+            self.plugin._process_api_events(function, api_events, template)
+
     def test_must_skip_events_without_properties(self):
 
         api_events = {


### PR DESCRIPTION
*Issue #, if available:*
#766 
*Description of changes:*
Handle key error from missing event keys.
*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
