### PR TITLE
Fix a deprecation warning from jsonschema 3.x

### DIFF
--- a/samtranslator/policy_templates_data/schema.json
+++ b/samtranslator/policy_templates_data/schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Schema for AWS SAM Policy Templates",
 
   "definitions": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

For example, in https://travis-ci.org/awslabs/serverless-application-model/jobs/538917819:
```
/home/travis/build/awslabs/serverless-application-model/.tox/py36/lib/python3.6/site-packages/jsonschema/validators.py:893: DeprecationWarning: The metaschema specified by $schema was not found. Using the latest draft to validate, but this will raise an error in the future.
  cls = validator_for(schema)
```

From the warning message, I think specifying the latest draft of jsonschema keeps the current behavior in samtranslator. Currently the latest draft is draft-07.

*Description of how you validated changes:*

Run the test suite.

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes - does not pass. I think the issue is outside of this PR.
- [ ] Update documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.