### PR TITLE
Add support to specify a SNS topic that belongs to a different region

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -344,6 +344,7 @@ class SNS(PushEventSource):
     principal = 'sns.amazonaws.com'
     property_types = {
             'Topic': PropertyType(True, is_str()),
+            'Region': PropertyType(False, is_str()),
             'FilterPolicy': PropertyType(False, dict_of(is_str(), list_of(one_of(is_str(), is_type(dict)))))
     }
 
@@ -360,13 +361,15 @@ class SNS(PushEventSource):
             raise TypeError("Missing required keyword argument: function")
 
         return [self._construct_permission(function, source_arn=self.Topic),
-                self._inject_subscription(function, self.Topic, self.FilterPolicy)]
+                self._inject_subscription(function, self.Topic, self.Region, self.FilterPolicy)]
 
-    def _inject_subscription(self, function, topic, filterPolicy):
+    def _inject_subscription(self, function, topic, region, filterPolicy):
         subscription = SNSSubscription(self.logical_id)
         subscription.Protocol = 'lambda'
         subscription.Endpoint = function.get_runtime_attr("arn")
         subscription.TopicArn = topic
+        if region is not None:
+            subscription.Region = region
         if CONDITION in function.resource_attributes:
             subscription.set_resource_attribute(CONDITION, function.resource_attributes[CONDITION])
 

--- a/samtranslator/model/sns.py
+++ b/samtranslator/model/sns.py
@@ -8,5 +8,6 @@ class SNSSubscription(Resource):
         'Endpoint': PropertyType(True, is_str()),
         'Protocol': PropertyType(True, is_str()),
         'TopicArn': PropertyType(True, is_str()),
+        'Region': PropertyType(False, is_str()),
         'FilterPolicy': PropertyType(False, is_type(dict))
     }

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -632,6 +632,9 @@
         "Topic": {
           "type": "string"
         },
+        "Region": {
+          "type": "string"
+        },
         "FilterPolicy": {
           "type": "object"
         }

--- a/tests/model/eventsources/test_sns_event_source.py
+++ b/tests/model/eventsources/test_sns_event_source.py
@@ -31,7 +31,20 @@ class SnsEventSource(TestCase):
         self.assertEqual(subscription.TopicArn, 'arn:aws:sns:MyTopic')
         self.assertEqual(subscription.Protocol, 'lambda')
         self.assertEqual(subscription.Endpoint, 'arn:aws:lambda:mock')
+        self.assertIsNone(subscription.Region)
         self.assertIsNone(subscription.FilterPolicy)
+
+    def test_to_cloudformation_passes_the_region(self):
+        region = 'us-west-2'
+        self.sns_event_source.Region = region
+
+        resources = self.sns_event_source.to_cloudformation(
+            function=self.function)
+        self.assertEqual(len(resources), 2)
+        self.assertEqual(resources[1].resource_type,
+                          'AWS::SNS::Subscription')
+        subscription = resources[1]
+        self.assertEqual(subscription.Region, region)
 
     def test_to_cloudformation_passes_the_filter_policy(self):
         filterPolicy = {

--- a/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
+++ b/tests/translator/input/function_with_sns_event_source_all_parameters.yaml
@@ -11,6 +11,7 @@ Resources:
           Type: SNS
           Properties:
             Topic: topicArn
+            Region: region
             FilterPolicy:
               store:
               - example_corp

--- a/tests/translator/output/aws-cn/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_sns_event_source_all_parameters.json
@@ -33,7 +33,8 @@
           ]
         },
         "Protocol": "lambda",
-        "TopicArn": "topicArn"
+        "TopicArn": "topicArn",
+        "Region": "region"
       }
     },
     "MyAwesomeFunctionNotificationTopicPermission": {

--- a/tests/translator/output/aws-us-gov/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_sns_event_source_all_parameters.json
@@ -33,7 +33,8 @@
           ]
         },
         "Protocol": "lambda",
-        "TopicArn": "topicArn"
+        "TopicArn": "topicArn",
+        "Region": "region"
       }
     },
     "MyAwesomeFunctionNotificationTopicPermission": {

--- a/tests/translator/output/function_with_sns_event_source_all_parameters.json
+++ b/tests/translator/output/function_with_sns_event_source_all_parameters.json
@@ -33,7 +33,8 @@
           ]
         },
         "Protocol": "lambda",
-        "TopicArn": "topicArn"
+        "TopicArn": "topicArn",
+        "Region": "region"
       }
     },
     "MyAwesomeFunctionNotificationTopicPermission": {

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -426,6 +426,7 @@ The object describing an event source with type `SNS`.
 Property Name | Type | Description
 ---|:---:|---
 Topic | `string` | **Required.** Topic ARN.
+Region | `string` | Region.
 FilterPolicy | [Amazon SNS filter policy](https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html) | Policy assigned to the topic subscription in order to receive only a subset of the messages.
 
 ##### Example: SNS event source object


### PR DESCRIPTION
*Issue #, if available:*
#105 

*Description of changes:*
Add support to specify a SNS topic that belongs to a different region.

I made changes in the steps written in the issue below:
https://github.com/awslabs/serverless-application-model/issues/105#issuecomment-476771718

*Description of how you validated changes:*
I verified transformed template in the steps written in [DEVELOPMENT_GUIDE](https://github.com/awslabs/serverless-application-model/blob/master/DEVELOPMENT_GUIDE.rst#verifying-transforms).

I confirmed that SAM template below could be deployed successfully.

```yaml
Resources:
  WorkerFunction:
    Type: AWS::Serverless::Function
    Properties:
      CodeUri: worker_lambda/
      Handler: app.lambda_handler
      Events:
        MessageTopic:
          Type: SNS
          Properties:
            Topic: (different region TopicArn)
            Region: (different region name)
```

also confirmed the SAM template below too.

```yaml
Resources:
  WorkerFunction:
    Type: AWS::Serverless::Function
    Properties:
      CodeUri: worker_lambda/
      Handler: app.lambda_handler
      Events:
        MessageTopic:
          Type: SNS
          Properties:
            Topic: (same region TopicArn)
```

I published a message to the SNS topic and confirmed to trigger Lambda function successfully.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
