### PR TITLE
fix: "Invalid permissions on Lambda function" on path parameter

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -495,7 +495,7 @@ class Api(PushEventSource):
         if not stage or not suffix:
             raise RuntimeError("Could not add permission to lambda function.")
 
-        path = path.replace('{proxy+}', '*')
+        path = re.sub(r'{([a-zA-Z0-9._-]+|proxy\+)}', '*', path)
         method = '*' if self.Method.lower() == 'any' else self.Method.upper()
 
         api_id = self.RestApiId

--- a/tests/model/eventsources/test_api_event_source.py
+++ b/tests/model/eventsources/test_api_event_source.py
@@ -52,6 +52,36 @@ class ApiEventSource(TestCase):
         self.assertEqual(arn, "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo")
 
     @patch("boto3.session.Session.region_name", "eu-west-2")
+    def test_get_permission_with_path_parameter(self):
+        self.api_event_source.Path = "/foo/{userId}/bar"
+        cfn = self.api_event_source.to_cloudformation(function=self.func, explicit_api={})
+
+        perm = cfn[0]
+        self.assertIsInstance(perm, LambdaPermission)
+
+        try:
+            arn = self._extract_path_from_arn("{}PermissionTest".format(self.logical_id), perm)
+        except AttributeError:
+            self.fail("Permission class isn't valid")
+
+        self.assertEqual(arn, "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo/*/bar")
+
+    @patch("boto3.session.Session.region_name", "eu-west-2")
+    def test_get_permission_with_proxy_resource(self):
+        self.api_event_source.Path = "/foo/{proxy+}"
+        cfn = self.api_event_source.to_cloudformation(function=self.func, explicit_api={})
+
+        perm = cfn[0]
+        self.assertIsInstance(perm, LambdaPermission)
+
+        try:
+            arn = self._extract_path_from_arn("{}PermissionTest".format(self.logical_id), perm)
+        except AttributeError:
+            self.fail("Permission class isn't valid")
+
+        self.assertEqual(arn, "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo/*")
+
+    @patch("boto3.session.Session.region_name", "eu-west-2")
     def test_get_permission_with_just_slash(self):
         self.api_event_source.Path = "/"
         cfn = self.api_event_source.to_cloudformation(function=self.func, explicit_api={})

--- a/tests/translator/input/api_with_path_parameters.yaml
+++ b/tests/translator/input/api_with_path_parameters.yaml
@@ -1,0 +1,20 @@
+Resources:
+  HtmlFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs4.3
+      Events:
+        GetHtml:
+          Type: Api
+          Properties:
+            RestApiId: HtmlApi
+            Path: /{prameter}/resources
+            Method: get
+
+  HtmlApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      DefinitionUri: s3://sam-demo-bucket/webpage_swagger.json

--- a/tests/translator/output/api_with_path_parameters.json
+++ b/tests/translator/output/api_with_path_parameters.json
@@ -1,0 +1,120 @@
+{
+  "Resources": {
+    "HtmlFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "HtmlApiDeploymentf117c932f7"
+        },
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/*/resources",
+            {
+              "__Stage__": "Prod",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/*/resources",
+            {
+              "__Stage__": "*",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "StageName": "Stage"
+      }
+    },
+    "HtmlApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "webpage_swagger.json"
+        }
+      }
+    },
+    "HtmlFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "member_portal.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "HtmlFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs4.3",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_path_parameters.json
+++ b/tests/translator/output/aws-cn/api_with_path_parameters.json
@@ -1,0 +1,128 @@
+{
+  "Resources": {
+    "HtmlFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "HtmlApiDeploymentf117c932f7"
+        },
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/*/resources",
+            {
+              "__Stage__": "Prod",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/*/resources",
+            {
+              "__Stage__": "*",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "StageName": "Stage"
+      }
+    },
+    "HtmlApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "webpage_swagger.json"
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "HtmlFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "member_portal.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "HtmlFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs4.3",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_with_path_parameters.json
+++ b/tests/translator/output/aws-us-gov/api_with_path_parameters.json
@@ -1,0 +1,128 @@
+{
+  "Resources": {
+    "HtmlFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage",
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "HtmlApiDeploymentf117c932f7"
+        },
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "StageName": "Prod"
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/*/resources",
+            {
+              "__Stage__": "Prod",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "Principal": "apigateway.amazonaws.com",
+        "FunctionName": {
+          "Ref": "HtmlFunction"
+        },
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/*/resources",
+            {
+              "__Stage__": "*",
+              "__ApiId__": "HtmlApi"
+            }
+          ]
+        }
+      }
+    },
+    "HtmlApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        },
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "StageName": "Stage"
+      }
+    },
+    "HtmlApi": {
+      "Type": "AWS::ApiGateway::RestApi",
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        },
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket",
+          "Key": "webpage_swagger.json"
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    },
+    "HtmlFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "member_portal.zip"
+        },
+        "Handler": "index.gethtml",
+        "Role": {
+          "Fn::GetAtt": [
+            "HtmlFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs4.3",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -263,6 +263,7 @@ class TestTranslatorEndToEnd(TestCase):
         'api_with_auth_and_conditions_all_max',
         'api_with_apikey_default_override',
         'api_with_apikey_required',
+        'api_with_path_parameters',
       ],
       [
        ("aws", "ap-southeast-1"),


### PR DESCRIPTION
*Issue #, if available:*
#110

*Description of changes:*
fix the issue #110

*Description of how you validated changes:*
Deployed the following template successfully on CloudFormation.
Also I confirmed deployed APIs works well.

```yaml
Resources:
  HelloWorldFunction:
    Type: AWS::Serverless::Function
    Properties:
      CodeUri: hello_world/
      Handler: app.lambda_handler
      Events:
        HttpGetUserExampleExample:
          Type: Api
          Properties:
            Path: '/users/example/example'
            Method: GET
        HttpGetUserGroupIdUserId:
          Type: Api
          Properties:
            Path: '/users/{groupId}/{userId}'
            Method: GET
        HttpGetGroupAster:
          Type: Api
          Properties:
            Path: '/groups/{proxy+}'
            Method: GET
```

*Checklist:*

- [x] Write/update tests
  - **If this pull request is on the right path, I will add some tests**
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
