### PR TITLE
docs: Delete misplaced package.json in several example apps

### DIFF
--- a/examples/apps/cloudfront-ab-test/package.json
+++ b/examples/apps/cloudfront-ab-test/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "algorithmia-blueprint",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "algorithmia": "^0.3.9"
-  }
-}

--- a/examples/apps/cloudfront-access-request-in-response/package.json
+++ b/examples/apps/cloudfront-access-request-in-response/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "algorithmia-blueprint",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "algorithmia": "^0.3.9"
-  }
-}

--- a/examples/apps/cloudfront-http-redirect/package.json
+++ b/examples/apps/cloudfront-http-redirect/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "algorithmia-blueprint",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "algorithmia": "^0.3.9"
-  }
-}

--- a/examples/apps/cloudfront-modify-querystring/package.json
+++ b/examples/apps/cloudfront-modify-querystring/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "algorithmia-blueprint",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "algorithmia": "^0.3.9"
-  }
-}

--- a/examples/apps/cloudfront-modify-response-header/package.json
+++ b/examples/apps/cloudfront-modify-response-header/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "algorithmia-blueprint",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "algorithmia": "^0.3.9"
-  }
-}

--- a/examples/apps/cloudfront-multiple-remote-calls-aggregate-response/package.json
+++ b/examples/apps/cloudfront-multiple-remote-calls-aggregate-response/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "algorithmia-blueprint",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "algorithmia": "^0.3.9"
-  }
-}

--- a/examples/apps/cloudfront-redirect-on-viewer-country/package.json
+++ b/examples/apps/cloudfront-redirect-on-viewer-country/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "algorithmia-blueprint",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "algorithmia": "^0.3.9"
-  }
-}

--- a/examples/apps/cloudfront-response-generation/package.json
+++ b/examples/apps/cloudfront-response-generation/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "algorithmia-blueprint",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "algorithmia": "^0.3.9"
-  }
-}

--- a/examples/apps/cloudfront-simple-remote-call/package.json
+++ b/examples/apps/cloudfront-simple-remote-call/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "algorithmia-blueprint",
-  "version": "1.0.0",
-  "private": true,
-  "dependencies": {
-    "algorithmia": "^0.3.9"
-  }
-}


### PR DESCRIPTION
*Description of changes:*
It looks like the algorithmia-blueprint package.json was copied across several example apps for no good reason. 
These example apps do not have any dependencies(and of course they don't depend on `algorithmia`) so it's best to delete those package.json

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
