### PR TITLE
Adds to documentation intrinsic functions are not working in external swagger files

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -216,7 +216,7 @@ Property Name | Type | Description
 ---|:---:|---
 Name | `string` | A name for the API Gateway RestApi resource.
 StageName | `string` | **Required** The name of the stage, which API Gateway uses as the first path segment in the invoke Uniform Resource Identifier (URI).
-DefinitionUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | S3 URI or location to the Swagger document describing the API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration.
+DefinitionUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | S3 URI or location to the Swagger document describing the API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration. **Note** Intrinsic functions are not supported in external Swagger files, instead use DefinitionBody to define swagger definition.
 DefinitionBody | `JSON or YAML Object` | Swagger specification that describes your API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration.
 CacheClusterEnabled | `boolean` | Indicates whether cache clustering is enabled for the stage.
 CacheClusterSize | `string` | The stage's cache cluster size.

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -216,7 +216,7 @@ Property Name | Type | Description
 ---|:---:|---
 Name | `string` | A name for the API Gateway RestApi resource.
 StageName | `string` | **Required** The name of the stage, which API Gateway uses as the first path segment in the invoke Uniform Resource Identifier (URI).
-DefinitionUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | S3 URI or location to the Swagger document describing the API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration. **Note** Intrinsic functions are not supported in external Swagger files, instead use DefinitionBody to define swagger definition.
+DefinitionUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | S3 URI or location to the Swagger document describing the API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration. **Note** Intrinsic functions are not supported in external Swagger files, instead use DefinitionBody to define Swagger definition.
 DefinitionBody | `JSON or YAML Object` | Swagger specification that describes your API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration.
 CacheClusterEnabled | `boolean` | Indicates whether cache clustering is enabled for the stage.
 CacheClusterSize | `string` | The stage's cache cluster size.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Documentation improvement: stating in the `DefinitionUri` section that intrinsic functions are not supported in the external Swagger files. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
