### PR TITLE
fix(policy-templates): Add more actions to ServerlessRepoReadWriteAccessPolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -927,9 +927,11 @@
             "Action": [
               "serverlessrepo:CreateApplication",
               "serverlessrepo:CreateApplicationVersion",
+              "serverlessrepo:UpdateApplication",
               "serverlessrepo:GetApplication",
               "serverlessrepo:ListApplications",
-              "serverlessrepo:ListApplicationVersions"
+              "serverlessrepo:ListApplicationVersions",
+              "serverlessrepo:ListApplicationDependencies"
             ],
             "Resource": [
               {

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -725,9 +725,11 @@
                   "Action": [
                     "serverlessrepo:CreateApplication",
                     "serverlessrepo:CreateApplicationVersion",
+                    "serverlessrepo:UpdateApplication",
                     "serverlessrepo:GetApplication",
                     "serverlessrepo:ListApplications",
-                    "serverlessrepo:ListApplicationVersions"
+                    "serverlessrepo:ListApplicationVersions",
+                    "serverlessrepo:ListApplicationDependencies"
                   ],
                   "Resource": [
                     {

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -724,9 +724,11 @@
                   "Action": [
                     "serverlessrepo:CreateApplication",
                     "serverlessrepo:CreateApplicationVersion",
+                    "serverlessrepo:UpdateApplication",
                     "serverlessrepo:GetApplication",
                     "serverlessrepo:ListApplications",
-                    "serverlessrepo:ListApplicationVersions"
+                    "serverlessrepo:ListApplicationVersions",
+                    "serverlessrepo:ListApplicationDependencies"
                   ],
                   "Resource": [
                     {

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -724,9 +724,11 @@
                   "Action": [
                     "serverlessrepo:CreateApplication",
                     "serverlessrepo:CreateApplicationVersion",
+                    "serverlessrepo:UpdateApplication",
                     "serverlessrepo:GetApplication",
                     "serverlessrepo:ListApplications",
-                    "serverlessrepo:ListApplicationVersions"
+                    "serverlessrepo:ListApplicationVersions",
+                    "serverlessrepo:ListApplicationDependencies"
                   ],
                   "Resource": [
                     {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
SAR policy template was missing UpdateApplication operation. Added that and also new ListApplicationDependencies API.

*Description of how you validated changes:*
make pr passes. Verified new actions against [this docs page](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/serverlessrepo-api-permissions-ref.html).

*Checklist:*

- [ x ] Write/update tests
- [ x ] `make pr` passes
- n/a Update documentation - [This page](https://docs.aws.amazon.com/serverlessrepo/latest/devguide/using-aws-sam.html#serverlessrepo-read-write-access-policy) will need to be updated, but only after release.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
