### PR TITLE
fix: randomize logical IDs of API stage and Lambda permission

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -10,6 +10,7 @@ from samtranslator.region_configuration import RegionConfiguration
 from samtranslator.swagger.swagger import SwaggerEditor
 from samtranslator.model.intrinsics import is_instrinsic, fnSub
 from samtranslator.model.lambda_ import LambdaPermission
+from samtranslator.translator import logical_id_generator
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.model.tags.resource_tagging import get_tag_list
 
@@ -184,8 +185,12 @@ class ApiGenerator(object):
         # If StageName is some intrinsic function, then don't prefix the Stage's logical ID
         # This will NOT create duplicates because we allow only ONE stage per API resource
         stage_name_prefix = self.stage_name if isinstance(self.stage_name, string_types) else ""
-
-        stage = ApiGatewayStage(self.logical_id + stage_name_prefix + 'Stage',
+        if '-' in stage_name_prefix or '_' in stage_name_prefix:
+            generator = logical_id_generator.LogicalIdGenerator(self.logical_id + 'Stage', stage_name_prefix)
+            stage_logical_id = generator.gen()
+        else:
+            stage_logical_id = self.logical_id + stage_name_prefix + 'Stage'
+        stage = ApiGatewayStage(stage_logical_id,
                                 attributes=self.passthrough_resource_attributes)
         stage.RestApiId = ref(self.logical_id)
         stage.update_deployment_ref(deployment.logical_id)

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -185,11 +185,11 @@ class ApiGenerator(object):
         # If StageName is some intrinsic function, then don't prefix the Stage's logical ID
         # This will NOT create duplicates because we allow only ONE stage per API resource
         stage_name_prefix = self.stage_name if isinstance(self.stage_name, string_types) else ""
-        if '-' in stage_name_prefix or '_' in stage_name_prefix:
+        if stage_name_prefix.isalnum():
+            stage_logical_id = self.logical_id + stage_name_prefix + 'Stage'
+        else:
             generator = logical_id_generator.LogicalIdGenerator(self.logical_id + 'Stage', stage_name_prefix)
             stage_logical_id = generator.gen()
-        else:
-            stage_logical_id = self.logical_id + stage_name_prefix + 'Stage'
         stage = ApiGatewayStage(stage_logical_id,
                                 attributes=self.passthrough_resource_attributes)
         stage.RestApiId = ref(self.logical_id)

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -56,11 +56,11 @@ class PushEventSource(ResourceMacro):
         """
         if prefix is None:
             prefix = self.logical_id
-        if '-' in suffix or '_' in suffix:
+        if suffix.isalnum():
+            permission_logical_id = prefix + 'Permission' + suffix
+        else:
             generator = logical_id_generator.LogicalIdGenerator(prefix + 'Permission', suffix)
             permission_logical_id = generator.gen()
-        else:
-            permission_logical_id = prefix + 'Permission' + suffix
         lambda_permission = LambdaPermission(permission_logical_id,
                                              attributes=function.get_passthrough_resource_attributes())
         try:

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -14,6 +14,7 @@ from samtranslator.model.eventsources.pull import SQS
 from samtranslator.model.sqs import SQSQueue, SQSQueuePolicy, SQSQueuePolicies
 from samtranslator.model.iot import IotTopicRule
 from samtranslator.model.cognito import CognitoUserPool
+from samtranslator.translator import logical_id_generator
 from samtranslator.translator.arn_generator import ArnGenerator
 from samtranslator.model.exceptions import InvalidEventException, InvalidResourceException
 from samtranslator.swagger.swagger import SwaggerEditor
@@ -55,9 +56,13 @@ class PushEventSource(ResourceMacro):
         """
         if prefix is None:
             prefix = self.logical_id
-        lambda_permission = LambdaPermission(prefix + 'Permission' + suffix,
+        if '-' in suffix or '_' in suffix:
+            generator = logical_id_generator.LogicalIdGenerator(prefix + 'Permission', suffix)
+            permission_logical_id = generator.gen()
+        else:
+            permission_logical_id = prefix + 'Permission' + suffix
+        lambda_permission = LambdaPermission(permission_logical_id,
                                              attributes=function.get_passthrough_resource_attributes())
-
         try:
             # Name will not be available for Alias resources
             function_name_or_arn = function.get_runtime_attr("name")

--- a/tests/translator/input/api_with_incompatible_stage_name.yaml
+++ b/tests/translator/input/api_with_incompatible_stage_name.yaml
@@ -1,0 +1,56 @@
+Resources:
+  HyphenFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs4.3
+      Events:
+        GetHtml:
+          Type: Api
+          Properties:
+            RestApiId: HyphenApi
+            Path: /
+            Method: get
+            RequestModel:
+              Model: User
+              Required: true
+
+  HyphenApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: hoge-fuga
+      Models:
+        User:
+          type: object
+          properties:
+            username:
+              type: string
+  
+  UnderscoreFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs4.3
+      Events:
+        GetHtml:
+          Type: Api
+          Properties:
+            RestApiId: UnderscoreApi
+            Path: /
+            Method: get
+            RequestModel:
+              Model: User
+              Required: true
+
+  UnderscoreApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: hoge_fuga
+      Models:
+        User:
+          type: object
+          properties:
+            username:
+              type: string

--- a/tests/translator/output/api_with_incompatible_stage_name.json
+++ b/tests/translator/output/api_with_incompatible_stage_name.json
@@ -1,0 +1,314 @@
+{
+  "Resources": {
+    "HyphenApiDeployment19b8787883": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HyphenApi"
+        }, 
+        "Description": "RestApi deployment id: 19b8787883c74d792cf1ba94de3fd550cf820694", 
+        "StageName": "Stage"
+      }
+    }, 
+    "UnderscoreApiStageb34d3ad84e": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "UnderscoreApiDeploymentc6c2bbcee6"
+        }, 
+        "RestApiId": {
+          "Ref": "UnderscoreApi"
+        }, 
+        "StageName": "hoge_fuga"
+      }
+    }, 
+    "UnderscoreApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UnderscoreFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}, 
+                "parameters": [
+                  {
+                    "required": true, 
+                    "in": "body", 
+                    "name": "user", 
+                    "schema": {
+                      "$ref": "#/definitions/user"
+                    }
+                  }
+                ]
+              }
+            }
+          }, 
+          "swagger": "2.0", 
+          "definitions": {
+            "user": {
+              "type": "object", 
+              "properties": {
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "UnderscoreFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "HyphenFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": "HyphenApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "UnderscoreApiDeploymentc6c2bbcee6": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "UnderscoreApi"
+        }, 
+        "Description": "RestApi deployment id: c6c2bbcee65f47628f0f53f9a9e5134f2f6394b5", 
+        "StageName": "Stage"
+      }
+    }, 
+    "HyphenFunctionGetHtmlPermission0c8ecc62cb": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "HyphenFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "hoge-fuga", 
+              "__ApiId__": "HyphenApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenApiStage0c8ecc62cb": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "HyphenApiDeployment19b8787883"
+        }, 
+        "RestApiId": {
+          "Ref": "HyphenApi"
+        }, 
+        "StageName": "hoge-fuga"
+      }
+    }, 
+    "UnderscoreFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "UnderscoreFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "UnderscoreFunctionGetHtmlPermissionb34d3ad84e": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "UnderscoreFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "hoge_fuga", 
+              "__ApiId__": "UnderscoreApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "UnderscoreFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "UnderscoreFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": "UnderscoreApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "HyphenFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "HyphenApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HyphenFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}, 
+                "parameters": [
+                  {
+                    "required": true, 
+                    "in": "body", 
+                    "name": "user", 
+                    "schema": {
+                      "$ref": "#/definitions/user"
+                    }
+                  }
+                ]
+              }
+            }
+          }, 
+          "swagger": "2.0", 
+          "definitions": {
+            "user": {
+              "type": "object", 
+              "properties": {
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }, 
+    "HyphenFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-cn/api_with_incompatible_stage_name.json
+++ b/tests/translator/output/aws-cn/api_with_incompatible_stage_name.json
@@ -1,0 +1,330 @@
+{
+  "Resources": {
+    "UnderscoreApiStageb34d3ad84e": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "UnderscoreApiDeploymentd4074182ff"
+        }, 
+        "RestApiId": {
+          "Ref": "UnderscoreApi"
+        }, 
+        "StageName": "hoge_fuga"
+      }
+    }, 
+    "UnderscoreApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UnderscoreFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}, 
+                "parameters": [
+                  {
+                    "required": true, 
+                    "in": "body", 
+                    "name": "user", 
+                    "schema": {
+                      "$ref": "#/definitions/user"
+                    }
+                  }
+                ]
+              }
+            }
+          }, 
+          "swagger": "2.0", 
+          "definitions": {
+            "user": {
+              "type": "object", 
+              "properties": {
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }, 
+    "UnderscoreFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "HyphenFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": "HyphenApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "UnderscoreApiDeploymentd4074182ff": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "UnderscoreApi"
+        }, 
+        "Description": "RestApi deployment id: d4074182ff399887934824aa702b5573c9ad3f7c", 
+        "StageName": "Stage"
+      }
+    }, 
+    "HyphenFunctionGetHtmlPermission0c8ecc62cb": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "HyphenFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "hoge-fuga", 
+              "__ApiId__": "HyphenApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenApiStage0c8ecc62cb": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "HyphenApiDeployment52a312db45"
+        }, 
+        "RestApiId": {
+          "Ref": "HyphenApi"
+        }, 
+        "StageName": "hoge-fuga"
+      }
+    }, 
+    "UnderscoreFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "UnderscoreFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "UnderscoreFunctionGetHtmlPermissionb34d3ad84e": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "UnderscoreFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "hoge_fuga", 
+              "__ApiId__": "UnderscoreApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "UnderscoreFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "UnderscoreFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": "UnderscoreApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "HyphenFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "HyphenApiDeployment52a312db45": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HyphenApi"
+        }, 
+        "Description": "RestApi deployment id: 52a312db455cee5b3a5fca6c9c078593381e179b", 
+        "StageName": "Stage"
+      }
+    }, 
+    "HyphenApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HyphenFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}, 
+                "parameters": [
+                  {
+                    "required": true, 
+                    "in": "body", 
+                    "name": "user", 
+                    "schema": {
+                      "$ref": "#/definitions/user"
+                    }
+                  }
+                ]
+              }
+            }
+          }, 
+          "swagger": "2.0", 
+          "definitions": {
+            "user": {
+              "type": "object", 
+              "properties": {
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }, 
+    "HyphenFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_with_incompatible_stage_name.json
+++ b/tests/translator/output/aws-us-gov/api_with_incompatible_stage_name.json
@@ -1,0 +1,330 @@
+{
+  "Resources": {
+    "UnderscoreApiStageb34d3ad84e": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "UnderscoreApiDeployment94459366c6"
+        }, 
+        "RestApiId": {
+          "Ref": "UnderscoreApi"
+        }, 
+        "StageName": "hoge_fuga"
+      }
+    }, 
+    "UnderscoreApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${UnderscoreFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}, 
+                "parameters": [
+                  {
+                    "required": true, 
+                    "in": "body", 
+                    "name": "user", 
+                    "schema": {
+                      "$ref": "#/definitions/user"
+                    }
+                  }
+                ]
+              }
+            }
+          }, 
+          "swagger": "2.0", 
+          "definitions": {
+            "user": {
+              "type": "object", 
+              "properties": {
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }, 
+    "UnderscoreFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "HyphenFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": "HyphenApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenFunctionGetHtmlPermission0c8ecc62cb": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "HyphenFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "hoge-fuga", 
+              "__ApiId__": "HyphenApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenApiStage0c8ecc62cb": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "HyphenApiDeploymente60ebb9f56"
+        }, 
+        "RestApiId": {
+          "Ref": "HyphenApi"
+        }, 
+        "StageName": "hoge-fuga"
+      }
+    }, 
+    "UnderscoreFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "UnderscoreFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "UnderscoreFunctionGetHtmlPermissionb34d3ad84e": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "UnderscoreFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "hoge_fuga", 
+              "__ApiId__": "UnderscoreApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "UnderscoreFunctionGetHtmlPermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "UnderscoreFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": "UnderscoreApi"
+            }
+          ]
+        }
+      }
+    }, 
+    "HyphenFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "HyphenFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "HyphenApiDeploymente60ebb9f56": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HyphenApi"
+        }, 
+        "Description": "RestApi deployment id: e60ebb9f56220ac12550230674d09ed8085afc74", 
+        "StageName": "Stage"
+      }
+    }, 
+    "UnderscoreApiDeployment94459366c6": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "UnderscoreApi"
+        }, 
+        "Description": "RestApi deployment id: 94459366c6f9a344235ddf7db2a7cd5115d60da4", 
+        "StageName": "Stage"
+      }
+    }, 
+    "HyphenApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HyphenFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}, 
+                "parameters": [
+                  {
+                    "required": true, 
+                    "in": "body", 
+                    "name": "user", 
+                    "schema": {
+                      "$ref": "#/definitions/user"
+                    }
+                  }
+                ]
+              }
+            }
+          }, 
+          "swagger": "2.0", 
+          "definitions": {
+            "user": {
+              "type": "object", 
+              "properties": {
+                "username": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
+      }
+    }, 
+    "HyphenFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -177,6 +177,7 @@ class TestTranslatorEndToEnd(TestCase):
         'api_with_cors_and_only_maxage',
         'api_with_cors_and_only_credentials_false',
         'api_with_cors_no_definitionbody',
+        'api_with_incompatible_stage_name',
         'api_with_gateway_responses',
         'api_with_gateway_responses_all',
         'api_with_gateway_responses_minimal',


### PR DESCRIPTION
*Issue #1002*

*Description of changes:*

("-") is not accepted in CFn logical ID, but the stage name of API Gateway and Lambda permission may include ("-").  I changed the way to generate logical ID by logical_id_generator.

*Description of how you validated changes:*

I tried the following template, and it worked.
And I also added E2E tests.

```yaml
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31
Description: HelloWorld
Resources:
  MyAPI:
    Type: "AWS::Serverless::Api"
    Properties:
      StageName: test_test
  HelloWorld:
    Type: AWS::Serverless::Function
    Properties:
      Handler: index.handler
      Runtime: nodejs10.x
      CodeUri: s3://xxx/xxx
      Description: HelloWorld
      MemorySize: 128
      Timeout: 3
      Events:
        GetResource:
          Type: Api
          Properties:
            Path: /hello
            Method: get
            RestApiId: !Ref MyAPI
```

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
