### PR TITLE
fix: randomize logical IDs of API stage and Lambdda permission

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -12,6 +12,7 @@ from samtranslator.region_configuration import RegionConfiguration
 from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.model.intrinsics import is_instrinsic, fnSub
 from samtranslator.model.lambda_ import LambdaPermission
+from samtranslator.translator import logical_id_generator
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.model.tags.resource_tagging import get_tag_list
 
@@ -184,8 +185,8 @@ class ApiGenerator(object):
         # If StageName is some intrinsic function, then don't prefix the Stage's logical ID
         # This will NOT create duplicates because we allow only ONE stage per API resource
         stage_name_prefix = self.stage_name if isinstance(self.stage_name, string_types) else ""
-
-        stage = ApiGatewayStage(self.logical_id + stage_name_prefix + 'Stage',
+        stage_logical_id = logical_id_generator.LogicalIdGenerator(self.logical_id + 'Stage', stage_name_prefix).gen()
+        stage = ApiGatewayStage(stage_logical_id,
                                 attributes=self.passthrough_resource_attributes)
         stage.RestApiId = ref(self.logical_id)
         stage.update_deployment_ref(deployment.logical_id)

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -11,6 +11,7 @@ from samtranslator.model.sns import SNSSubscription
 from samtranslator.model.lambda_ import LambdaPermission
 from samtranslator.model.events import EventsRule
 from samtranslator.model.iot import IotTopicRule
+from samtranslator.translator import logical_id_generator
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.model.exceptions import InvalidEventException, InvalidResourceException
 from samtranslator.swagger.swagger import SwaggerEditor
@@ -47,7 +48,8 @@ class PushEventSource(ResourceMacro):
         :returns: the permission resource
         :rtype: model.lambda_.LambdaPermission
         """
-        lambda_permission = LambdaPermission(self.logical_id + 'Permission' + suffix,
+        permission_logical_id = logical_id_generator.LogicalIdGenerator(self.logical_id + 'Permission', suffix).gen()
+        lambda_permission = LambdaPermission(permission_logical_id,
                                              attributes=function.get_passthrough_resource_attributes())
 
         try:


### PR DESCRIPTION
*Issue #1002*

*Description of changes:*

("-") is not accepted in CFn logical ID, but the stage name of API Gateway and Lambda permission may include ("-").  I changed the way to generate logical ID by logical_id_generator.

*Description of how you validated changes:*

I tried the following template, and it worked.

```yaml
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31
Description: HelloWorld
Resources:
  MyAPI:
    Type: "AWS::Serverless::Api"
    Properties:
      StageName: test_test
  HelloWorld:
    Type: AWS::Serverless::Function
    Properties:
      Handler: index.handler
      Runtime: nodejs10.x
      CodeUri: s3://xxx/xxx
      Description: HelloWorld
      MemorySize: 128
      Timeout: 3
      Events:
        GetResource:
          Type: Api
          Properties:
            Path: /hello
            Method: get
            RestApiId: !Ref MyAPI
```

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
