### PR TITLE
Fix ElasticsearchHttpPostPolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -261,7 +261,7 @@
             ],
             "Resource": {
               "Fn::Sub": [
-                "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}",
+                "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}/*",
                 {
                   "domainName": {
                     "Ref": "DomainName"

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -212,7 +212,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}",
+                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}/*",
                       {
                         "domainName": "name"
                       }

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -211,7 +211,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}",
+                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}/*",
                       {
                         "domainName": "name"
                       }

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -211,7 +211,7 @@
                   ],
                   "Resource": {
                     "Fn::Sub": [
-                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}",
+                      "arn:${AWS::Partition}:es:${AWS::Region}:${AWS::AccountId}:domain/${domainName}/*",
                       {
                         "domainName": "name"
                       }


### PR DESCRIPTION

*Description of changes:*
Added /* to resource to fix Unauthorized error for es:ESHttpPost action.

*Description of how you validated changes:*

Created a custom policy and tested to remove unauthorized error.
```yaml
        Policies:
          - Statement:
            - Effect: Allow
              Action:
                - es:ESHttpPost
              Resource: !Sub 'arn:aws:es:${AWS::Region}:${AWS::AccountId}:domain/${DomainName}/*'
          # NOTE: Fails to work missing "/*"
          #- ElasticsearchHttpPostPolicy: 
          #    DomainName: !Ref DomainName

```


*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
