### PR TITLE
feat: Add SQS option to SNS event

### DIFF
--- a/samtranslator/model/sqs.py
+++ b/samtranslator/model/sqs.py
@@ -1,0 +1,44 @@
+from samtranslator.model import PropertyType, Resource
+from samtranslator.model.types import is_type, list_of
+from samtranslator.model.intrinsics import fnGetAtt, ref
+
+
+class SQSQueue(Resource):
+    resource_type = 'AWS::SQS::Queue'
+    property_types = {
+    }
+    runtime_attrs = {
+        "queue_url": lambda self: ref(self.logical_id),
+        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),
+    }
+
+
+class SQSQueuePolicy(Resource):
+    resource_type = 'AWS::SQS::QueuePolicy'
+    property_types = {
+        'PolicyDocument': PropertyType(True, is_type(dict)),
+        'Queues': PropertyType(True, list_of(str)),
+    }
+    runtime_attrs = {
+        "arn": lambda self: fnGetAtt(self.logical_id, "Arn")
+    }
+
+
+class SQSQueuePolicies:
+    @classmethod
+    def sns_topic_send_message_role_policy(cls, topic_arn, queue_arn):
+        document = {
+            'Version': '2012-10-17',
+            'Statement': [{
+                'Action': 'sqs:SendMessage',
+                'Effect': 'Allow',
+                'Principal': '*',
+                'Resource': queue_arn,
+                'Condition': {
+                    'ArnEquals': {
+                        'aws:SourceArn': topic_arn
+                    }
+                }
+            }]
+        }
+        return document

--- a/tests/translator/input/sns_sqs.yaml
+++ b/tests/translator/input/sns_sqs.yaml
@@ -1,0 +1,23 @@
+Resources:
+  SaveNotificationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/notifications.zip
+      Handler: index.save_notification
+      Runtime: nodejs8.10
+      Events:
+        NotificationTopic:
+          Type: SNS
+          Properties:
+            Topic: !Ref Notifications
+            SqsSubscription: true
+            FilterPolicy:
+              store:
+                - example_corp
+              price_usd:
+                - numeric:
+                    - ">="
+                    - 100
+
+  Notifications:
+    Type: AWS::SNS::Topic

--- a/tests/translator/output/aws-cn/sns_sqs.json
+++ b/tests/translator/output/aws-cn/sns_sqs.json
@@ -1,0 +1,136 @@
+{
+  "Resources": {
+    "Notifications": {
+      "Type": "AWS::SNS::Topic"
+    }, 
+    "SaveNotificationFunctionNotificationTopicQueue": {
+      "Type": "AWS::SQS::Queue", 
+      "Properties": {}
+    }, 
+    "SaveNotificationFunctionNotificationTopicQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy", 
+      "Properties": {
+        "Queues": [
+          {
+            "Ref": "SaveNotificationFunctionNotificationTopicQueue"
+          }
+        ], 
+        "PolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage", 
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SaveNotificationFunctionNotificationTopicQueue", 
+                  "Arn"
+                ]
+              }, 
+              "Effect": "Allow", 
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "Notifications"
+                  }
+                }
+              }, 
+              "Principal": "*"
+            }
+          ]
+        }
+      }
+    }, 
+    "SaveNotificationFunctionNotificationTopic": {
+      "Type": "AWS::SNS::Subscription", 
+      "Properties": {
+        "FilterPolicy": {
+          "price_usd": [
+            {
+              "numeric": [
+                ">=", 
+                100
+              ]
+            }
+          ], 
+          "store": [
+            "example_corp"
+          ]
+        }, 
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "SaveNotificationFunctionNotificationTopicQueue", 
+            "Arn"
+          ]
+        }, 
+        "Protocol": "sqs", 
+        "TopicArn": {
+          "Ref": "Notifications"
+        }
+      }
+    }, 
+    "SaveNotificationFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
+        ], 
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "SaveNotificationFunctionNotificationTopicEventSourceMapping": {
+      "Type": "AWS::Lambda::EventSourceMapping", 
+      "Properties": {
+        "BatchSize": 10, 
+        "Enabled": true, 
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "SaveNotificationFunctionNotificationTopicQueue", 
+            "Arn"
+          ]
+        }, 
+        "FunctionName": {
+          "Ref": "SaveNotificationFunction"
+        }
+      }
+    }, 
+    "SaveNotificationFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.save_notification", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "notifications.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "SaveNotificationFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs8.10", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/sns_sqs.json
+++ b/tests/translator/output/aws-us-gov/sns_sqs.json
@@ -1,0 +1,136 @@
+{
+  "Resources": {
+    "Notifications": {
+      "Type": "AWS::SNS::Topic"
+    },
+    "SaveNotificationFunctionNotificationTopicQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {}
+    },
+    "SaveNotificationFunctionNotificationTopicQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "Queues": [
+          {
+            "Ref": "SaveNotificationFunctionNotificationTopicQueue"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SaveNotificationFunctionNotificationTopicQueue",
+                  "Arn"
+                ]
+              },
+              "Effect": "Allow",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "Notifications"
+                  }
+                }
+              },
+              "Principal": "*"
+            }
+          ]
+        }
+      }
+    },
+    "SaveNotificationFunctionNotificationTopic": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "FilterPolicy": {
+          "price_usd": [
+            {
+              "numeric": [
+                ">=",
+                100
+              ]
+            }
+          ],
+          "store": [
+            "example_corp"
+          ]
+        },
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "SaveNotificationFunctionNotificationTopicQueue",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "Notifications"
+        }
+      }
+    },
+    "SaveNotificationFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "SaveNotificationFunctionNotificationTopicEventSourceMapping": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "BatchSize": 10,
+        "Enabled": true,
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "SaveNotificationFunctionNotificationTopicQueue",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "SaveNotificationFunction"
+        }
+      }
+    },
+    "SaveNotificationFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.save_notification",
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "notifications.zip"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "SaveNotificationFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs8.10",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/output/sns_sqs.json
+++ b/tests/translator/output/sns_sqs.json
@@ -1,0 +1,136 @@
+{
+  "Resources": {
+    "Notifications": {
+      "Type": "AWS::SNS::Topic"
+    },
+    "SaveNotificationFunctionNotificationTopicQueue": {
+      "Type": "AWS::SQS::Queue",
+      "Properties": {}
+    },
+    "SaveNotificationFunctionNotificationTopicQueuePolicy": {
+      "Type": "AWS::SQS::QueuePolicy",
+      "Properties": {
+        "Queues": [
+          {
+            "Ref": "SaveNotificationFunctionNotificationTopicQueue"
+          }
+        ],
+        "PolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": "sqs:SendMessage",
+              "Resource": {
+                "Fn::GetAtt": [
+                  "SaveNotificationFunctionNotificationTopicQueue",
+                  "Arn"
+                ]
+              },
+              "Effect": "Allow",
+              "Condition": {
+                "ArnEquals": {
+                  "aws:SourceArn": {
+                    "Ref": "Notifications"
+                  }
+                }
+              },
+              "Principal": "*"
+            }
+          ]
+        }
+      }
+    },
+    "SaveNotificationFunctionNotificationTopic": {
+      "Type": "AWS::SNS::Subscription",
+      "Properties": {
+        "FilterPolicy": {
+          "price_usd": [
+            {
+              "numeric": [
+                ">=",
+                100
+              ]
+            }
+          ],
+          "store": [
+            "example_corp"
+          ]
+        },
+        "Endpoint": {
+          "Fn::GetAtt": [
+            "SaveNotificationFunctionNotificationTopicQueue",
+            "Arn"
+          ]
+        },
+        "Protocol": "sqs",
+        "TopicArn": {
+          "Ref": "Notifications"
+        }
+      }
+    },
+    "SaveNotificationFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaSQSQueueExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "SaveNotificationFunctionNotificationTopicEventSourceMapping": {
+      "Type": "AWS::Lambda::EventSourceMapping",
+      "Properties": {
+        "BatchSize": 10,
+        "Enabled": true,
+        "EventSourceArn": {
+          "Fn::GetAtt": [
+            "SaveNotificationFunctionNotificationTopicQueue",
+            "Arn"
+          ]
+        },
+        "FunctionName": {
+          "Ref": "SaveNotificationFunction"
+        }
+      }
+    },
+    "SaveNotificationFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.save_notification",
+        "Code": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "notifications.zip"
+        },
+        "Role": {
+          "Fn::GetAtt": [
+            "SaveNotificationFunctionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "nodejs8.10",
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -195,6 +195,7 @@ class TestTranslatorEndToEnd(TestCase):
         's3_multiple_functions',
         's3_with_dependsOn',
         'sns',
+        'sns_sqs',
         'sns_existing_other_subscription',
         'sns_topic_outside_template',
         'alexa_skill',

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -429,6 +429,7 @@ Property Name | Type | Description
 Topic | `string` | **Required.** Topic ARN.
 Region | `string` | Region.
 FilterPolicy | [Amazon SNS filter policy](https://docs.aws.amazon.com/sns/latest/dg/message-filtering.html) | Policy assigned to the topic subscription in order to receive only a subset of the messages.
+SqsSubscription | `boolean` | Indicates whether SQS option is enabled.
 
 ##### Example: SNS event source object
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/serverless-application-model/issues/854

This pull request will resolve #854 partially.
I implemented simple `SqsSubscription` option to SNSEvent at first.

*Description of changes:*
Added SQS option(`SqsSubscription`) to SNS event.

*Description of how you validated changes:*
- make pr
- verified transformed template in the steps written in DEVELOPMENT_GUIDE
-  confirmed that SAM template below could be deployed successfully.

```
AWSTemplateFormatVersion: '2010-09-09'
Transform: AWS::Serverless-2016-10-31

Resources:
  TweetTopic:
    Type: AWS::SNS::Topic
  WorkerFunction:
    Type: AWS::Serverless::Function
    Properties:
      CodeUri: worker_lambda/
      Handler: app.lambda_handler
      Timeout: 10
      Runtime: python3.7
      Events:
        MessageTopic:
          Type: SNS
          Properties:
            Topic: !Ref TweetTopic
            SqsSubscription: true
```



*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
