### PR TITLE
fix: allow setting InvokeRole to NONE or null

### DIFF
--- a/examples/2016-10-31/api_aws_iam_auth/template.yaml
+++ b/examples/2016-10-31/api_aws_iam_auth/template.yaml
@@ -8,7 +8,7 @@ Resources:
       StageName: Prod
       Auth:
         DefaultAuthorizer: AWS_IAM
-        InvokeRole: CALLER_CREDENTIALS
+        InvokeRole: CALLER_CREDENTIALS # default, set to NONE or null to not require credentials
 
   MyFunction:
     Type: AWS::Serverless::Function

--- a/examples/2016-10-31/api_aws_iam_auth/template.yaml
+++ b/examples/2016-10-31/api_aws_iam_auth/template.yaml
@@ -8,7 +8,7 @@ Resources:
       StageName: Prod
       Auth:
         DefaultAuthorizer: AWS_IAM
-        InvokeRole: CALLER_CREDENTIALS # default, set to NONE or null to not require credentials
+        InvokeRole: CALLER_CREDENTIALS # default, can specify other role or NONE
 
   MyFunction:
     Type: AWS::Serverless::Function

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -169,10 +169,18 @@ class SwaggerEditor(object):
         api_auth_config = api_auth_config or {}
         if method_auth_config.get('Authorizer') == 'AWS_IAM' \
            or api_auth_config.get('DefaultAuthorizer') == 'AWS_IAM' and not method_auth_config:
-            self.paths[path][method][self._X_APIGW_INTEGRATION]['credentials'] = self._generate_integration_credentials(
-                method_invoke_role=method_auth_config.get('InvokeRole'),
-                api_invoke_role=api_auth_config.get('InvokeRole')
+            method_invoke_role = method_auth_config.get('InvokeRole')
+            if not method_invoke_role and 'InvokeRole' in method_auth_config:
+                method_invoke_role = 'NONE'
+            api_invoke_role = api_auth_config.get('InvokeRole')
+            if not api_invoke_role and 'InvokeRole' in api_auth_config:
+                api_invoke_role = 'NONE'
+            credentials = self._generate_integration_credentials(
+                method_invoke_role=method_invoke_role,
+                api_invoke_role=api_invoke_role
             )
+            if credentials and credentials != 'NONE':
+                self.paths[path][method][self._X_APIGW_INTEGRATION]['credentials'] = credentials
 
         # If 'responses' key is *not* present, add it with an empty dict as value
         path_dict[method].setdefault('responses', {})

--- a/tests/translator/input/api_with_aws_iam_auth_overrides.yaml
+++ b/tests/translator/input/api_with_aws_iam_auth_overrides.yaml
@@ -84,3 +84,35 @@ Resources:
             Auth:
               Authorizer: AWS_IAM
               InvokeRole: arn:aws:iam::456::role/something-else
+  MyFunctionNONEInvokeRole:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: index.handler
+      Runtime: nodejs8.10
+      Events:
+        API3:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApiWithAwsIamAuth
+            Method: get
+            Path: /MyFunctionNONEInvokeRole
+            Auth:
+              Authorizer: AWS_IAM
+              InvokeRole: NONE
+  MyFunctionNullInvokeRole:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: index.handler
+      Runtime: nodejs8.10
+      Events:
+        API3:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApiWithAwsIamAuth
+            Method: get
+            Path: /MyFunctionNullInvokeRole
+            Auth:
+              Authorizer: AWS_IAM
+              InvokeRole: null

--- a/tests/translator/input/api_with_aws_iam_auth_overrides.yaml
+++ b/tests/translator/input/api_with_aws_iam_auth_overrides.yaml
@@ -1,4 +1,11 @@
 Resources:
+  MyApiWithAwsIamAuthNoCallerCredentials:
+    Type: "AWS::Serverless::Api"
+    Properties:
+      StageName: Prod
+      Auth:
+        DefaultAuthorizer: AWS_IAM
+        InvokeRole: NONE
   MyApiWithAwsIamAuth:
     Type: "AWS::Serverless::Api"
     Properties:
@@ -116,3 +123,32 @@ Resources:
             Auth:
               Authorizer: AWS_IAM
               InvokeRole: null
+  MyFunctionCallerCredentialsOverride:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: index.handler
+      Runtime: nodejs8.10
+      Events:
+        API3:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApiWithAwsIamAuthNoCallerCredentials
+            Method: get
+            Path: /
+            Auth:
+              Authorizer: AWS_IAM
+              InvokeRole: CALLER_CREDENTIALS
+  MyFunctionNoCallerCredentials:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: index.handler
+      Runtime: nodejs8.10
+      Events:
+        API3:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApiWithAwsIamAuthNoCallerCredentials
+            Method: post
+            Path: /

--- a/tests/translator/output/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/api_with_aws_iam_auth_overrides.json
@@ -1,77 +1,130 @@
 {
   "Resources": {
     "MyFunctionCustomInvokeRole": {
-      "Type": "AWS::Lambda::Function",
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Handler": "index.handler",
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionCustomInvokeRoleRole",
+            "MyFunctionCustomInvokeRoleRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
+    }, 
     "MyFunctionNoneAuth": {
-      "Type": "AWS::Lambda::Function",
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Handler": "index.handler",
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNoneAuthRole",
+            "MyFunctionNoneAuthRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
-    "MyApiWithAwsIamAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage",
+    }, 
+    "MyFunctionNullInvokeRole": {
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeployment8a32fb1652"
-        },
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        },
-        "StageName": "Prod"
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionNullInvokeRoleRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
-    },
+    }, 
+    "MyFunctionNullInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNullInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNONEInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
     "MyFunctionWithoutAuthRole": {
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
+        ], 
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
+          "Version": "2012-10-17", 
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
+              ], 
+              "Effect": "Allow", 
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -81,20 +134,20 @@
           ]
         }
       }
-    },
+    }, 
     "MyFunctionCustomInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionCustomInvokeRole"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole",
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole", 
             {
-              "__Stage__": "Prod",
+              "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -102,20 +155,20 @@
           ]
         }
       }
-    },
+    }, 
     "MyFunctionWithoutAuthAPI2PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionWithoutAuth"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth",
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
             {
-              "__Stage__": "Prod",
+              "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -123,96 +176,143 @@
           ]
         }
       }
-    },
-    "MyApiWithAwsIamAuthDeployment8a32fb1652": {
-      "Type": "AWS::ApiGateway::Deployment",
+    }, 
+    "MyFunctionMyCognitoAuthAPI1PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionMyCognitoAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionDefaultInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionDefaultInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuth": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionMyCognitoAuthRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "MyFunctionNullInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyApiWithAwsIamAuthDeployment3bec5f30f2": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
-        },
-        "Description": "RestApi deployment id: 8a32fb165218ee858b16980eed421b4f38d18f00",
+        }, 
+        "Description": "RestApi deployment id: 3bec5f30f275272b5feee10af30f848d1ce4400d", 
         "StageName": "Stage"
       }
-    },
-    "MyFunctionMyCognitoAuthAPI1PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
+    }, 
+    "MyFunctionNONEInvokeRole": {
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionMyCognitoAuth"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth",
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionMyCognitoAuth": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Handler": "index.handler",
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionMyCognitoAuthRole",
+            "MyFunctionNONEInvokeRoleRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
-    "MyFunctionDefaultInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionDefaultInvokeRole"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole",
-            {
-              "__Stage__": "Prod",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
+    }, 
     "MyFunctionNoneAuthRole": {
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
+        ], 
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
+          "Version": "2012-10-17", 
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
+              ], 
+              "Effect": "Allow", 
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -222,21 +322,21 @@
           ]
         }
       }
-    },
+    }, 
     "MyFunctionCustomInvokeRoleRole": {
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
+        ], 
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
+          "Version": "2012-10-17", 
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
+              ], 
+              "Effect": "Allow", 
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -246,20 +346,20 @@
           ]
         }
       }
-    },
+    }, 
     "MyFunctionDefaultInvokeRoleAPI3PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionDefaultInvokeRole"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole",
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole", 
             {
-              "__Stage__": "*",
+              "__Stage__": "*", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -267,20 +367,41 @@
           ]
         }
       }
-    },
-    "MyFunctionWithoutAuthAPI2PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
+    }, 
+    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNONEInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionWithoutAuthAPI2PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionWithoutAuth"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth",
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
             {
-              "__Stage__": "*",
+              "__Stage__": "*", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -288,43 +409,64 @@
           ]
         }
       }
-    },
+    }, 
     "MyFunctionWithoutAuth": {
-      "Type": "AWS::Lambda::Function",
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Handler": "index.handler",
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionWithoutAuthRole",
+            "MyFunctionWithoutAuthRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
-    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
+    }, 
+    "MyFunctionNullInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNullInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionMyCognitoAuth"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth",
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
             {
-              "__Stage__": "Prod",
+              "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -332,21 +474,21 @@
           ]
         }
       }
-    },
+    }, 
     "MyFunctionDefaultInvokeRoleRole": {
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
+        ], 
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
+          "Version": "2012-10-17", 
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
+              ], 
+              "Effect": "Allow", 
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -356,21 +498,21 @@
           ]
         }
       }
-    },
+    }, 
     "MyFunctionMyCognitoAuthRole": {
-      "Type": "AWS::IAM::Role",
+      "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
+        ], 
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
+          "Version": "2012-10-17", 
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
+              ], 
+              "Effect": "Allow", 
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -380,20 +522,20 @@
           ]
         }
       }
-    },
+    }, 
     "MyFunctionCustomInvokeRoleAPI3PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionCustomInvokeRole"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole",
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole", 
             {
-              "__Stage__": "*",
+              "__Stage__": "*", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -401,43 +543,55 @@
           ]
         }
       }
-    },
+    }, 
     "MyFunctionDefaultInvokeRole": {
-      "Type": "AWS::Lambda::Function",
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Handler": "index.handler",
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionDefaultInvokeRoleRole",
+            "MyFunctionDefaultInvokeRoleRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
-    "MyFunctionNoneAuthAPI3PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
+    }, 
+    "MyApiWithAwsIamAuthProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "DeploymentId": {
+          "Ref": "MyApiWithAwsIamAuthDeployment3bec5f30f2"
+        }, 
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "MyFunctionNoneAuthAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionNoneAuth"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth",
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth", 
             {
-              "__Stage__": "*",
+              "__Stage__": "*", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -445,146 +599,204 @@
           ]
         }
       }
-    },
+    }, 
     "MyApiWithAwsIamAuth": {
-      "Type": "AWS::ApiGateway::RestApi",
+      "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0",
+            "version": "1.0", 
             "title": {
               "Ref": "AWS::StackName"
             }
-          },
+          }, 
           "paths": {
-            "/MyFunctionDefaultInvokeRole": {
-              "get": {
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
-                  "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionDefaultInvokeRole.Arn}/invocations"
-                  },
-                  "credentials": "arn:aws:iam::*:user/*"
-                },
-                "security": [
-                  {
-                    "AWS_IAM": []
-                  }
-                ],
-                "responses": {}
-              }
-            },
             "/MyFunctionWithoutAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithoutAuth.Arn}/invocations"
-                  },
+                  }, 
                   "credentials": "arn:aws:iam::123:role/AUTH_AWS_IAM"
-                },
+                }, 
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ],
+                ], 
                 "responses": {}
               }
-            },
-            "/MyFunctionNoneAuth": {
+            }, 
+            "/MyFunctionNONEInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoneAuth.Arn}/invocations"
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNONEInvokeRole.Arn}/invocations"
                   }
-                },
+                }, 
                 "security": [
                   {
-                    "NONE": []
+                    "AWS_IAM": []
                   }
-                ],
+                ], 
                 "responses": {}
               }
-            },
+            }, 
             "/MyFunctionMyCognitoAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionMyCognitoAuth.Arn}/invocations"
                   }
-                },
+                }, 
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ],
+                ], 
                 "responses": {}
               }
-            },
-            "/MyFunctionCustomInvokeRole": {
+            }, 
+            "/MyFunctionDefaultInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
-                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCustomInvokeRole.Arn}/invocations"
-                  },
-                  "credentials": "arn:aws:iam::456::role/something-else"
-                },
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionDefaultInvokeRole.Arn}/invocations"
+                  }, 
+                  "credentials": "arn:aws:iam::*:user/*"
+                }, 
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ],
+                ], 
+                "responses": {}
+              }
+            }, 
+            "/MyFunctionCustomInvokeRole": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCustomInvokeRole.Arn}/invocations"
+                  }, 
+                  "credentials": "arn:aws:iam::456::role/something-else"
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }
+            }, 
+            "/MyFunctionNullInvokeRole": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNullInvokeRole.Arn}/invocations"
+                  }
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }
+            }, 
+            "/MyFunctionNoneAuth": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoneAuth.Arn}/invocations"
+                  }
+                }, 
+                "security": [
+                  {
+                    "NONE": []
+                  }
+                ], 
                 "responses": {}
               }
             }
-          },
-          "swagger": "2.0",
+          }, 
+          "swagger": "2.0", 
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
+              "in": "header", 
+              "type": "apiKey", 
+              "name": "Authorization", 
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:cognito-idp:xxxxxxxxx"
-                ],
+                ], 
                 "type": "cognito_user_pools"
-              },
+              }, 
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            },
+            }, 
             "AWS_IAM": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
+              "in": "header", 
+              "type": "apiKey", 
+              "name": "Authorization", 
               "x-amazon-apigateway-authtype": "awsSigv4"
             }
           }
         }
       }
-    },
+    }, 
     "MyFunctionNoneAuthAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionNoneAuth"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth",
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth", 
             {
-              "__Stage__": "Prod",
+              "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ]

--- a/tests/translator/output/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/api_with_aws_iam_auth_overrides.json
@@ -90,21 +90,33 @@
         }
       }
     }, 
-    "MyFunctionNONEInvokeRoleAPI3PermissionTest": {
+    "MyApiWithAwsIamAuthProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithAwsIamAuthDeployment3bec5f30f2"
+        }, 
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "MyFunctionCallerCredentialsOverrideAPI3PermissionTest": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
         "Action": "lambda:invokeFunction", 
         "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionNONEInvokeRole"
+          "Ref": "MyFunctionCallerCredentialsOverride"
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
             {
               "__Stage__": "*", 
               "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
               }
             }
           ]
@@ -153,6 +165,84 @@
               }
             }
           ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionMyCognitoAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyApiWithAwsIamAuthNoCallerCredentials": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoCallerCredentials.Arn}/invocations"
+                  }
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }, 
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCallerCredentialsOverride.Arn}/invocations"
+                  }, 
+                  "credentials": "arn:aws:iam::*:user/*"
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }
+            }
+          }, 
+          "swagger": "2.0", 
+          "securityDefinitions": {
+            "AWS_IAM": {
+              "in": "header", 
+              "type": "apiKey", 
+              "name": "Authorization", 
+              "x-amazon-apigateway-authtype": "awsSigv4"
+            }
+          }
         }
       }
     }, 
@@ -266,14 +356,25 @@
         }
       }
     }, 
-    "MyApiWithAwsIamAuthDeployment3bec5f30f2": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "MyFunctionNoCallerCredentialsAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNoCallerCredentials"
         }, 
-        "Description": "RestApi deployment id: 3bec5f30f275272b5feee10af30f848d1ce4400d", 
-        "StageName": "Stage"
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+              }
+            }
+          ]
+        }
       }
     }, 
     "MyFunctionNONEInvokeRole": {
@@ -297,6 +398,27 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    }, 
+    "MyFunctionNoCallerCredentialsAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNoCallerCredentials"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+              }
+            }
+          ]
+        }
       }
     }, 
     "MyFunctionNoneAuthRole": {
@@ -368,46 +490,68 @@
         }
       }
     }, 
-    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
+    "MyApiWithAwsIamAuthDeployment3bec5f30f2": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        }, 
+        "Description": "RestApi deployment id: 3bec5f30f275272b5feee10af30f848d1ce4400d", 
+        "StageName": "Stage"
+      }
+    }, 
+    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment38c75afec1": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+        }, 
+        "Description": "RestApi deployment id: 38c75afec1f32ff6e177b0f49a2b9e86958f594e", 
+        "StageName": "Stage"
+      }
+    }, 
+    "MyFunctionCallerCredentialsOverrideAPI3PermissionProd": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
         "Action": "lambda:invokeFunction", 
         "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionNONEInvokeRole"
+          "Ref": "MyFunctionCallerCredentialsOverride"
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
               }
             }
           ]
         }
       }
     }, 
-    "MyFunctionWithoutAuthAPI2PermissionTest": {
-      "Type": "AWS::Lambda::Permission", 
+    "MyFunctionCallerCredentialsOverride": {
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Action": "lambda:invokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "MyFunctionWithoutAuth"
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
         }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
-            {
-              "__Stage__": "*", 
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionCallerCredentialsOverrideRole", 
+            "Arn"
           ]
-        }
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
     }, 
     "MyFunctionWithoutAuth": {
@@ -454,21 +598,45 @@
         }
       }
     }, 
-    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
+    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
         "Action": "lambda:invokeFunction", 
         "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionMyCognitoAuth"
+          "Ref": "MyFunctionNONEInvokeRole"
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNoCallerCredentialsRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ]
@@ -499,6 +667,72 @@
         }
       }
     }, 
+    "MyFunctionWithoutAuthAPI2PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionWithoutAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionCallerCredentialsOverrideRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNONEInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
     "MyFunctionMyCognitoAuthRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -521,6 +755,18 @@
             }
           ]
         }
+      }
+    }, 
+    "MyApiWithAwsIamAuthNoCallerCredentialsProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment38c75afec1"
+        }, 
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+        }, 
+        "StageName": "Prod"
       }
     }, 
     "MyFunctionCustomInvokeRoleAPI3PermissionTest": {
@@ -567,16 +813,27 @@
         ]
       }
     }, 
-    "MyApiWithAwsIamAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+    "MyFunctionNoCallerCredentials": {
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeployment3bec5f30f2"
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
         }, 
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionNoCallerCredentialsRole", 
+            "Arn"
+          ]
         }, 
-        "StageName": "Prod"
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
     }, 
     "MyFunctionNoneAuthAPI3PermissionTest": {

--- a/tests/translator/output/aws-cn/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/aws-cn/api_with_aws_iam_auth_overrides.json
@@ -1,100 +1,87 @@
 {
   "Resources": {
     "MyFunctionCustomInvokeRole": {
-      "Type": "AWS::Lambda::Function",
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Handler": "index.handler",
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionCustomInvokeRoleRole",
+            "MyFunctionCustomInvokeRoleRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
+    }, 
     "MyFunctionNoneAuth": {
-      "Type": "AWS::Lambda::Function",
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Handler": "index.handler",
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNoneAuthRole",
+            "MyFunctionNoneAuthRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
-    "MyApiWithAwsIamAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage",
+    }, 
+    "MyFunctionNullInvokeRole": {
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymented0a631915"
-        },
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
-        },
-        "StageName": "Prod"
-      }
-    },
-    "MyFunctionWithoutAuthRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionNullInvokeRoleRole", 
+            "Arn"
           ]
-        }
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
-    },
-    "MyFunctionCustomInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
+    }, 
+    "MyFunctionNullInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionCustomInvokeRole"
-        },
+          "Ref": "MyFunctionNullInvokeRole"
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole",
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole", 
             {
-              "__Stage__": "Prod",
+              "__Stage__": "*", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -102,95 +89,30 @@
           ]
         }
       }
-    },
-    "MyFunctionWithoutAuthAPI2PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionWithoutAuth"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth",
-            {
-              "__Stage__": "Prod",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionMyCognitoAuthAPI1PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionMyCognitoAuth"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth",
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyApiWithAwsIamAuthDeploymented0a631915": {
-      "Type": "AWS::ApiGateway::Deployment",
+    }, 
+    "MyApiWithAwsIamAuthDeployment4253f994cd": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
-        },
-        "Description": "RestApi deployment id: ed0a631915dc4df4436f471e81cd69beb6f89603",
+        }, 
+        "Description": "RestApi deployment id: 4253f994cdaf14767907decd5cb875cbafc08704", 
         "StageName": "Stage"
       }
-    },
-    "MyFunctionMyCognitoAuth": {
-      "Type": "AWS::Lambda::Function",
+    }, 
+    "MyFunctionNONEInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Handler": "index.handler",
-        "Code": {
-          "S3Bucket": "bucket",
-          "S3Key": "key"
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "MyFunctionMyCognitoAuthRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "nodejs8.10",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ]
-      }
-    },
-    "MyFunctionDefaultInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionDefaultInvokeRole"
-        },
+          "Ref": "MyFunctionNONEInvokeRole"
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole",
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
             {
-              "__Stage__": "Prod",
+              "__Stage__": "*", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -198,21 +120,21 @@
           ]
         }
       }
-    },
-    "MyFunctionNoneAuthRole": {
-      "Type": "AWS::IAM::Role",
+    }, 
+    "MyFunctionWithoutAuthRole": {
+      "Type": "AWS::IAM::Role", 
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
+        ], 
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
+          "Version": "2012-10-17", 
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
+              ], 
+              "Effect": "Allow", 
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -222,178 +144,20 @@
           ]
         }
       }
-    },
-    "MyFunctionCustomInvokeRoleRole": {
-      "Type": "AWS::IAM::Role",
+    }, 
+    "MyFunctionCustomInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionDefaultInvokeRoleAPI3PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionDefaultInvokeRole"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole",
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionWithoutAuthAPI2PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionWithoutAuth"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth",
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionWithoutAuth": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Handler": "index.handler",
-        "Code": {
-          "S3Bucket": "bucket",
-          "S3Key": "key"
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "MyFunctionWithoutAuthRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "nodejs8.10",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ]
-      }
-    },
-    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionMyCognitoAuth"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth",
-            {
-              "__Stage__": "Prod",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionDefaultInvokeRoleRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionMyCognitoAuthRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionCustomInvokeRoleAPI3PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionCustomInvokeRole"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole",
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole", 
             {
-              "__Stage__": "*",
+              "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -401,43 +165,201 @@
           ]
         }
       }
-    },
-    "MyFunctionDefaultInvokeRole": {
-      "Type": "AWS::Lambda::Function",
+    }, 
+    "MyFunctionWithoutAuthAPI2PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Handler": "index.handler",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionWithoutAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuthAPI1PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionMyCognitoAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionDefaultInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionDefaultInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuth": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionDefaultInvokeRoleRole",
+            "MyFunctionMyCognitoAuthRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
-    "MyFunctionNoneAuthAPI3PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
+    }, 
+    "MyFunctionNullInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRole": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionNONEInvokeRoleRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "MyFunctionNoneAuthRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionCustomInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionDefaultInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionNoneAuth"
-        },
+          "Ref": "MyFunctionDefaultInvokeRole"
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth",
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole", 
             {
-              "__Stage__": "*",
+              "__Stage__": "*", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -445,154 +367,444 @@
           ]
         }
       }
-    },
+    }, 
+    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNONEInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionWithoutAuthAPI2PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionWithoutAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionWithoutAuth": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionWithoutAuthRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "MyFunctionNullInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNullInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionMyCognitoAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionDefaultInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuthRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionCustomInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionCustomInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionDefaultInvokeRole": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionDefaultInvokeRoleRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "MyApiWithAwsIamAuthProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithAwsIamAuthDeployment4253f994cd"
+        }, 
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "MyFunctionNoneAuthAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNoneAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
     "MyApiWithAwsIamAuth": {
-      "Type": "AWS::ApiGateway::RestApi",
+      "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0",
+            "version": "1.0", 
             "title": {
               "Ref": "AWS::StackName"
             }
-          },
+          }, 
           "paths": {
-            "/MyFunctionDefaultInvokeRole": {
-              "get": {
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
-                  "uri": {
-                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionDefaultInvokeRole.Arn}/invocations"
-                  },
-                  "credentials": "arn:aws:iam::*:user/*"
-                },
-                "security": [
-                  {
-                    "AWS_IAM": []
-                  }
-                ],
-                "responses": {}
-              }
-            },
             "/MyFunctionWithoutAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithoutAuth.Arn}/invocations"
-                  },
+                  }, 
                   "credentials": "arn:aws:iam::123:role/AUTH_AWS_IAM"
-                },
+                }, 
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ],
+                ], 
                 "responses": {}
               }
-            },
-            "/MyFunctionNoneAuth": {
+            }, 
+            "/MyFunctionNONEInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
-                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoneAuth.Arn}/invocations"
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNONEInvokeRole.Arn}/invocations"
                   }
-                },
+                }, 
                 "security": [
                   {
-                    "NONE": []
+                    "AWS_IAM": []
                   }
-                ],
+                ], 
                 "responses": {}
               }
-            },
+            }, 
             "/MyFunctionMyCognitoAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionMyCognitoAuth.Arn}/invocations"
                   }
-                },
+                }, 
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ],
+                ], 
                 "responses": {}
               }
-            },
-            "/MyFunctionCustomInvokeRole": {
+            }, 
+            "/MyFunctionDefaultInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
-                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCustomInvokeRole.Arn}/invocations"
-                  },
-                  "credentials": "arn:aws:iam::456::role/something-else"
-                },
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionDefaultInvokeRole.Arn}/invocations"
+                  }, 
+                  "credentials": "arn:aws:iam::*:user/*"
+                }, 
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ],
+                ], 
+                "responses": {}
+              }
+            }, 
+            "/MyFunctionCustomInvokeRole": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCustomInvokeRole.Arn}/invocations"
+                  }, 
+                  "credentials": "arn:aws:iam::456::role/something-else"
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }
+            }, 
+            "/MyFunctionNullInvokeRole": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNullInvokeRole.Arn}/invocations"
+                  }
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }
+            }, 
+            "/MyFunctionNoneAuth": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoneAuth.Arn}/invocations"
+                  }
+                }, 
+                "security": [
+                  {
+                    "NONE": []
+                  }
+                ], 
                 "responses": {}
               }
             }
-          },
-          "swagger": "2.0",
+          }, 
+          "swagger": "2.0", 
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
+              "in": "header", 
+              "type": "apiKey", 
+              "name": "Authorization", 
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:cognito-idp:xxxxxxxxx"
-                ],
+                ], 
                 "type": "cognito_user_pools"
-              },
+              }, 
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            },
+            }, 
             "AWS_IAM": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
+              "in": "header", 
+              "type": "apiKey", 
+              "name": "Authorization", 
               "x-amazon-apigateway-authtype": "awsSigv4"
             }
           }
-        },
+        }, 
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        },
+        }, 
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    },
+    }, 
     "MyFunctionNoneAuthAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionNoneAuth"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth",
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth", 
             {
-              "__Stage__": "Prod",
+              "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ]

--- a/tests/translator/output/aws-cn/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/aws-cn/api_with_aws_iam_auth_overrides.json
@@ -90,6 +90,18 @@
         }
       }
     }, 
+    "MyApiWithAwsIamAuthProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithAwsIamAuthDeployment4253f994cd"
+        }, 
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
     "MyApiWithAwsIamAuthDeployment4253f994cd": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
@@ -100,21 +112,21 @@
         "StageName": "Stage"
       }
     }, 
-    "MyFunctionNONEInvokeRoleAPI3PermissionTest": {
+    "MyFunctionCallerCredentialsOverrideAPI3PermissionTest": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
         "Action": "lambda:invokeFunction", 
         "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionNONEInvokeRole"
+          "Ref": "MyFunctionCallerCredentialsOverride"
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
             {
               "__Stage__": "*", 
               "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
               }
             }
           ]
@@ -163,6 +175,102 @@
               }
             }
           ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionMyCognitoAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment07ee28f86e": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+        }, 
+        "Description": "RestApi deployment id: 07ee28f86edc705d064d88266db4dea8f5c305b1", 
+        "StageName": "Stage"
+      }
+    }, 
+    "MyApiWithAwsIamAuthNoCallerCredentials": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoCallerCredentials.Arn}/invocations"
+                  }
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }, 
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCallerCredentialsOverride.Arn}/invocations"
+                  }, 
+                  "credentials": "arn:aws:iam::*:user/*"
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }
+            }
+          }, 
+          "swagger": "2.0", 
+          "securityDefinitions": {
+            "AWS_IAM": {
+              "in": "header", 
+              "type": "apiKey", 
+              "name": "Authorization", 
+              "x-amazon-apigateway-authtype": "awsSigv4"
+            }
+          }
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
         }
       }
     }, 
@@ -276,6 +384,27 @@
         }
       }
     }, 
+    "MyFunctionNoCallerCredentialsAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNoCallerCredentials"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+              }
+            }
+          ]
+        }
+      }
+    }, 
     "MyFunctionNONEInvokeRole": {
       "Type": "AWS::Lambda::Function", 
       "Properties": {
@@ -297,6 +426,27 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    }, 
+    "MyFunctionNoCallerCredentialsAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNoCallerCredentials"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+              }
+            }
+          ]
+        }
       }
     }, 
     "MyFunctionNoneAuthRole": {
@@ -368,46 +518,48 @@
         }
       }
     }, 
-    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
+    "MyFunctionCallerCredentialsOverrideAPI3PermissionProd": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
         "Action": "lambda:invokeFunction", 
         "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionNONEInvokeRole"
+          "Ref": "MyFunctionCallerCredentialsOverride"
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
               }
             }
           ]
         }
       }
     }, 
-    "MyFunctionWithoutAuthAPI2PermissionTest": {
-      "Type": "AWS::Lambda::Permission", 
+    "MyFunctionCallerCredentialsOverride": {
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Action": "lambda:invokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "MyFunctionWithoutAuth"
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
         }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
-            {
-              "__Stage__": "*", 
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionCallerCredentialsOverrideRole", 
+            "Arn"
           ]
-        }
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
     }, 
     "MyFunctionWithoutAuth": {
@@ -454,21 +606,45 @@
         }
       }
     }, 
-    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
+    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
         "Action": "lambda:invokeFunction", 
         "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionMyCognitoAuth"
+          "Ref": "MyFunctionNONEInvokeRole"
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNoCallerCredentialsRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ]
@@ -499,6 +675,72 @@
         }
       }
     }, 
+    "MyFunctionWithoutAuthAPI2PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionWithoutAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionCallerCredentialsOverrideRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNONEInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
     "MyFunctionMyCognitoAuthRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -521,6 +763,18 @@
             }
           ]
         }
+      }
+    }, 
+    "MyApiWithAwsIamAuthNoCallerCredentialsProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment07ee28f86e"
+        }, 
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+        }, 
+        "StageName": "Prod"
       }
     }, 
     "MyFunctionCustomInvokeRoleAPI3PermissionTest": {
@@ -567,16 +821,27 @@
         ]
       }
     }, 
-    "MyApiWithAwsIamAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+    "MyFunctionNoCallerCredentials": {
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeployment4253f994cd"
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
         }, 
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionNoCallerCredentialsRole", 
+            "Arn"
+          ]
         }, 
-        "StageName": "Prod"
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
     }, 
     "MyFunctionNoneAuthAPI3PermissionTest": {

--- a/tests/translator/output/aws-us-gov/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/aws-us-gov/api_with_aws_iam_auth_overrides.json
@@ -1,443 +1,597 @@
 {
   "Resources": {
     "MyFunctionCustomInvokeRole": {
-      "Type": "AWS::Lambda::Function",
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Handler": "index.handler",
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionCustomInvokeRoleRole",
+            "MyFunctionCustomInvokeRoleRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
+    }, 
     "MyFunctionNoneAuth": {
-      "Type": "AWS::Lambda::Function",
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Handler": "index.handler",
+        "Handler": "index.handler", 
         "Code": {
-          "S3Bucket": "bucket",
+          "S3Bucket": "bucket", 
           "S3Key": "key"
-        },
+        }, 
         "Role": {
           "Fn::GetAtt": [
-            "MyFunctionNoneAuthRole",
+            "MyFunctionNoneAuthRole", 
             "Arn"
           ]
-        },
-        "Runtime": "nodejs8.10",
+        }, 
+        "Runtime": "nodejs8.10", 
         "Tags": [
           {
-            "Value": "SAM",
+            "Value": "SAM", 
             "Key": "lambda:createdBy"
           }
         ]
       }
-    },
-    "MyApiWithAwsIamAuthDeploymentd6dd2d1504": {
-      "Type": "AWS::ApiGateway::Deployment",
+    }, 
+    "MyFunctionNullInvokeRole": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionNullInvokeRoleRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "MyFunctionNullInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNullInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNONEInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionWithoutAuthRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionCustomInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionCustomInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyApiWithAwsIamAuthDeploymentc7d4214444": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
-        },
-        "Description": "RestApi deployment id: d6dd2d1504ea960bdb50055b256d9292aa565e4b",
+        }, 
+        "Description": "RestApi deployment id: c7d4214444b325ee43f7a16744a5a74d01b268b2", 
         "StageName": "Stage"
       }
-    },
+    }, 
+    "MyFunctionWithoutAuthAPI2PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionWithoutAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuthAPI1PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionMyCognitoAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionDefaultInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionDefaultInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuth": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionMyCognitoAuthRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "MyFunctionNullInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRole": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionNONEInvokeRoleRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "MyFunctionNoneAuthRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionCustomInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionDefaultInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionDefaultInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNONEInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionWithoutAuthAPI2PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionWithoutAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionWithoutAuth": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionWithoutAuthRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "MyFunctionNullInvokeRoleAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNullInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNullInvokeRole", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionMyCognitoAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionDefaultInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionMyCognitoAuthRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionCustomInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionCustomInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionDefaultInvokeRole": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionDefaultInvokeRoleRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
     "MyApiWithAwsIamAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage",
+      "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentd6dd2d1504"
-        },
+          "Ref": "MyApiWithAwsIamAuthDeploymentc7d4214444"
+        }, 
         "RestApiId": {
           "Ref": "MyApiWithAwsIamAuth"
-        },
+        }, 
         "StageName": "Prod"
       }
-    },
-    "MyFunctionWithoutAuthRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionCustomInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionCustomInvokeRole"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole",
-            {
-              "__Stage__": "Prod",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionWithoutAuthAPI2PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionWithoutAuth"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth",
-            {
-              "__Stage__": "Prod",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionMyCognitoAuthAPI1PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionMyCognitoAuth"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth",
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionMyCognitoAuth": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Handler": "index.handler",
-        "Code": {
-          "S3Bucket": "bucket",
-          "S3Key": "key"
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "MyFunctionMyCognitoAuthRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "nodejs8.10",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ]
-      }
-    },
-    "MyFunctionDefaultInvokeRoleAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionDefaultInvokeRole"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole",
-            {
-              "__Stage__": "Prod",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionNoneAuthRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionCustomInvokeRoleRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionDefaultInvokeRoleAPI3PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionDefaultInvokeRole"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionDefaultInvokeRole",
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionWithoutAuthAPI2PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionWithoutAuth"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth",
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionWithoutAuth": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Handler": "index.handler",
-        "Code": {
-          "S3Bucket": "bucket",
-          "S3Key": "key"
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "MyFunctionWithoutAuthRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "nodejs8.10",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ]
-      }
-    },
-    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionMyCognitoAuth"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth",
-            {
-              "__Stage__": "Prod",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionDefaultInvokeRoleRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionMyCognitoAuthRole": {
-      "Type": "AWS::IAM::Role",
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
-        "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17",
-          "Statement": [
-            {
-              "Action": [
-                "sts:AssumeRole"
-              ],
-              "Effect": "Allow",
-              "Principal": {
-                "Service": [
-                  "lambda.amazonaws.com"
-                ]
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionCustomInvokeRoleAPI3PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
-      "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
-        "FunctionName": {
-          "Ref": "MyFunctionCustomInvokeRole"
-        },
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionCustomInvokeRole",
-            {
-              "__Stage__": "*",
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
-          ]
-        }
-      }
-    },
-    "MyFunctionDefaultInvokeRole": {
-      "Type": "AWS::Lambda::Function",
-      "Properties": {
-        "Handler": "index.handler",
-        "Code": {
-          "S3Bucket": "bucket",
-          "S3Key": "key"
-        },
-        "Role": {
-          "Fn::GetAtt": [
-            "MyFunctionDefaultInvokeRoleRole",
-            "Arn"
-          ]
-        },
-        "Runtime": "nodejs8.10",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          }
-        ]
-      }
-    },
+    }, 
     "MyFunctionNoneAuthAPI3PermissionTest": {
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionNoneAuth"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth",
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth", 
             {
-              "__Stage__": "*",
+              "__Stage__": "*", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
               }
@@ -445,154 +599,212 @@
           ]
         }
       }
-    },
+    }, 
     "MyApiWithAwsIamAuth": {
-      "Type": "AWS::ApiGateway::RestApi",
+      "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0",
+            "version": "1.0", 
             "title": {
               "Ref": "AWS::StackName"
             }
-          },
+          }, 
           "paths": {
-            "/MyFunctionDefaultInvokeRole": {
-              "get": {
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
-                  "uri": {
-                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionDefaultInvokeRole.Arn}/invocations"
-                  },
-                  "credentials": "arn:aws:iam::*:user/*"
-                },
-                "security": [
-                  {
-                    "AWS_IAM": []
-                  }
-                ],
-                "responses": {}
-              }
-            },
             "/MyFunctionWithoutAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionWithoutAuth.Arn}/invocations"
-                  },
+                  }, 
                   "credentials": "arn:aws:iam::123:role/AUTH_AWS_IAM"
-                },
+                }, 
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ],
+                ], 
                 "responses": {}
               }
-            },
-            "/MyFunctionNoneAuth": {
+            }, 
+            "/MyFunctionNONEInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
-                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoneAuth.Arn}/invocations"
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNONEInvokeRole.Arn}/invocations"
                   }
-                },
+                }, 
                 "security": [
                   {
-                    "NONE": []
+                    "AWS_IAM": []
                   }
-                ],
+                ], 
                 "responses": {}
               }
-            },
+            }, 
             "/MyFunctionMyCognitoAuth": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionMyCognitoAuth.Arn}/invocations"
                   }
-                },
+                }, 
                 "security": [
                   {
                     "MyCognitoAuth": []
                   }
-                ],
+                ], 
                 "responses": {}
               }
-            },
-            "/MyFunctionCustomInvokeRole": {
+            }, 
+            "/MyFunctionDefaultInvokeRole": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST",
-                  "type": "aws_proxy",
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
                   "uri": {
-                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCustomInvokeRole.Arn}/invocations"
-                  },
-                  "credentials": "arn:aws:iam::456::role/something-else"
-                },
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionDefaultInvokeRole.Arn}/invocations"
+                  }, 
+                  "credentials": "arn:aws:iam::*:user/*"
+                }, 
                 "security": [
                   {
                     "AWS_IAM": []
                   }
-                ],
+                ], 
+                "responses": {}
+              }
+            }, 
+            "/MyFunctionCustomInvokeRole": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCustomInvokeRole.Arn}/invocations"
+                  }, 
+                  "credentials": "arn:aws:iam::456::role/something-else"
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }
+            }, 
+            "/MyFunctionNullInvokeRole": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNullInvokeRole.Arn}/invocations"
+                  }
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }
+            }, 
+            "/MyFunctionNoneAuth": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoneAuth.Arn}/invocations"
+                  }
+                }, 
+                "security": [
+                  {
+                    "NONE": []
+                  }
+                ], 
                 "responses": {}
               }
             }
-          },
-          "swagger": "2.0",
+          }, 
+          "swagger": "2.0", 
           "securityDefinitions": {
             "MyCognitoAuth": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
+              "in": "header", 
+              "type": "apiKey", 
+              "name": "Authorization", 
               "x-amazon-apigateway-authorizer": {
                 "providerARNs": [
                   "arn:aws:cognito-idp:xxxxxxxxx"
-                ],
+                ], 
                 "type": "cognito_user_pools"
-              },
+              }, 
               "x-amazon-apigateway-authtype": "cognito_user_pools"
-            },
+            }, 
             "AWS_IAM": {
-              "in": "header",
-              "type": "apiKey",
-              "name": "Authorization",
+              "in": "header", 
+              "type": "apiKey", 
+              "name": "Authorization", 
               "x-amazon-apigateway-authtype": "awsSigv4"
             }
           }
-        },
+        }, 
         "EndpointConfiguration": {
           "Types": [
             "REGIONAL"
           ]
-        },
+        }, 
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
       }
-    },
+    }, 
     "MyFunctionNoneAuthAPI3PermissionProd": {
-      "Type": "AWS::Lambda::Permission",
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "Action": "lambda:invokeFunction",
-        "Principal": "apigateway.amazonaws.com",
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
           "Ref": "MyFunctionNoneAuth"
-        },
+        }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth",
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNoneAuth", 
             {
-              "__Stage__": "Prod",
+              "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRoleRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ]

--- a/tests/translator/output/aws-us-gov/api_with_aws_iam_auth_overrides.json
+++ b/tests/translator/output/aws-us-gov/api_with_aws_iam_auth_overrides.json
@@ -90,21 +90,33 @@
         }
       }
     }, 
-    "MyFunctionNONEInvokeRoleAPI3PermissionTest": {
+    "MyApiWithAwsIamAuthProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithAwsIamAuthDeploymentc7d4214444"
+        }, 
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuth"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "MyFunctionCallerCredentialsOverrideAPI3PermissionTest": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
         "Action": "lambda:invokeFunction", 
         "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionNONEInvokeRole"
+          "Ref": "MyFunctionCallerCredentialsOverride"
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
             {
               "__Stage__": "*", 
               "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
               }
             }
           ]
@@ -156,6 +168,27 @@
         }
       }
     }, 
+    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionMyCognitoAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
     "MyApiWithAwsIamAuthDeploymentc7d4214444": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
@@ -164,6 +197,71 @@
         }, 
         "Description": "RestApi deployment id: c7d4214444b325ee43f7a16744a5a74d01b268b2", 
         "StageName": "Stage"
+      }
+    }, 
+    "MyApiWithAwsIamAuthNoCallerCredentials": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionNoCallerCredentials.Arn}/invocations"
+                  }
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }, 
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunctionCallerCredentialsOverride.Arn}/invocations"
+                  }, 
+                  "credentials": "arn:aws:iam::*:user/*"
+                }, 
+                "security": [
+                  {
+                    "AWS_IAM": []
+                  }
+                ], 
+                "responses": {}
+              }
+            }
+          }, 
+          "swagger": "2.0", 
+          "securityDefinitions": {
+            "AWS_IAM": {
+              "in": "header", 
+              "type": "apiKey", 
+              "name": "Authorization", 
+              "x-amazon-apigateway-authtype": "awsSigv4"
+            }
+          }
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
       }
     }, 
     "MyFunctionWithoutAuthAPI2PermissionProd": {
@@ -276,6 +374,27 @@
         }
       }
     }, 
+    "MyFunctionNoCallerCredentialsAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNoCallerCredentials"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+              }
+            }
+          ]
+        }
+      }
+    }, 
     "MyFunctionNONEInvokeRole": {
       "Type": "AWS::Lambda::Function", 
       "Properties": {
@@ -297,6 +416,27 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    }, 
+    "MyFunctionNoCallerCredentialsAPI3PermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNoCallerCredentials"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/POST/", 
+            {
+              "__Stage__": "Prod", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+              }
+            }
+          ]
+        }
       }
     }, 
     "MyFunctionNoneAuthRole": {
@@ -368,46 +508,48 @@
         }
       }
     }, 
-    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
+    "MyFunctionCallerCredentialsOverrideAPI3PermissionProd": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
         "Action": "lambda:invokeFunction", 
         "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionNONEInvokeRole"
+          "Ref": "MyFunctionCallerCredentialsOverride"
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
+                "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
               }
             }
           ]
         }
       }
     }, 
-    "MyFunctionWithoutAuthAPI2PermissionTest": {
-      "Type": "AWS::Lambda::Permission", 
+    "MyFunctionCallerCredentialsOverride": {
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "Action": "lambda:invokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "MyFunctionWithoutAuth"
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
         }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
-            {
-              "__Stage__": "*", 
-              "__ApiId__": {
-                "Ref": "MyApiWithAwsIamAuth"
-              }
-            }
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionCallerCredentialsOverrideRole", 
+            "Arn"
           ]
-        }
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
     }, 
     "MyFunctionWithoutAuth": {
@@ -454,21 +596,45 @@
         }
       }
     }, 
-    "MyFunctionMyCognitoAuthAPI1PermissionProd": {
+    "MyFunctionNONEInvokeRoleAPI3PermissionProd": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
         "Action": "lambda:invokeFunction", 
         "Principal": "apigateway.amazonaws.com", 
         "FunctionName": {
-          "Ref": "MyFunctionMyCognitoAuth"
+          "Ref": "MyFunctionNONEInvokeRole"
         }, 
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionMyCognitoAuth", 
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
             {
               "__Stage__": "Prod", 
               "__ApiId__": {
                 "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNoCallerCredentialsRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
               }
             }
           ]
@@ -499,6 +665,72 @@
         }
       }
     }, 
+    "MyFunctionWithoutAuthAPI2PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionWithoutAuth"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionWithoutAuth", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionCallerCredentialsOverrideRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "MyFunctionNONEInvokeRoleAPI3PermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFunctionNONEInvokeRole"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/MyFunctionNONEInvokeRole", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithAwsIamAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
     "MyFunctionMyCognitoAuthRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -521,6 +753,18 @@
             }
           ]
         }
+      }
+    }, 
+    "MyApiWithAwsIamAuthNoCallerCredentialsProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentialsDeployment673da6c5e9"
+        }, 
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+        }, 
+        "StageName": "Prod"
       }
     }, 
     "MyFunctionCustomInvokeRoleAPI3PermissionTest": {
@@ -567,16 +811,27 @@
         ]
       }
     }, 
-    "MyApiWithAwsIamAuthProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+    "MyFunctionNoCallerCredentials": {
+      "Type": "AWS::Lambda::Function", 
       "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiWithAwsIamAuthDeploymentc7d4214444"
+        "Handler": "index.handler", 
+        "Code": {
+          "S3Bucket": "bucket", 
+          "S3Key": "key"
         }, 
-        "RestApiId": {
-          "Ref": "MyApiWithAwsIamAuth"
+        "Role": {
+          "Fn::GetAtt": [
+            "MyFunctionNoCallerCredentialsRole", 
+            "Arn"
+          ]
         }, 
-        "StageName": "Prod"
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
       }
     }, 
     "MyFunctionNoneAuthAPI3PermissionTest": {
@@ -785,6 +1040,16 @@
             }
           ]
         }
+      }
+    }, 
+    "MyApiWithAwsIamAuthNoCallerCredentialsDeployment673da6c5e9": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithAwsIamAuthNoCallerCredentials"
+        }, 
+        "Description": "RestApi deployment id: 673da6c5e9481163e7b1cbf6d5604eb84cf64fd0", 
+        "StageName": "Stage"
       }
     }, 
     "MyFunctionNONEInvokeRoleRole": {

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -786,6 +786,9 @@ Configure Auth on APIs. Define Lambda and Cognito `Authorizers` and specify a `D
 ```yaml
 Auth:
   DefaultAuthorizer: MyCognitoAuth # OPTIONAL, if you use IAM permissions, specify AWS_IAM.
+  # For AWS_IAM:
+  # DefaultAuthorizer: AWS_IAM
+  # InvokeRole: NONE # CALLER_CREDENTIALS by default unless overridden
   Authorizers:
     MyCognitoAuth:
       UserPoolArn: !GetAtt MyCognitoUserPool.Arn # Can also accept an array


### PR DESCRIPTION
*Issue #, if available:*
#923 

*Description of changes:*
Allows invoke role override (removes the "credentials" field as discussed in #923)

*Description of how you validated changes:*
Verified that the transformed template removes the "credentials" section when InvokeRole is set to 'None' or null. Also deployed template to CFN to verify that "Invoke with caller credentials" and "execution role" were not set on the api method.

I also attempted to make it more explicit that `CALLER_CREDENTIALS` is the default value, due to a conversation in the above issue.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
