### PR TITLE
fix: hard corded region and stack name of api_cognito_auth example

### DIFF
--- a/examples/2016-10-31/api_cognito_auth/package.json
+++ b/examples/2016-10-31/api_cognito_auth/package.json
@@ -19,12 +19,12 @@
     "configure-cognito-user-pool": "npm run set-cognito-user-pool-id && npm run set-cognito-user-pool-client-id && npm run set-api-id && npm run set-api-url && npm run update-user-pool-client && npm run create-user-pool-domain",
     "set-cognito-user-pool-id": "npm config set COGNITO_USER_POOL_ID $(aws cloudformation describe-stacks --stack-name $(npm config get STACK_NAME) --query 'Stacks[].Outputs[?OutputKey==`CognitoUserPoolId`].OutputValue' --output text)",
     "set-cognito-user-pool-client-id": "npm config set COGNITO_USER_POOL_CLIENT_ID $(aws cloudformation describe-stacks --stack-name $(npm config get STACK_NAME) --query 'Stacks[].Outputs[?OutputKey==`CognitoUserPoolClientId`].OutputValue' --output text)",
-    "set-api-url": "npm config set API_URL $(aws cloudformation describe-stacks --stack-name sam-example-api-cognito-auth --query 'Stacks[].Outputs[?OutputKey==`ApiUrl`].OutputValue' --output text)",
-    "set-api-id": "npm config set API_ID $(aws cloudformation describe-stacks --stack-name sam-example-api-cognito-auth --query 'Stacks[].Outputs[?OutputKey==`ApiId`].OutputValue' --output text)",
+    "set-api-url": "npm config set API_URL $(aws cloudformation describe-stacks --stack-name $(npm config get STACK_NAME) --query 'Stacks[].Outputs[?OutputKey==`ApiUrl`].OutputValue' --output text)",
+    "set-api-id": "npm config set API_ID $(aws cloudformation describe-stacks --stack-name $(npm config get STACK_NAME) --query 'Stacks[].Outputs[?OutputKey==`ApiId`].OutputValue' --output text)",
     "update-user-pool-client": "aws cognito-idp update-user-pool-client --user-pool-id $(npm config get COGNITO_USER_POOL_ID) --client-id $(npm config get COGNITO_USER_POOL_CLIENT_ID) --supported-identity-providers COGNITO --callback-urls \"[\\\"$(npm config get API_URL)\\\"]\" --allowed-o-auth-flows code implicit --allowed-o-auth-scopes openid email --allowed-o-auth-flows-user-pool-client",
     "create-user-pool-domain": "aws cognito-idp create-user-pool-domain --domain $(npm config get API_ID) --user-pool-id $(npm config get COGNITO_USER_POOL_ID)",
-    "open-signup-page": "open \"https://$(npm config get API_ID).auth.us-east-1.amazoncognito.com/signup?response_type=code&client_id=$(npm config get COGNITO_USER_POOL_CLIENT_ID)&redirect_uri=$(npm config get API_URL)\"",
-    "open-login-page": "open \"https://$(npm config get API_ID).auth.us-east-1.amazoncognito.com/login?response_type=code&client_id=$(npm config get COGNITO_USER_POOL_CLIENT_ID)&redirect_uri=$(npm config get API_URL)\"",
+    "open-signup-page": "open \"https://$(npm config get API_ID).auth.$(aws cloudformation describe-stacks --stack-name $(npm config get STACK_NAME) --query 'Stacks[].Outputs[?OutputKey==`Region`].OutputValue' --output text).amazoncognito.com/signup?response_type=code&client_id=$(npm config get COGNITO_USER_POOL_CLIENT_ID)&redirect_uri=$(npm config get API_URL)\"",
+    "open-login-page": "open \"https://$(npm config get API_ID).auth.$(aws cloudformation describe-stacks --stack-name $(npm config get STACK_NAME) --query 'Stacks[].Outputs[?OutputKey==`Region`].OutputValue' --output text).amazoncognito.com/login?response_type=code&client_id=$(npm config get COGNITO_USER_POOL_CLIENT_ID)&redirect_uri=$(npm config get API_URL)\"",
     "open-api-ui": "open \"$(npm config get API_URL)\""
   }
 }

--- a/examples/2016-10-31/api_cognito_auth/template.yaml
+++ b/examples/2016-10-31/api_cognito_auth/template.yaml
@@ -140,6 +140,10 @@ Resources:
       #       UserPool: !Ref MyCognitoUserPool
 
 Outputs:
+    Region:
+      Description: "Region"
+      Value: !Ref AWS::Region
+
     ApiId:
       Description: "API ID"
       Value: !Ref MyApi


### PR DESCRIPTION
*Issue #, if available:*
none 

*Description of changes:*

- `region` and `stack-name` of api_cognito_auth example was hard corded.
  - when I create stack on us-west-2 region, `npm run open-login-page` command returns wrong login-page.
  - when I create stack named hoge, `npm run configure-cognito-user-pool` command fails.
- I fixed hard corded region and stack-name parameters in package.json

*Description of how you validated changes:*

After I run the commands below, I verified the example worked well.

- npm run package-deploy 
- npm run configure-cognito-user-pool


*Checklist:*

- [-] Write/update tests
- [-] `make pr` passes
- [-] Update documentation
- [-] Verify transformed template deploys and application functions as expected
- [-] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
