### PR TITLE
docs: add Auth to supported Api Global properties

### DIFF
--- a/docs/globals.rst
+++ b/docs/globals.rst
@@ -73,6 +73,7 @@ Currently, the following resources and properties are being supported:
     Api:
       # Properties of AWS::Serverless::Api
       # Also works with Implicit APIs
+      Auth:
       Name:
       DefinitionUri:
       CacheClusterEnabled:


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Add Auth to API globals docs. It is supported in the code: https://github.com/awslabs/serverless-application-model/blob/master/samtranslator/plugins/globals/globals.py#L42
*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
