### PR TITLE
Add es:ESHttpPut in ElasticsearchHttpPostPolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -246,7 +246,7 @@
       }
     },
     "ElasticsearchHttpPostPolicy": {
-      "Description": "Gives POST permissions to Elasticsearch",
+      "Description": "Gives POST and PUT permissions to Elasticsearch",
       "Parameters": {
         "DomainName": {
           "Description": "Name of Domain"
@@ -257,7 +257,8 @@
           {
             "Effect": "Allow",
             "Action": [
-              "es:ESHttpPost"
+              "es:ESHttpPost",
+              "es:ESHttpPut"
             ],
             "Resource": {
               "Fn::Sub": [

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -208,7 +208,8 @@
               "Statement": [
                 {
                   "Action": [
-                    "es:ESHttpPost"
+                    "es:ESHttpPost",
+                    "es:ESHttpPut"
                   ],
                   "Resource": {
                     "Fn::Sub": [

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -207,7 +207,8 @@
               "Statement": [
                 {
                   "Action": [
-                    "es:ESHttpPost"
+                    "es:ESHttpPost",
+                    "es:ESHttpPut"
                   ],
                   "Resource": {
                     "Fn::Sub": [

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -207,7 +207,8 @@
               "Statement": [
                 {
                   "Action": [
-                    "es:ESHttpPost"
+                    "es:ESHttpPost",
+                    "es:ESHttpPut"
                   ],
                   "Resource": {
                     "Fn::Sub": [


### PR DESCRIPTION
Include es:ESHttpPut action in ElasticsearchHttpPostPolicy Template

*Issue #1010 

*Description of changes:*
Add es:ESHttpPut action  available in Policy Template List as part of ElasticsearchHttpPostPolicy template.

*Description of how you validated changes:*

*Checklist:*

- [x] ~~Write~~/update tests(policy templates)
- [x] `make pr` passes
- [x] ~~Update documentation~~(no change required)
- [x] Verify transformed template deploys and application functions as expected
- [x] ~~Add/update example to `examples/2016-10-31`~~(no change required)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
