### PR TITLE
fix: do not log InvalidDocumentException as an uncaught error

### DIFF
--- a/samtranslator/plugins/__init__.py
+++ b/samtranslator/plugins/__init__.py
@@ -1,6 +1,6 @@
 import logging
 
-from samtranslator.model.exceptions import InvalidResourceException
+from samtranslator.model.exceptions import InvalidResourceException, InvalidDocumentException
 from enum import Enum
 
 
@@ -128,7 +128,7 @@ class SamPlugins(object):
 
             try:
                 getattr(plugin, method_name)(*args, **kwargs)
-            except InvalidResourceException as ex:
+            except (InvalidResourceException, InvalidDocumentException) as ex:
                 # Don't need to log these because they don't result in crashes
                 raise ex
             except Exception as ex:


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
InvalidDocumentExceptions were being logged as uncaught exceptions. This removes this unnecessary logging.
*Description of how you validated changes:*
`make pr` ran and passed. Travis is running.
*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
