### PR TITLE
fix: redeploy api if the openapi version changes

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -199,7 +199,7 @@ class ApiGenerator(object):
         stage.TracingEnabled = self.tracing_enabled
 
         if swagger is not None:
-            deployment.make_auto_deployable(stage, swagger)
+            deployment.make_auto_deployable(stage, self.open_api_version, swagger)
 
         if self.tags is not None:
             stage.Tags = get_tag_list(self.tags)

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -74,9 +74,10 @@ class ApiGatewayDeployment(Resource):
         "deployment_id": lambda self: ref(self.logical_id),
     }
 
-    def make_auto_deployable(self, stage, swagger=None):
+    def make_auto_deployable(self, stage, openapi_version=None, swagger=None):
         """
-        Sets up the resource such that it will triggers a re-deployment when Swagger changes
+        Sets up the resource such that it will trigger a re-deployment when Swagger changes
+        or the openapi version changes.
 
         :param swagger: Dictionary containing the Swagger definition of the API
         """
@@ -89,7 +90,10 @@ class ApiGatewayDeployment(Resource):
         # to prevent redeployment when API has not changed
 
         # NOTE: `str(swagger)` is for backwards compatibility. Changing it to a JSON or something will break compat
-        generator = logical_id_generator.LogicalIdGenerator(self.logical_id, str(swagger))
+        hash_input = str(swagger)
+        if openapi_version:
+            hash_input = hash_input + str(openapi_version)
+        generator = logical_id_generator.LogicalIdGenerator(self.logical_id, hash_input)
         self.logical_id = generator.gen()
         hash = generator.get_hash(length=40)  # Get the full hash
         self.Description = "RestApi deployment id: {}".format(hash)

--- a/tests/translator/output/api_request_model_openapi_3.json
+++ b/tests/translator/output/api_request_model_openapi_3.json
@@ -21,6 +21,15 @@
         }
       }
     }, 
+    "HtmlApiDeployment77aaf3ac13": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        }, 
+        "Description": "RestApi deployment id: 77aaf3ac132a9282281fd55bdeac6fe7466e8337"
+      }
+    }, 
     "HtmlFunctionRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -49,7 +58,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeployment47f78fe7d9"
+          "Ref": "HtmlApiDeployment77aaf3ac13"
         }, 
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -162,15 +171,6 @@
             }
           }
         }
-      }
-    }, 
-    "HtmlApiDeployment47f78fe7d9": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: 47f78fe7d91eb5d2070674ad77943842c49dab89"
       }
     }, 
     "HtmlFunctionGetHtmlPermissionTest": {

--- a/tests/translator/output/api_with_apikey_required_openapi_3.json
+++ b/tests/translator/output/api_with_apikey_required_openapi_3.json
@@ -45,6 +45,15 @@
         }
       }
     }, 
+    "MyApiWithoutAuthDeployment140350c252": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithoutAuth"
+        }, 
+        "Description": "RestApi deployment id: 140350c2525068ff2e9bb5e7ee0765718974523d"
+      }
+    }, 
     "MyApiWithoutAuth": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
@@ -91,7 +100,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment741383c56d"
+          "Ref": "MyApiWithoutAuthDeployment140350c252"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
@@ -141,15 +150,6 @@
             "Key": "lambda:createdBy"
           }
         ]
-      }
-    }, 
-    "MyApiWithoutAuthDeployment741383c56d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithoutAuth"
-        }, 
-        "Description": "RestApi deployment id: 741383c56de0cab1f561223582a9259cf165b42f"
       }
     }
   }

--- a/tests/translator/output/api_with_auth_all_maximum_openapi_3.json
+++ b/tests/translator/output/api_with_auth_all_maximum_openapi_3.json
@@ -170,15 +170,6 @@
         }
       }
     }, 
-    "MyApiDeployment959b43a9ef": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 959b43a9efc3347ee417e242c5f936bbd40ef663"
-      }
-    }, 
     "MyApi": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
@@ -486,7 +477,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment959b43a9ef"
+          "Ref": "MyApiDeploymente181e32adc"
         }, 
         "RestApiId": {
           "Ref": "MyApi"
@@ -513,6 +504,15 @@
             }
           ]
         }
+      }
+    }, 
+    "MyApiDeploymente181e32adc": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "Description": "RestApi deployment id: e181e32adcccf59d699baf300078344166614113"
       }
     }, 
     "MyFunctionWithDefaultAuthorizerPermissionProd": {

--- a/tests/translator/output/api_with_auth_all_minimum_openapi.json
+++ b/tests/translator/output/api_with_auth_all_minimum_openapi.json
@@ -54,11 +54,20 @@
         }
       }
     }, 
+    "MyApiWithLambdaTokenAuthDeployment5100134cea": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        }, 
+        "Description": "RestApi deployment id: 5100134cea4b4506bd0894f86bfe775c9903ae82"
+      }
+    }, 
     "MyApiWithLambdaRequestAuthProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeployment54a6335ed7"
+          "Ref": "MyApiWithLambdaRequestAuthDeployment195678a2e7"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
@@ -87,6 +96,15 @@
             }
           ]
         }
+      }
+    }, 
+    "MyApiWithLambdaRequestAuthDeployment195678a2e7": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        }, 
+        "Description": "RestApi deployment id: 195678a2e73ee92ca367f5b4ba814c6e0022df01"
       }
     }, 
     "MyFnLambdaRequestPermissionTest": {
@@ -131,13 +149,25 @@
         }
       }
     }, 
-    "MyApiWithLambdaTokenAuthDeployment2ac4484273": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "MyFnCognitoPermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFn"
         }, 
-        "Description": "RestApi deployment id: 2ac4484273f55c601b17c8491ffad73a979b2aeb"
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithCognitoAuth"
+              }
+            }
+          ]
+        }
       }
     }, 
     "MyAuthFn": {
@@ -161,15 +191,6 @@
             "Key": "lambda:createdBy"
           }
         ]
-      }
-    }, 
-    "MyApiWithCognitoAuthDeployment2eadfec019": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: 2eadfec019d342cb7f6d66f595b9ab88e82fa00a"
       }
     }, 
     "MyFnRole": {
@@ -200,7 +221,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeployment2eadfec019"
+          "Ref": "MyApiWithCognitoAuthDeploymentcae360c856"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
@@ -227,36 +248,6 @@
             }
           ]
         }
-      }
-    }, 
-    "MyApiWithLambdaRequestAuthDeployment54a6335ed7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: 54a6335ed76c2060eaf1fff2ff6522f20ecaef0f"
-      }
-    }, 
-    "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
-      "Properties": {
-        "UsernameAttributes": [
-          "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
-        "Policies": {
-          "PasswordPolicy": {
-            "MinimumLength": 8
-          }
-        }, 
-        "Schema": [
-          {
-            "AttributeDataType": "String", 
-            "Required": false, 
-            "Name": "email"
-          }
-        ]
       }
     }, 
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
@@ -383,25 +374,34 @@
         }
       }
     }, 
-    "MyFnCognitoPermissionTest": {
-      "Type": "AWS::Lambda::Permission", 
+    "MyApiWithCognitoAuthDeploymentcae360c856": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
-        "Action": "lambda:invokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "MyFn"
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
         }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/cognito", 
-            {
-              "__Stage__": "*", 
-              "__ApiId__": {
-                "Ref": "MyApiWithCognitoAuth"
-              }
-            }
-          ]
-        }
+        "Description": "RestApi deployment id: cae360c856d65fceaffb4bf24ebf5c4eac239e53"
+      }
+    }, 
+    "MyUserPool": {
+      "Type": "AWS::Cognito::UserPool", 
+      "Properties": {
+        "UsernameAttributes": [
+          "email"
+        ], 
+        "UserPoolName": "UserPoolName", 
+        "Policies": {
+          "PasswordPolicy": {
+            "MinimumLength": 8
+          }
+        }, 
+        "Schema": [
+          {
+            "AttributeDataType": "String", 
+            "Required": false, 
+            "Name": "email"
+          }
+        ]
       }
     }, 
     "MyFn": {
@@ -455,7 +455,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeployment2ac4484273"
+          "Ref": "MyApiWithLambdaTokenAuthDeployment5100134cea"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"

--- a/tests/translator/output/api_with_cors_openapi_3.json
+++ b/tests/translator/output/api_with_cors_openapi_3.json
@@ -253,7 +253,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment36174ded39"
+          "Ref": "ServerlessRestApiDeployment3e214d1cac"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -265,7 +265,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment3a5a78688c"
+          "Ref": "ExplicitApiDeploymentbabea58445"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -318,13 +318,13 @@
         }
       }
     }, 
-    "ExplicitApiDeployment3a5a78688c": {
+    "ServerlessRestApiDeployment3e214d1cac": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
-          "Ref": "ExplicitApi"
+          "Ref": "ServerlessRestApi"
         }, 
-        "Description": "RestApi deployment id: 3a5a78688c9bc377d53aa4153a11f0c4f6e7364c"
+        "Description": "RestApi deployment id: 3e214d1cac2e110e6e28a389a4ba80057c5f0842"
       }
     }, 
     "RestApiFunction": {
@@ -350,13 +350,13 @@
         ]
       }
     }, 
-    "ServerlessRestApiDeployment36174ded39": {
+    "ExplicitApiDeploymentbabea58445": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
-          "Ref": "ServerlessRestApi"
+          "Ref": "ExplicitApi"
         }, 
-        "Description": "RestApi deployment id: 36174ded3978092f96669107074db6caeaaafddd"
+        "Description": "RestApi deployment id: babea584458ca2e980baa334bd70f8b193375895"
       }
     }, 
     "ServerlessRestApi": {

--- a/tests/translator/output/api_with_gateway_responses_all_openapi_3.json
+++ b/tests/translator/output/api_with_gateway_responses_all_openapi_3.json
@@ -23,15 +23,6 @@
         ]
       }
     }, 
-    "ExplicitApiDeployment47d77987a3": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 47d77987a3152a97c89d794f2682485b9dafde5d"
-      }
-    }, 
     "FunctionRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -104,11 +95,20 @@
         }
       }
     }, 
+    "ExplicitApiDeployment23e7ed36e4": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 23e7ed36e41c87979e26864331c8fbd0a22d2906"
+      }
+    }, 
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment47d77987a3"
+          "Ref": "ExplicitApiDeployment23e7ed36e4"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"

--- a/tests/translator/output/api_with_open_api_version.json
+++ b/tests/translator/output/api_with_open_api_version.json
@@ -68,15 +68,6 @@
         }
       }
     }, 
-    "ExplicitApiDeployment01dd43a75f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 01dd43a75fc0e125c678d20749bacde95d723928"
-      }
-    }, 
     "ImplicitApiFunctionGetHtmlPermissionProd": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
@@ -113,11 +104,23 @@
         }
       }
     }, 
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeployment1e9fbca603"
+        }, 
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment82c7b2e316"
+          "Ref": "ServerlessRestApiDeploymentacd2d469b0"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -125,16 +128,22 @@
         "StageName": "Prod"
       }
     }, 
-    "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+    "ExplicitApiDeployment1e9fbca603": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
-        "DeploymentId": {
-          "Ref": "ExplicitApiDeployment01dd43a75f"
-        }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
         }, 
-        "StageName": "Prod"
+        "Description": "RestApi deployment id: 1e9fbca603907b0cfb3e8164fa9d4c3b95b4272d"
+      }
+    }, 
+    "ServerlessRestApiDeploymentacd2d469b0": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: acd2d469b0bc58a0e115764c4385e0254ae0bd7e"
       }
     }, 
     "ServerlessRestApi": {
@@ -203,15 +212,6 @@
           }, 
           "openapi": "3.0.1"
         }
-      }
-    }, 
-    "ServerlessRestApiDeployment82c7b2e316": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 82c7b2e3162ebd01c9b3ccaa1fafa5cc1df94a68"
       }
     }
   }

--- a/tests/translator/output/api_with_open_api_version_2.json
+++ b/tests/translator/output/api_with_open_api_version_2.json
@@ -89,6 +89,15 @@
         }
       }
     }, 
+    "ExplicitApiDeployment323af4d2f5": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 323af4d2f576d27b094bb4e64e6fd8ada81b630b"
+      }
+    }, 
     "ExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
@@ -104,20 +113,11 @@
         }
       }
     }, 
-    "ServerlessRestApiDeploymentb9bf7835be": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: b9bf7835be8ea0cb2c188b846e03ff6f79f4d330"
-      }
-    }, 
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment5332c373d4"
+          "Ref": "ExplicitApiDeployment323af4d2f5"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -129,12 +129,21 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentb9bf7835be"
+          "Ref": "ServerlessRestApiDeployment3644a4133f"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         }, 
         "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment3644a4133f": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 3644a4133f18ca79220abe30b7f27b7e9a55cd06"
       }
     }, 
     "ServerlessRestApi": {
@@ -203,15 +212,6 @@
           }, 
           "swagger": "2.0"
         }
-      }
-    }, 
-    "ExplicitApiDeployment5332c373d4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 5332c373d45c69e6c0f562b4a419aa8eb311adc7"
       }
     }
   }

--- a/tests/translator/output/api_with_openapi_definition_body_no_flag.json
+++ b/tests/translator/output/api_with_openapi_definition_body_no_flag.json
@@ -47,15 +47,6 @@
         }
       }
     }, 
-    "ExplicitApiDeployment9252467a1e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 9252467a1edc49ba35cb258640f5e3734cc9fab1"
-      }
-    }, 
     "ImplicitApiFunctionGetHtmlPermissionTest": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
@@ -172,7 +163,7 @@
         }, 
         "CacheClusterEnabled": true, 
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9252467a1e"
+          "Ref": "ExplicitApiDeployment748947f06a"
         }
       }
     }, 
@@ -216,6 +207,15 @@
             "Name": "email"
           }
         ]
+      }
+    }, 
+    "ExplicitApiDeployment748947f06a": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 748947f06a1a8de71a295f51af31d94b932fe2fc"
       }
     }, 
     "ServerlessRestApi": {

--- a/tests/translator/output/aws-cn/api_request_model_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_request_model_openapi_3.json
@@ -49,7 +49,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeployment78cd64f7cb"
+          "Ref": "HtmlApiDeploymentdcba4b4073"
         }, 
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -172,13 +172,13 @@
         }
       }
     }, 
-    "HtmlApiDeployment78cd64f7cb": {
+    "HtmlApiDeploymentdcba4b4073": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "HtmlApi"
         }, 
-        "Description": "RestApi deployment id: 78cd64f7cb1e91b0fda215267bac0aac70b20b1b"
+        "Description": "RestApi deployment id: dcba4b407341ea76ae262bf7fd11078328e52168"
       }
     }, 
     "HtmlFunctionGetHtmlPermissionTest": {

--- a/tests/translator/output/aws-cn/api_with_apikey_required_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_with_apikey_required_openapi_3.json
@@ -45,13 +45,13 @@
         }
       }
     }, 
-    "MyApiWithoutAuthDeployment859a8b8388": {
+    "MyApiWithoutAuthDeployment357a42f0aa": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
         }, 
-        "Description": "RestApi deployment id: 859a8b8388c863dbda96b384cefea4ac988f5f81"
+        "Description": "RestApi deployment id: 357a42f0aa7732edc83e7064dab8dc4050abb0e9"
       }
     }, 
     "MyApiWithoutAuth": {
@@ -108,7 +108,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeployment859a8b8388"
+          "Ref": "MyApiWithoutAuthDeployment357a42f0aa"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"

--- a/tests/translator/output/aws-cn/api_with_auth_all_maximum_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_with_auth_all_maximum_openapi_3.json
@@ -146,6 +146,15 @@
         }
       }
     }, 
+    "MyApiDeploymentc3ee011ecc": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "Description": "RestApi deployment id: c3ee011ecc11fa841524767079400e1fb8a3d57c"
+      }
+    }, 
     "MyFunctionRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -382,13 +391,22 @@
         }
       }
     }, 
-    "MyApiDeploymente3164c0eda": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "MyApiMyLambdaTokenAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: e3164c0edaf0d9fc342c47f30edf05040f87af8b"
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": "arn:aws", 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            {
+              "__ApiId__": {
+                "Ref": "MyApi"
+              }
+            }
+          ]
+        }
       }
     }, 
     "MyFunctionWithLambdaRequestAuthorizerPermissionTest": {
@@ -472,29 +490,11 @@
         }
       }
     }, 
-    "MyApiMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
-      "Properties": {
-        "Action": "lambda:invokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": "arn:aws", 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-            {
-              "__ApiId__": {
-                "Ref": "MyApi"
-              }
-            }
-          ]
-        }
-      }
-    }, 
     "MyApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymente3164c0eda"
+          "Ref": "MyApiDeploymentc3ee011ecc"
         }, 
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-cn/api_with_auth_all_minimum_openapi.json
+++ b/tests/translator/output/aws-cn/api_with_auth_all_minimum_openapi.json
@@ -66,7 +66,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeploymentf8f280f2eb"
+          "Ref": "MyApiWithLambdaRequestAuthDeployment50560e1b93"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
@@ -74,36 +74,22 @@
         "StageName": "Prod"
       }
     }, 
-    "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
-      "Type": "AWS::Lambda::Permission", 
-      "Properties": {
-        "Action": "lambda:invokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Fn::GetAtt": [
-            "MyAuthFn", 
-            "Arn"
-          ]
-        }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
-            {
-              "__ApiId__": {
-                "Ref": "MyApiWithLambdaTokenAuth"
-              }
-            }
-          ]
-        }
-      }
-    }, 
-    "MyApiWithLambdaRequestAuthDeploymentf8f280f2eb": {
+    "MyApiWithLambdaRequestAuthDeployment50560e1b93": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
         }, 
-        "Description": "RestApi deployment id: f8f280f2eb973eb694b872901c9395c3d3e05252"
+        "Description": "RestApi deployment id: 50560e1b93c278b5dedf0adcaf531cde88700103"
+      }
+    }, 
+    "MyApiWithLambdaTokenAuthDeploymente8e324a96a": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
+        }, 
+        "Description": "RestApi deployment id: e8e324a96af0eefc9f8b328f9abdb94af12348ed"
       }
     }, 
     "MyFnLambdaRequestPermissionTest": {
@@ -220,12 +206,21 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeploymente116f8541f"
+          "Ref": "MyApiWithCognitoAuthDeployment943c497d0c"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
         }, 
         "StageName": "Prod"
+      }
+    }, 
+    "MyApiWithCognitoAuthDeployment943c497d0c": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        }, 
+        "Description": "RestApi deployment id: 943c497d0c89ac6ab9c933c386e68f15b8cde482"
       }
     }, 
     "MyFnCognitoPermissionProd": {
@@ -381,15 +376,6 @@
         }
       }
     }, 
-    "MyApiWithLambdaTokenAuthDeploymentae2752e462": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: ae2752e46261b6dac7c962a6a65154ea5189f594"
-      }
-    }, 
     "MyUserPool": {
       "Type": "AWS::Cognito::UserPool", 
       "Properties": {
@@ -434,6 +420,29 @@
         ]
       }
     }, 
+    "MyApiWithLambdaTokenAuthMyLambdaTokenAuthAuthorizerPermission": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Fn::GetAtt": [
+            "MyAuthFn", 
+            "Arn"
+          ]
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/authorizers/*", 
+            {
+              "__ApiId__": {
+                "Ref": "MyApiWithLambdaTokenAuth"
+              }
+            }
+          ]
+        }
+      }
+    }, 
     "MyAuthFnRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -462,7 +471,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeploymentae2752e462"
+          "Ref": "MyApiWithLambdaTokenAuthDeploymente8e324a96a"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"
@@ -536,15 +545,6 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }
-    }, 
-    "MyApiWithCognitoAuthDeploymente116f8541f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
-        }, 
-        "Description": "RestApi deployment id: e116f8541f950bade71c8656c6a8493fd823d35c"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_cors_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_with_cors_openapi_3.json
@@ -261,7 +261,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment5f2f2e0731"
+          "Ref": "ServerlessRestApiDeployment85d3360729"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -273,21 +273,12 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment3a5a78688c"
+          "Ref": "ExplicitApiDeploymentbabea58445"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
         }, 
         "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiDeployment5f2f2e0731": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 5f2f2e07317e5f71e17f2a1f0cb2c1833f881340"
       }
     }, 
     "RestApiFunctionRole": {
@@ -335,13 +326,13 @@
         }
       }
     }, 
-    "ExplicitApiDeployment3a5a78688c": {
+    "ServerlessRestApiDeployment85d3360729": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
-          "Ref": "ExplicitApi"
+          "Ref": "ServerlessRestApi"
         }, 
-        "Description": "RestApi deployment id: 3a5a78688c9bc377d53aa4153a11f0c4f6e7364c"
+        "Description": "RestApi deployment id: 85d33607297efc01252aeae20f6a000ac2843483"
       }
     }, 
     "RestApiFunction": {
@@ -365,6 +356,15 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    }, 
+    "ExplicitApiDeploymentbabea58445": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: babea584458ca2e980baa334bd70f8b193375895"
       }
     }, 
     "ServerlessRestApi": {

--- a/tests/translator/output/aws-cn/api_with_gateway_responses_all_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_with_gateway_responses_all_openapi_3.json
@@ -107,12 +107,21 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment4c4177079d"
+          "Ref": "ExplicitApiDeployment9cf935255f"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
         }, 
         "StageName": "Prod"
+      }
+    }, 
+    "ExplicitApiDeployment9cf935255f": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 9cf935255fad6f1e878435583797e0245e85e570"
       }
     }, 
     "FunctionGetHtmlPermissionProd": {
@@ -134,15 +143,6 @@
             }
           ]
         }
-      }
-    }, 
-    "ExplicitApiDeployment4c4177079d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 4c4177079dd342a2b71978bd25721b7b774295ad"
       }
     }, 
     "FunctionGetHtmlPermissionTest": {

--- a/tests/translator/output/aws-cn/api_with_open_api_version.json
+++ b/tests/translator/output/aws-cn/api_with_open_api_version.json
@@ -68,15 +68,6 @@
         }
       }
     }, 
-    "ExplicitApiDeployment01dd43a75f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 01dd43a75fc0e125c678d20749bacde95d723928"
-      }
-    }, 
     "ImplicitApiFunctionGetHtmlPermissionProd": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
@@ -125,7 +116,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentb86b9dad9d"
+          "Ref": "ServerlessRestApiDeployment1eb1f25f25"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -133,11 +124,20 @@
         "StageName": "Prod"
       }
     }, 
+    "ExplicitApiDeployment1e9fbca603": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 1e9fbca603907b0cfb3e8164fa9d4c3b95b4272d"
+      }
+    }, 
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment01dd43a75f"
+          "Ref": "ExplicitApiDeployment1e9fbca603"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -221,13 +221,13 @@
         }
       }
     }, 
-    "ServerlessRestApiDeploymentb86b9dad9d": {
+    "ServerlessRestApiDeployment1eb1f25f25": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         }, 
-        "Description": "RestApi deployment id: b86b9dad9d2fd5286c7b355dbd5350987cf492c1"
+        "Description": "RestApi deployment id: 1eb1f25f25d73d4340cd16527052e2efcdca8b74"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_open_api_version_2.json
+++ b/tests/translator/output/aws-cn/api_with_open_api_version_2.json
@@ -89,6 +89,15 @@
         }
       }
     }, 
+    "ServerlessRestApiDeployment2bcbad30d7": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 2bcbad30d76c3d64bfb45cf0c5e883588cf75944"
+      }
+    }, 
     "ExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
@@ -112,11 +121,20 @@
         }
       }
     }, 
+    "ExplicitApiDeployment323af4d2f5": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 323af4d2f576d27b094bb4e64e6fd8ada81b630b"
+      }
+    }, 
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentc444e5d902"
+          "Ref": "ServerlessRestApiDeployment2bcbad30d7"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -128,21 +146,12 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment5332c373d4"
+          "Ref": "ExplicitApiDeployment323af4d2f5"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
         }, 
         "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiDeploymentc444e5d902": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: c444e5d902971761ced658a7ce701149743eb376"
       }
     }, 
     "ServerlessRestApi": {
@@ -219,15 +228,6 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }
-    }, 
-    "ExplicitApiDeployment5332c373d4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 5332c373d45c69e6c0f562b4a419aa8eb311adc7"
       }
     }
   }

--- a/tests/translator/output/aws-cn/api_with_openapi_definition_body_no_flag.json
+++ b/tests/translator/output/aws-cn/api_with_openapi_definition_body_no_flag.json
@@ -47,15 +47,6 @@
         }
       }
     }, 
-    "ExplicitApiDeployment9252467a1e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 9252467a1edc49ba35cb258640f5e3734cc9fab1"
-      }
-    }, 
     "ImplicitApiFunctionGetHtmlPermissionTest": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
@@ -180,7 +171,7 @@
         }, 
         "CacheClusterEnabled": true, 
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9252467a1e"
+          "Ref": "ExplicitApiDeployment748947f06a"
         }
       }
     }, 
@@ -224,6 +215,15 @@
             "Name": "email"
           }
         ]
+      }
+    }, 
+    "ExplicitApiDeployment748947f06a": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 748947f06a1a8de71a295f51af31d94b932fe2fc"
       }
     }, 
     "ServerlessRestApi": {

--- a/tests/translator/output/aws-cn/explicit_api_openapi_3.json
+++ b/tests/translator/output/aws-cn/explicit_api_openapi_3.json
@@ -37,7 +37,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment09cda3d97b"
+          "Ref": "ApiWithInlineSwaggerDeployment88733439c5"
         }, 
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
@@ -45,6 +45,15 @@
         "StageName": {
           "Ref": "MyStageName"
         }
+      }
+    }, 
+    "ApiWithInlineSwaggerDeployment88733439c5": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithInlineSwagger"
+        }, 
+        "Description": "RestApi deployment id: 88733439c55b6ebd05ddec6505b6d8647d145b50"
       }
     }, 
     "GetHtmlFunctionGetHtmlPermissionTest": {
@@ -179,15 +188,6 @@
         "StageName": {
           "Ref": "MyStageName"
         }
-      }
-    }, 
-    "ApiWithInlineSwaggerDeployment09cda3d97b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 09cda3d97b008bed7bd4ebb1b5304ed622492941"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_request_model_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_request_model_openapi_3.json
@@ -21,6 +21,15 @@
         }
       }
     }, 
+    "HtmlApiDeploymentda3232aa55": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        }, 
+        "Description": "RestApi deployment id: da3232aa55c051d9a70127cb968912176f191af7"
+      }
+    }, 
     "HtmlFunctionRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -49,7 +58,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeployment73fda15117"
+          "Ref": "HtmlApiDeploymentda3232aa55"
         }, 
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -170,15 +179,6 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }
-    }, 
-    "HtmlApiDeployment73fda15117": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: 73fda151173319fe1f84fa9c2a7ff69514fced3b"
       }
     }, 
     "HtmlFunctionGetHtmlPermissionTest": {

--- a/tests/translator/output/aws-us-gov/api_with_apikey_required_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_with_apikey_required_openapi_3.json
@@ -45,6 +45,15 @@
         }
       }
     }, 
+    "MyApiWithoutAuthDeploymentb6f62a92bd": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithoutAuth"
+        }, 
+        "Description": "RestApi deployment id: b6f62a92bd079aa91036e202673cedd83b73e0c3"
+      }
+    }, 
     "MyApiWithoutAuth": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
@@ -99,7 +108,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithoutAuthDeploymentfee0b2b452"
+          "Ref": "MyApiWithoutAuthDeploymentb6f62a92bd"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithoutAuth"
@@ -149,15 +158,6 @@
             "Key": "lambda:createdBy"
           }
         ]
-      }
-    }, 
-    "MyApiWithoutAuthDeploymentfee0b2b452": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithoutAuth"
-        }, 
-        "Description": "RestApi deployment id: fee0b2b45266fff45b8edba43206618eabefebfe"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_auth_all_maximum_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_all_maximum_openapi_3.json
@@ -442,6 +442,15 @@
         }
       }
     }, 
+    "MyApiDeploymentcc3d4f033f": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "Description": "RestApi deployment id: cc3d4f033f302fc0827f2ec54ee1b394474f3bc8"
+      }
+    }, 
     "MyFunctionWithCognitoMultipleUserPoolsAuthorizerPermissionTest": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
@@ -481,20 +490,11 @@
         }
       }
     }, 
-    "MyApiDeploymente67481ad45": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: e67481ad4559fa2ba87f90009db679ae7d0c7c57"
-      }
-    }, 
     "MyApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymente67481ad45"
+          "Ref": "MyApiDeploymentcc3d4f033f"
         }, 
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-us-gov/api_with_auth_all_minimum_openapi.json
+++ b/tests/translator/output/aws-us-gov/api_with_auth_all_minimum_openapi.json
@@ -1,14 +1,5 @@
 {
   "Resources": {
-    "MyApiWithLambdaTokenAuthDeployment0add72ee5b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaTokenAuth"
-        }, 
-        "Description": "RestApi deployment id: 0add72ee5b93d4332ccfaf6b521b1d6c98346235"
-      }
-    }, 
     "MyApiWithCognitoAuth": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
@@ -75,7 +66,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaRequestAuthDeploymente9da24fd8b"
+          "Ref": "MyApiWithLambdaRequestAuthDeployment26f2ec8dc2"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithLambdaRequestAuth"
@@ -106,25 +97,31 @@
         }
       }
     }, 
-    "MyFnLambdaRequestPermissionTest": {
-      "Type": "AWS::Lambda::Permission", 
+    "MyApiWithLambdaTokenAuthDeployment12dbbda3a3": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
-        "Action": "lambda:invokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
-        "FunctionName": {
-          "Ref": "MyFn"
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaTokenAuth"
         }, 
-        "SourceArn": {
-          "Fn::Sub": [
-            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
-            {
-              "__Stage__": "*", 
-              "__ApiId__": {
-                "Ref": "MyApiWithLambdaRequestAuth"
-              }
-            }
-          ]
-        }
+        "Description": "RestApi deployment id: 12dbbda3a3bf53e42069a9045c5a54b8650b092d"
+      }
+    }, 
+    "MyApiWithCognitoAuthDeployment2813ca7ed8": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithCognitoAuth"
+        }, 
+        "Description": "RestApi deployment id: 2813ca7ed87e18b2a034b30d5c5696abd95d7c66"
+      }
+    }, 
+    "MyApiWithLambdaRequestAuthDeployment26f2ec8dc2": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApiWithLambdaRequestAuth"
+        }, 
+        "Description": "RestApi deployment id: 26f2ec8dc2f36b8ae66401fa2c1e915b6c9130e2"
       }
     }, 
     "MyFnLambdaTokenPermissionTest": {
@@ -220,7 +217,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithCognitoAuthDeploymentc77185482f"
+          "Ref": "MyApiWithCognitoAuthDeployment2813ca7ed8"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithCognitoAuth"
@@ -249,25 +246,25 @@
         }
       }
     }, 
-    "MyUserPool": {
-      "Type": "AWS::Cognito::UserPool", 
+    "MyFnLambdaRequestPermissionTest": {
+      "Type": "AWS::Lambda::Permission", 
       "Properties": {
-        "UsernameAttributes": [
-          "email"
-        ], 
-        "UserPoolName": "UserPoolName", 
-        "Policies": {
-          "PasswordPolicy": {
-            "MinimumLength": 8
-          }
+        "Action": "lambda:invokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "MyFn"
         }, 
-        "Schema": [
-          {
-            "AttributeDataType": "String", 
-            "Required": false, 
-            "Name": "email"
-          }
-        ]
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/lambda-request", 
+            {
+              "__Stage__": "*", 
+              "__ApiId__": {
+                "Ref": "MyApiWithLambdaRequestAuth"
+              }
+            }
+          ]
+        }
       }
     }, 
     "MyApiWithLambdaRequestAuthMyLambdaRequestAuthAuthorizerPermission": {
@@ -402,13 +399,25 @@
         }
       }
     }, 
-    "MyApiWithCognitoAuthDeploymentc77185482f": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "MyUserPool": {
+      "Type": "AWS::Cognito::UserPool", 
       "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithCognitoAuth"
+        "UsernameAttributes": [
+          "email"
+        ], 
+        "UserPoolName": "UserPoolName", 
+        "Policies": {
+          "PasswordPolicy": {
+            "MinimumLength": 8
+          }
         }, 
-        "Description": "RestApi deployment id: c77185482f5da13033fc9807c218b651c53a8c6c"
+        "Schema": [
+          {
+            "AttributeDataType": "String", 
+            "Required": false, 
+            "Name": "email"
+          }
+        ]
       }
     }, 
     "MyFn": {
@@ -432,15 +441,6 @@
             "Key": "lambda:createdBy"
           }
         ]
-      }
-    }, 
-    "MyApiWithLambdaRequestAuthDeploymente9da24fd8b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApiWithLambdaRequestAuth"
-        }, 
-        "Description": "RestApi deployment id: e9da24fd8b2ad6c40b7137492a1a1c9a3cdf1908"
       }
     }, 
     "MyAuthFnRole": {
@@ -471,7 +471,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiWithLambdaTokenAuthDeployment0add72ee5b"
+          "Ref": "MyApiWithLambdaTokenAuthDeployment12dbbda3a3"
         }, 
         "RestApiId": {
           "Ref": "MyApiWithLambdaTokenAuth"

--- a/tests/translator/output/aws-us-gov/api_with_cors_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_with_cors_openapi_3.json
@@ -261,7 +261,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment2cd28b2066"
+          "Ref": "ServerlessRestApiDeploymentdd32a75aeb"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -273,7 +273,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment3a5a78688c"
+          "Ref": "ExplicitApiDeploymentbabea58445"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
@@ -326,24 +326,6 @@
         }
       }
     }, 
-    "ServerlessRestApiDeployment2cd28b2066": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 2cd28b2066d69ecfb44eb7e024734cab2f3f9dac"
-      }
-    }, 
-    "ExplicitApiDeployment3a5a78688c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 3a5a78688c9bc377d53aa4153a11f0c4f6e7364c"
-      }
-    }, 
     "RestApiFunction": {
       "Type": "AWS::Lambda::Function", 
       "Properties": {
@@ -365,6 +347,24 @@
             "Key": "lambda:createdBy"
           }
         ]
+      }
+    }, 
+    "ExplicitApiDeploymentbabea58445": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: babea584458ca2e980baa334bd70f8b193375895"
+      }
+    }, 
+    "ServerlessRestApiDeploymentdd32a75aeb": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: dd32a75aeb16c5183a85dd7fe7591c4b88387b6d"
       }
     }, 
     "ServerlessRestApi": {

--- a/tests/translator/output/aws-us-gov/api_with_gateway_responses_all_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_with_gateway_responses_all_openapi_3.json
@@ -23,15 +23,6 @@
         ]
       }
     }, 
-    "ExplicitApiDeployment3a19adf892": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 3a19adf892fbe70d360659eb3660359ade61913b"
-      }
-    }, 
     "FunctionRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -116,12 +107,21 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment3a19adf892"
+          "Ref": "ExplicitApiDeployment81c693e541"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
         }, 
         "StageName": "Prod"
+      }
+    }, 
+    "ExplicitApiDeployment81c693e541": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 81c693e5415eab343422dcaa0b0899ff31e192d0"
       }
     }, 
     "FunctionGetHtmlPermissionProd": {

--- a/tests/translator/output/aws-us-gov/api_with_open_api_version.json
+++ b/tests/translator/output/aws-us-gov/api_with_open_api_version.json
@@ -112,23 +112,20 @@
         }
       }
     }, 
-    "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+    "ExplicitApiDeployment1e9fbca603": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
-        "DeploymentId": {
-          "Ref": "ExplicitApiDeployment01dd43a75f"
-        }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
         }, 
-        "StageName": "Prod"
+        "Description": "RestApi deployment id: 1e9fbca603907b0cfb3e8164fa9d4c3b95b4272d"
       }
     }, 
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment3f1d889857"
+          "Ref": "ServerlessRestApiDeployment63c7ea66fa"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -136,13 +133,25 @@
         "StageName": "Prod"
       }
     }, 
-    "ServerlessRestApiDeployment3f1d889857": {
+    "ServerlessRestApiDeployment63c7ea66fa": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         }, 
-        "Description": "RestApi deployment id: 3f1d889857c22227451ab7a02be7ea74b2e9d5b4"
+        "Description": "RestApi deployment id: 63c7ea66fa789640585db13196d24833004df4e0"
+      }
+    }, 
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeployment1e9fbca603"
+        }, 
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "StageName": "Prod"
       }
     }, 
     "ServerlessRestApi": {
@@ -219,15 +228,6 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }
-    }, 
-    "ExplicitApiDeployment01dd43a75f": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 01dd43a75fc0e125c678d20749bacde95d723928"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_open_api_version_2.json
+++ b/tests/translator/output/aws-us-gov/api_with_open_api_version_2.json
@@ -47,6 +47,15 @@
         }
       }
     }, 
+    "ServerlessRestApiDeploymentde54219387": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: de542193875063eb109b0bb4f1a6bfd6ca3cec29"
+      }
+    }, 
     "ImplicitApiFunctionGetHtmlPermissionTest": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
@@ -89,6 +98,15 @@
         }
       }
     }, 
+    "ExplicitApiDeployment323af4d2f5": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 323af4d2f576d27b094bb4e64e6fd8ada81b630b"
+      }
+    }, 
     "ExplicitApi": {
       "Type": "AWS::ApiGateway::RestApi", 
       "Properties": {
@@ -112,35 +130,26 @@
         }
       }
     }, 
-    "ServerlessRestApiDeployment3d22acdeb7": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentde54219387"
+        }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         }, 
-        "Description": "RestApi deployment id: 3d22acdeb7a3302c0b978e3dbb15c149380fbe77"
+        "StageName": "Prod"
       }
     }, 
     "ExplicitApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment5332c373d4"
+          "Ref": "ExplicitApiDeployment323af4d2f5"
         }, 
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
-        "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment3d22acdeb7"
-        }, 
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
         }, 
         "StageName": "Prod"
       }
@@ -219,15 +228,6 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
-      }
-    }, 
-    "ExplicitApiDeployment5332c373d4": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 5332c373d45c69e6c0f562b4a419aa8eb311adc7"
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/api_with_openapi_definition_body_no_flag.json
+++ b/tests/translator/output/aws-us-gov/api_with_openapi_definition_body_no_flag.json
@@ -47,15 +47,6 @@
         }
       }
     }, 
-    "ExplicitApiDeployment9252467a1e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: 9252467a1edc49ba35cb258640f5e3734cc9fab1"
-      }
-    }, 
     "ImplicitApiFunctionGetHtmlPermissionTest": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
@@ -170,7 +161,7 @@
         }, 
         "CacheClusterEnabled": true, 
         "DeploymentId": {
-          "Ref": "ExplicitApiDeployment9252467a1e"
+          "Ref": "ExplicitApiDeployment748947f06a"
         }
       }
     }, 
@@ -224,6 +215,15 @@
             "Name": "email"
           }
         ]
+      }
+    }, 
+    "ExplicitApiDeployment748947f06a": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: 748947f06a1a8de71a295f51af31d94b932fe2fc"
       }
     }, 
     "ServerlessRestApi": {

--- a/tests/translator/output/aws-us-gov/explicit_api_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/explicit_api_openapi_3.json
@@ -37,7 +37,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment09cda3d97b"
+          "Ref": "ApiWithInlineSwaggerDeployment88733439c5"
         }, 
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
@@ -45,6 +45,15 @@
         "StageName": {
           "Ref": "MyStageName"
         }
+      }
+    }, 
+    "ApiWithInlineSwaggerDeployment88733439c5": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithInlineSwagger"
+        }, 
+        "Description": "RestApi deployment id: 88733439c55b6ebd05ddec6505b6d8647d145b50"
       }
     }, 
     "GetHtmlFunctionGetHtmlPermissionTest": {
@@ -179,15 +188,6 @@
         "StageName": {
           "Ref": "MyStageName"
         }
-      }
-    }, 
-    "ApiWithInlineSwaggerDeployment09cda3d97b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 09cda3d97b008bed7bd4ebb1b5304ed622492941"
       }
     }
   }

--- a/tests/translator/output/explicit_api_openapi_3.json
+++ b/tests/translator/output/explicit_api_openapi_3.json
@@ -37,7 +37,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ApiWithInlineSwaggerDeployment09cda3d97b"
+          "Ref": "ApiWithInlineSwaggerDeployment88733439c5"
         }, 
         "RestApiId": {
           "Ref": "ApiWithInlineSwagger"
@@ -45,6 +45,15 @@
         "StageName": {
           "Ref": "MyStageName"
         }
+      }
+    }, 
+    "ApiWithInlineSwaggerDeployment88733439c5": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ApiWithInlineSwagger"
+        }, 
+        "Description": "RestApi deployment id: 88733439c55b6ebd05ddec6505b6d8647d145b50"
       }
     }, 
     "GetHtmlFunctionGetHtmlPermissionTest": {
@@ -163,15 +172,6 @@
         "StageName": {
           "Ref": "MyStageName"
         }
-      }
-    }, 
-    "ApiWithInlineSwaggerDeployment09cda3d97b": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ApiWithInlineSwagger"
-        }, 
-        "Description": "RestApi deployment id: 09cda3d97b008bed7bd4ebb1b5304ed622492941"
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:*
#191 
*Description of changes:*
If the template has OpenApiVersion flag defined, change the hash generated so the api gets redeployed. 
*Description of how you validated changes:*
First I deployed a simple hello world template.
```yaml
Globals:
  Function:
    Timeout: 3

Resources:
  HelloWorldFunction:
    Type: AWS::Serverless::Function
    Properties:
      InlineCode: |
        exports.handler = async (event) => {
          const response = {
            statusCode: 200,
            body: JSON.stringify('Hello from Lambda!'),
          };
          return response;
        };      
      Handler: index.handler
      Runtime: nodejs8.10
      Events:
        HelloWorld:
          Type: Api 
          Properties:
            Path: /hello
            Method: get

Outputs:
  HelloWorldApi:
    Description: "API Gateway endpoint URL for Prod stage for Hello World function"
    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
  HelloWorldFunction:
    Description: "Hello World Lambda Function ARN"
    Value: !GetAtt HelloWorldFunction.Arn
  HelloWorldFunctionIamRole:
    Description: "Implicit IAM Role created for Hello World function"
    Value: !GetAtt HelloWorldFunctionRole.Arn
```

Then I added the OpenApiVersion flag to the template with version '2.0', which wouldnt change the swagger document from the template above. 

```yaml
Globals:
  Function:
    Timeout: 3
  Api:
    OpenApiVersion: "2.0"

Resources:
  HelloWorldFunction:
    Type: AWS::Serverless::Function
    Properties:
      InlineCode: |
        exports.handler = async (event) => {
          const response = {
            statusCode: 200,
            body: JSON.stringify('Hello from Lambda!'),
          };
          return response;
        };      
      Handler: index.handler
      Runtime: nodejs8.10
      Events:
        HelloWorld:
          Type: Api
          Properties:
            Path: /hello
            Method: get

Outputs:
  HelloWorldApi:
    Description: "API Gateway endpoint URL for Prod stage for Hello World function"
    Value: !Sub "https://${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com/Prod/hello/"
  HelloWorldFunction:
    Description: "Hello World Lambda Function ARN"
    Value: !GetAtt HelloWorldFunction.Arn
  HelloWorldFunctionIamRole:
    Description: "Implicit IAM Role created for Hello World function"
    Value: !GetAtt HelloWorldFunctionRole.Arn
```
I verified that the API got redeployed by looking at the deployment history on API GW console. 
The API gateway Stage stage was on the older deployment version than Prod stage.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
