### PR TITLE
docs: fix policy in safe deployments example and documentation

### DIFF
--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -93,7 +93,7 @@ resource:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       AutoPublishAlias: live
       DeploymentPreference:
         Type: Linear10PercentEvery10Minutes
@@ -163,7 +163,7 @@ resource:
             Action:
               - "lambda:InvokeFunction"
             Resource: !GetAtt MyLambdaFunction.Arn
-      Runtime: nodejs6.10
+      Runtime: nodejs8.10
       FunctionName: 'CodeDeployHook_preTrafficHook'
       DeploymentPreference:
         Enabled: false

--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -162,7 +162,7 @@ resource:
           - Effect: "Allow"
             Action:
               - "lambda:InvokeFunction"
-            Resource: !Ref MyLambdaFunction.Version
+            Resource: !GetAtt MyLambdaFunction.Arn
       Runtime: nodejs6.10
       FunctionName: 'CodeDeployHook_preTrafficHook'
       DeploymentPreference:
@@ -286,7 +286,7 @@ Hooks are extremely powerful because:
           - Effect: "Allow"
             Action:
               - "lambda:InvokeFunction"
-            Resource: !Ref MyLambdaFunction.Version
+            Resource: !GetAtt MyLambdaFunction.Arn
 
 Checkout the lambda_safe_deployments_ folder for an example for how to create SAM template that contains a hook function.
 

--- a/examples/2016-10-31/lambda_safe_deployments/template.yaml
+++ b/examples/2016-10-31/lambda_safe_deployments/template.yaml
@@ -34,7 +34,7 @@ Resources:
           - Effect: "Allow"
             Action:
               - "lambda:InvokeFunction"
-            Resource: !Ref safeTest.Version
+            Resource: !GetAtt safeTest.Arn
       Runtime: nodejs8.10
       FunctionName: 'CodeDeployHook_preTrafficHook'
       DeploymentPreference:


### PR DESCRIPTION
*Issue #, if available:*

Fixes: #452

*Description of changes:*

It seems like the pretraffic hook policies in the safe lambda deployment examples don’t work as expected. When just using the ARN instead of the ARN+version the example works. 