### PR TITLE
Remove unused CollectionId parameter of RekognitionFacesPolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1051,9 +1051,7 @@
     "RekognitionFacesPolicy": {
       "Description": "Gives permission to compare and detect faces and labels",
       "Parameters": {
-        "CollectionId": {
-          "Description": "ID of the collection"
-        }
+
       },
       "Definition": {
         "Statement": [
@@ -1063,16 +1061,7 @@
               "rekognition:CompareFaces",
               "rekognition:DetectFaces"
             ],
-            "Resource": {
-              "Fn::Sub": [
-                "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
-                {
-                  "collectionId": {
-                    "Ref": "CollectionId"
-                  }
-                }
-              ]
-            }
+            "Resource": "*"
           }
         ]
       }

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -98,8 +98,7 @@ Resources:
 
         - CloudWatchDashboardPolicy: {}
 
-        - RekognitionFacesPolicy:
-            CollectionId: collection
+        - RekognitionFacesPolicy: {}
 
         - RekognitionLabelsPolicy: {}
 

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -809,14 +809,7 @@
                     "rekognition:CompareFaces",
                     "rekognition:DetectFaces"
                   ],
-                  "Resource": {
-                    "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
-                      {
-                        "collectionId": "collection"
-                      }
-                    ]
-                  },
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -808,14 +808,7 @@
                     "rekognition:CompareFaces",
                     "rekognition:DetectFaces"
                   ],
-                  "Resource": {
-                    "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
-                      {
-                        "collectionId": "collection"
-                      }
-                    ]
-                  },
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -808,14 +808,7 @@
                     "rekognition:CompareFaces",
                     "rekognition:DetectFaces"
                   ],
-                  "Resource": {
-                    "Fn::Sub": [
-                      "arn:${AWS::Partition}:rekognition:${AWS::Region}:${AWS::AccountId}:collection/${collectionId}",
-                      {
-                        "collectionId": "collection"
-                      }
-                    ]
-                  },
+                  "Resource": "*",
                   "Effect": "Allow"
                 }
               ]


### PR DESCRIPTION
*Issue:* 
Fixes #974 

*Description of changes:*
Removed unused CollectionId parameter of RekognitionFacesPolicy (policy template)


*Description of how you validated changes:*
- `make test`: passed all tests
- verified transformed template in the steps written in [DEVELOPMENT_GUIDE](https://github.com/awslabs/serverless-application-model/blob/master/DEVELOPMENT_GUIDE.rst#verifying-transforms)

using this SAM template

```
# template.yaml
Resources:
  HogeFugaFunction:
    Type: AWS::Serverless::Function
    Properties:
      CodeUri: src/hogefuga/
      Handler: app.lambda_handler
      Policies:
        - RekognitionFacesPolicy: {}
```

I executed the commands below:

```
aws cloudformation package --template-file MY_TEMPLATE_PATH/template.yaml --output-template-file output-template.yaml --s3-bucket MY_S3_BUCKET
bin/sam-translate.py --template-file=output-template.yaml
```

Then I got expected transformed template like this

```json
...
          {
            "PolicyName": "HogeFugaFunctionRolePolicy1", 
            "PolicyDocument": {
              "Statement": [
                {
                  "Action": [
                    "rekognition:CompareFaces", 
                    "rekognition:DetectFaces"
                  ], 
                  "Resource": "*", 
                  "Effect": "Allow"
                }
              ]
            }
          }
...
```




*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation: 
   - have to update [this document](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-policy-template-list.html#rekognition-faces-policy) when this pr merged.
- [x] Verify transformed template deploys and application functions as expected
- [x]  Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
