### PR TITLE
fix: make sure Name and Type exists as a property of PrimaryKey of SimpleTable

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -537,6 +537,11 @@ class SamSimpleTable(SamResourceMacro):
         dynamodb_table = DynamoDBTable(self.logical_id, depends_on=self.depends_on, attributes=self.resource_attributes)
 
         if self.PrimaryKey:
+            if 'Name' not in self.PrimaryKey or 'Type' not in self.PrimaryKey:
+                raise InvalidResourceException(
+                    self.logical_id,
+                    '\'PrimaryKey\' is missing required Property \'Name\' or \'Type\'.'
+                )
             primary_key = {
                 'AttributeName': self.PrimaryKey['Name'],
                 'AttributeType': self._convert_attribute_type(self.PrimaryKey['Type'])

--- a/tests/translator/input/error_table_primary_key_missing_name.yaml
+++ b/tests/translator/input/error_table_primary_key_missing_name.yaml
@@ -1,0 +1,7 @@
+Resources:
+  Table:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Id: id
+        Type: String

--- a/tests/translator/input/error_table_primary_key_missing_type.yaml
+++ b/tests/translator/input/error_table_primary_key_missing_type.yaml
@@ -1,0 +1,6 @@
+Resources:
+  Table:
+    Type: AWS::Serverless::SimpleTable
+    Properties:
+      PrimaryKey:
+        Name: id

--- a/tests/translator/output/error_table_primary_key_missing_name.json
+++ b/tests/translator/output/error_table_primary_key_missing_name.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [Table] is invalid. 'PrimaryKey' is missing required Property 'Name' or 'Type'."
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Table] is invalid. 'PrimaryKey' is missing required Property 'Name' or 'Type'."
+}

--- a/tests/translator/output/error_table_primary_key_missing_type.json
+++ b/tests/translator/output/error_table_primary_key_missing_type.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [Table] is invalid. 'PrimaryKey' is missing required Property 'Name' or 'Type'."
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Table] is invalid. 'PrimaryKey' is missing required Property 'Name' or 'Type'."
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -457,6 +457,8 @@ class TestTranslatorEndToEnd(TestCase):
     'error_multiple_resource_errors',
     'error_s3_not_in_template',
     'error_table_invalid_attributetype',
+    'error_table_primary_key_missing_name',
+    'error_table_primary_key_missing_type',
     'error_invalid_resource_parameters',
     'error_reserved_sam_tag',
     'existing_event_logical_id',


### PR DESCRIPTION
*Issue #, if available:*
#884

*Description of changes:*
Add validation to `AWS::Serverless::SimpleTable` to make sure `Name` and `Type` exists as a property of `PrimaryKey`

*Description of how you validated changes:*
Added tests

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [-] Update documentation
- [-] Verify transformed template deploys and application functions as expected
- [-] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
