### PR TITLE
Noting "httpMethod" attribute is for lambda call

### DIFF
--- a/examples/2016-10-31/api_swagger_cors/swagger.yaml
+++ b/examples/2016-10-31/api_swagger_cors/swagger.yaml
@@ -24,7 +24,7 @@ paths:
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaFunction.Arn}/invocations"
 
         passthroughBehavior: when_no_match
-        httpMethod: POST
+        httpMethod: POST  # Keep "POST" when the API definition method is not POST. This "httpMethod" is used to call Lambda.
         type: aws_proxy
   /{proxy+}:
     x-amazon-apigateway-any-method:
@@ -41,7 +41,7 @@ paths:
       x-amazon-apigateway-integration:
         uri: 
           Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${LambdaFunction.Arn}/invocations"
-        httpMethod: POST
+        httpMethod: POST  # Keep "POST" when the API definition method is not POST. This "httpMethod" is used to call Lambda.
         type: aws_proxy
 definitions:
   Empty:


### PR DESCRIPTION
When integrating API Gateway with Lambda, "httpMethod" in swagger.yaml should be "POST" when defining API method is not POST.
It is kind to let the reader know it, because some people misunderstood it.
see https://forums.aws.amazon.com/thread.jspa?messageID=745275

*Issue #, if available:*

NA

*Description of changes:*

Add comment on "swagger.yaml" in "examples/2016-10-31/api_swagger_cors"

*Description of how you validated changes:*

Open edited "swagger.yaml" with https://editor.swagger.io/ and it have no error about edited lines.

*Checklist:*

- [na] Write/update tests
- [na] `make pr` passes
- [x] Update documentation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
