### PR TITLE
fix: to_cloudformation functions of PushEventSource class docstrings

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -79,7 +79,7 @@ class Schedule(PushEventSource):
         """Returns the CloudWatch Events Rule and Lambda Permission to which this Schedule event source corresponds.
 
         :param dict kwargs: no existing resources need to be modified
-        :returns: a list of vanilla CloudFormation Resources, to which this pull event expands
+        :returns: a list of vanilla CloudFormation Resources, to which this Schedule event expands
         :rtype: list
         """
         function = kwargs.get('function')
@@ -133,7 +133,7 @@ class CloudWatchEvent(PushEventSource):
         corresponds.
 
         :param dict kwargs: no existing resources need to be modified
-        :returns: a list of vanilla CloudFormation Resources, to which this pull event expands
+        :returns: a list of vanilla CloudFormation Resources, to which this CloudWatch Events event expands
         :rtype: list
         """
         function = kwargs.get('function')


### PR DESCRIPTION
*Issue #, if available:*
#1017 

I'm sorry if I was wrong but I understand CloudWatch Events trigger is no pull event. 
So I think docstrings of `to_cloudformation` of CloudWatchEvent class and Schedule class have to fix.

- [-] Write/update tests
- [-] `make pr` passes
- [x] Update documentation
- [-] Verify transformed template deploys and application functions as expected
- [-] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
