### PR TITLE
feat: Cognito event sources #229

### DIFF
--- a/docs/cloudformation_compatibility.rst
+++ b/docs/cloudformation_compatibility.rst
@@ -68,6 +68,15 @@ ReservedConcurrentExecutions       All
 Events Properties
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Cognito
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+======================== ================================== ========================
+     Property Name        Intrinsic(s) Supported            Reasons
+======================== ================================== ========================
+UserPool                 Ref of a AWS::Cognito::UserPool    Properties in the AWS::Cognito::UserPool are used to construct different attributes.
+Trigger                  All
+======================== ================================== ========================
+
 S3
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 ======================== ================================== ========================

--- a/docs/internals/generated_resources.rst
+++ b/docs/internals/generated_resources.rst
@@ -141,7 +141,7 @@ Example:
       ...
       Events:
         CognitoTrigger:
-          Type: S3
+          Type: Cognito
           Properties:
             UserPool: !Ref MyUserPool
             Trigger: PreSignUp

--- a/docs/internals/generated_resources.rst
+++ b/docs/internals/generated_resources.rst
@@ -128,6 +128,46 @@ AWS::Lambda::Permissions           MyFunction\ **ThumbnailApi**\ Permission\ **P
 
   NOTE: ``ServerlessRestApi*`` resources are generated one per stack.
 
+Cognito
+^^^
+
+Example:
+
+.. code:: yaml
+
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      ...
+      Events:
+        CognitoTrigger:
+          Type: S3
+          Properties:
+            UserPool: !Ref MyUserPool
+            Trigger: PreSignUp
+      ...
+
+  MyUserPool:
+    Type: AWS::Cognito::UserPool
+
+Additional generated resources:
+
+================================== ================================
+CloudFormation Resource Type       Logical ID 
+================================== ================================
+AWS::Lambda::Permissions           *MyFunction*\ CognitoPermission
+AWS::Cognito::UserPool             Existing MyUserPool resource is modified to append ``LambdaConfig`` 
+                                   property where the Lambda function trigger is defined
+================================== ================================
+
+  NOTE: You **must** refer to a Cognito UserPool defined in the same template. This is for two reasons:
+  
+  1. SAM needs to add a ``LambdaConfig`` property to the UserPool resource by reading and modifying the 
+  resource definition
+
+  2. Lambda triggers are specified as a property on the UserPool resource. Since CloudFormation cannot modify a resource
+  created outside of the stack, this bucket needs to be defined within the template.
+
 S3
 ^^^
 

--- a/examples/2016-10-31/api_cognito_auth/template.yaml
+++ b/examples/2016-10-31/api_cognito_auth/template.yaml
@@ -124,20 +124,12 @@ Resources:
       MemorySize: 128
       Runtime: nodejs8.10
       Timeout: 3
-
-  LambdaCognitoUserPoolExecutionPermission:
-    Type: AWS::Lambda::Permission
-    Properties: 
-      Action: lambda:InvokeFunction
-      FunctionName: !GetAtt PreSignupLambdaFunction.Arn
-      Principal: cognito-idp.amazonaws.com
-      SourceArn: !Sub 'arn:${AWS::Partition}:cognito-idp:${AWS::Region}:${AWS::AccountId}:userpool/${MyCognitoUserPool}'
-      # TODO: Add a CognitoUserPool Event Source to SAM to create this permission for you.
-      # Events:
-      #   CognitoUserPoolPreSignup:
-      #     Type: CognitoUserPool
-      #     Properties:
-      #       UserPool: !Ref MyCognitoUserPool
+      Events:
+        CognitoUserPoolPreSignup:
+          Type: Cognito
+          Properties:
+            UserPool: !Ref MyCognitoUserPool
+            Trigger: PreSignUp
 
 Outputs:
     Region:

--- a/examples/2016-10-31/api_cognito_auth/template.yaml
+++ b/examples/2016-10-31/api_cognito_auth/template.yaml
@@ -93,8 +93,6 @@ Resources:
     Type: AWS::Cognito::UserPool
     Properties:
       UserPoolName: !Ref CognitoUserPoolName
-      LambdaConfig:
-        PreSignUp: !GetAtt PreSignupLambdaFunction.Arn
       Policies:
         PasswordPolicy:
           MinimumLength: 8

--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -1,5 +1,5 @@
 from samtranslator.model import PropertyType, Resource
-from samtranslator.model.types import is_type, dict_of, list_of, is_str, one_of
+from samtranslator.model.types import is_type, list_of, is_str
 from samtranslator.model.intrinsics import fnGetAtt, ref
 
 

--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -20,11 +20,11 @@ class CognitoUserPool(Resource):
             'SmsAuthenticationMessage': PropertyType(False, is_str()),
             'SmsConfiguration': PropertyType(False, list_of(dict)),
             'SmsVerificationMessage': PropertyType(False, is_str()),
-            'UsernameAttributes': PropertyType(False, list_of(is_str())), 
+            'UsernameAttributes': PropertyType(False, list_of(is_str())),
             'UserPoolAddOns': PropertyType(False, list_of(dict)),
             'UserPoolName': PropertyType(False, is_str()),
             'UserPoolTags': PropertyType(False, is_str()),
-            'VerificationMessageTemplate': PropertyType(False, is_type(dict))         
+            'VerificationMessageTemplate': PropertyType(False, is_type(dict))
     }
 
     runtime_attrs = {

--- a/samtranslator/model/cognito.py
+++ b/samtranslator/model/cognito.py
@@ -1,0 +1,35 @@
+from samtranslator.model import PropertyType, Resource
+from samtranslator.model.types import is_type, dict_of, list_of, is_str, one_of
+from samtranslator.model.intrinsics import fnGetAtt, ref
+
+
+class CognitoUserPool(Resource):
+    resource_type = 'AWS::Cognito::UserPool'
+    property_types = {
+            'AdminCreateUserConfig': PropertyType(False, is_type(dict)),
+            'AliasAttributes': PropertyType(False, list_of(is_str())),
+            'AutoVerifiedAttributes': PropertyType(False, list_of(is_str())),
+            'DeviceConfiguration': PropertyType(False, is_type(dict)),
+            'EmailConfiguration': PropertyType(False, is_type(dict)),
+            'EmailVerificationMessage': PropertyType(False, is_str()),
+            'EmailVerificationSubject': PropertyType(False, is_str()),
+            'LambdaConfig': PropertyType(False, is_type(dict)),
+            'MfaConfiguration': PropertyType(False, is_str()),
+            'Policies': PropertyType(False, is_type(dict)),
+            'Schema': PropertyType(False, list_of(dict)),
+            'SmsAuthenticationMessage': PropertyType(False, is_str()),
+            'SmsConfiguration': PropertyType(False, list_of(dict)),
+            'SmsVerificationMessage': PropertyType(False, is_str()),
+            'UsernameAttributes': PropertyType(False, list_of(is_str())), 
+            'UserPoolAddOns': PropertyType(False, list_of(dict)),
+            'UserPoolName': PropertyType(False, is_str()),
+            'UserPoolTags': PropertyType(False, is_str()),
+            'VerificationMessageTemplate': PropertyType(False, is_type(dict))         
+    }
+
+    runtime_attrs = {
+        "name": lambda self: ref(self.logical_id),
+        "arn": lambda self: fnGetAtt(self.logical_id, "Arn"),
+        "provider_name": lambda self: fnGetAtt(self.logical_id, "ProviderName"),
+        "provider_url": lambda self: fnGetAtt(self.logical_id, "ProviderURL")
+    }

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -41,14 +41,15 @@ class PushEventSource(ResourceMacro):
     """
     principal = None
 
-    def _construct_permission(self, function, source_arn=None, source_account=None, suffix="", event_source_token=None, prefix=None):
+    def _construct_permission(
+            self, function, source_arn=None, source_account=None, suffix="", event_source_token=None, prefix=None):
         """Constructs the Lambda Permission resource allowing the source service to invoke the function this event
         source triggers.
 
         :returns: the permission resource
         :rtype: model.lambda_.LambdaPermission
         """
-        if prefix is None:        
+        if prefix is None:
             prefix = self.logical_id
         lambda_permission = LambdaPermission(prefix + 'Permission' + suffix,
                                              attributes=function.get_passthrough_resource_attributes())
@@ -687,6 +688,7 @@ class IoTRule(PushEventSource):
 
         return rule
 
+
 class Cognito(PushEventSource):
     resource_type = 'Cognito'
     principal = 'cognito-idp.amazonaws.com'
@@ -704,7 +706,9 @@ class Cognito(PushEventSource):
                     'userpool': resources[userpool_id],
                     'userpool_id': userpool_id
                 }
-        raise InvalidEventException(self.relative_id, "Cognito events must reference a Cognito UserPool in the same template.")
+        raise InvalidEventException(
+            self.relative_id,
+            "Cognito events must reference a Cognito UserPool in the same template.")
 
     def to_cloudformation(self, **kwargs):
         function = kwargs.get('function')
@@ -722,22 +726,20 @@ class Cognito(PushEventSource):
         userpool_id = kwargs['userpool_id']
 
         resources = []
-        resources.append(self._construct_permission(function, event_source_token=self.UserPool, prefix=function.logical_id + "Cognito"))
+        resources.append(
+            self._construct_permission(
+                function, event_source_token=self.UserPool, prefix=function.logical_id + "Cognito"))
 
         self._inject_lambda_config(function, userpool)
         resources.append(CognitoUserPool.from_dict(userpool_id, userpool))
         return resources
 
     def _inject_lambda_config(self, function, userpool):
-        base_event_mapping = {
-            'Function': function.get_runtime_attr("arn")
-        }
-
         event_triggers = self.Trigger
         if isinstance(self.Trigger, string_types):
             event_triggers = [self.Trigger]
 
-        #TODO can these be conditional?
+        # TODO can these be conditional?
 
         properties = userpool.get('Properties', None)
         if properties is None:
@@ -754,7 +756,7 @@ class Cognito(PushEventSource):
                 lambda_config[event_trigger] = function.get_runtime_attr("arn")
             else:
                 raise InvalidEventException(
-                    self.relative_id, 
+                    self.relative_id,
                     'Cognito trigger "{trigger}" defined multiple times.'.format(
                         trigger=self.Trigger))
-        return userpool        
+        return userpool

--- a/samtranslator/translator/verify_logical_id.py
+++ b/samtranslator/translator/verify_logical_id.py
@@ -6,7 +6,8 @@ do_not_verify = {
     'AWS::S3::Bucket': 'AWS::S3::Bucket',
     'AWS::SNS::Topic': 'AWS::SNS::Topic',
     'AWS::DynamoDB::Table': 'AWS::Serverless::SimpleTable',
-    'AWS::CloudFormation::Stack': 'AWS::Serverless::Application'
+    'AWS::CloudFormation::Stack': 'AWS::Serverless::Application',
+    'AWS::Cognito::UserPool': 'AWS::Cognito::UserPool'
 }
 
 

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -383,6 +383,39 @@
       ],
       "type": "object"
     },
+    "AWS::Serverless::Function.CognitoEvent": {
+      "additionalProperties": false,
+      "properties": {
+        "UserPool": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "object"
+            }
+          ]
+        },
+        "Trigger": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            }
+          ]
+        }
+      },
+      "required": [
+        "UserPool",
+        "Trigger"
+      ],      
+      "type": "object"
+    },
     "AWS::Serverless::Function.DynamoDBEvent": {
       "additionalProperties": false,
       "properties": {
@@ -443,6 +476,9 @@
             },
             {
               "$ref": "#/definitions/AWS::Serverless::Function.AlexaSkillEvent"
+            },
+            {
+              "$ref": "#/definitions/AWS::Serverless::Function.CognitoEvent"
             }
           ]
         },

--- a/tests/translator/input/cognito_userpool_with_event.yaml
+++ b/tests/translator/input/cognito_userpool_with_event.yaml
@@ -17,3 +17,9 @@ Resources:
             UserPool: 
               Ref: UserPool
             Trigger: PreSignUp
+        TwoTrigger:
+          Type: Cognito
+          Properties:
+            UserPool: 
+              Ref: UserPool
+            Trigger: [Test1, Test2]        

--- a/tests/translator/input/cognito_userpool_with_event.yaml
+++ b/tests/translator/input/cognito_userpool_with_event.yaml
@@ -1,0 +1,19 @@
+Resources:
+  UserPool:
+    Type: AWS::Cognito::UserPool
+    Properties:
+      LambdaConfig:
+        PreAuthentication: "Test"
+  ImplicitApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs4.3
+      Events:
+        OneTrigger:
+          Type: Cognito
+          Properties:
+            UserPool: 
+              Ref: UserPool
+            Trigger: PreSignUp

--- a/tests/translator/input/error_cognito_userpool_duplicate_trigger.yaml
+++ b/tests/translator/input/error_cognito_userpool_duplicate_trigger.yaml
@@ -1,0 +1,23 @@
+Resources:
+  UserPool:
+    Type: AWS::Cognito::UserPool
+
+  ImplicitApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs4.3
+      Events:
+        OneTrigger:
+          Type: Cognito
+          Properties:
+            UserPool: 
+              Ref: UserPool
+            Trigger: PreSignUp
+        TwoTrigger:
+          Type: Cognito
+          Properties:
+            UserPool: 
+              Ref: UserPool
+            Trigger: PreSignUp            

--- a/tests/translator/output/aws-cn/cognito_userpool_with_event.json
+++ b/tests/translator/output/aws-cn/cognito_userpool_with_event.json
@@ -9,7 +9,19 @@
               "ImplicitApiFunction", "Arn"
             ]
           },
-          "PreAuthentication": "Test"
+          "PreAuthentication": "Test",
+          "Test1": {
+            "Fn::GetAtt": [
+              "ImplicitApiFunction",
+              "Arn"
+            ]
+          },
+          "Test2": {
+            "Fn::GetAtt": [
+              "ImplicitApiFunction",
+              "Arn"
+            ]
+          }
         }
       }
     },
@@ -60,7 +72,7 @@
         }
       }
     },    
-    "ImplicitApiFunctionOneTriggerPermission": {
+    "ImplicitApiFunctionCognitoPermission": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:invokeFunction",

--- a/tests/translator/output/aws-cn/cognito_userpool_with_event.json
+++ b/tests/translator/output/aws-cn/cognito_userpool_with_event.json
@@ -1,0 +1,77 @@
+{
+  "Resources": {
+    "UserPool": {
+      "Type": "AWS::Cognito::UserPool",
+      "Properties": {
+        "LambdaConfig": {
+          "PreSignUp": {
+            "Fn::GetAtt": [
+              "ImplicitApiFunction", "Arn"
+            ]
+          },
+          "PreAuthentication": "Test"
+        }
+      }
+    },
+    "ImplicitApiFunction": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "ImplicitApiFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ImplicitApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },    
+    "ImplicitApiFunctionOneTriggerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "FunctionName": {
+          "Ref": "ImplicitApiFunction"
+        },
+        "EventSourceToken": {
+          "Ref": "UserPool"
+        },
+        "Principal": "cognito-idp.amazonaws.com"
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/cognito_userpool_with_event.json
+++ b/tests/translator/output/aws-us-gov/cognito_userpool_with_event.json
@@ -9,7 +9,19 @@
               "ImplicitApiFunction", "Arn"
             ]
           },
-          "PreAuthentication": "Test"
+          "PreAuthentication": "Test",
+          "Test1": {
+            "Fn::GetAtt": [
+              "ImplicitApiFunction",
+              "Arn"
+            ]
+          },
+          "Test2": {
+            "Fn::GetAtt": [
+              "ImplicitApiFunction",
+              "Arn"
+            ]
+          }
         }
       }
     },
@@ -60,7 +72,7 @@
         }
       }
     },    
-    "ImplicitApiFunctionOneTriggerPermission": {
+    "ImplicitApiFunctionCognitoPermission": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:invokeFunction",

--- a/tests/translator/output/aws-us-gov/cognito_userpool_with_event.json
+++ b/tests/translator/output/aws-us-gov/cognito_userpool_with_event.json
@@ -1,0 +1,77 @@
+{
+  "Resources": {
+    "UserPool": {
+      "Type": "AWS::Cognito::UserPool",
+      "Properties": {
+        "LambdaConfig": {
+          "PreSignUp": {
+            "Fn::GetAtt": [
+              "ImplicitApiFunction", "Arn"
+            ]
+          },
+          "PreAuthentication": "Test"
+        }
+      }
+    },
+    "ImplicitApiFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "ImplicitApiFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ImplicitApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },    
+    "ImplicitApiFunctionOneTriggerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "FunctionName": {
+          "Ref": "ImplicitApiFunction"
+        },
+        "EventSourceToken": {
+          "Ref": "UserPool"
+        },
+        "Principal": "cognito-idp.amazonaws.com"
+      }
+    }
+  }
+}

--- a/tests/translator/output/cognito_userpool_with_event.json
+++ b/tests/translator/output/cognito_userpool_with_event.json
@@ -9,7 +9,19 @@
               "ImplicitApiFunction", "Arn"
             ]
           },
-          "PreAuthentication": "Test"
+          "PreAuthentication": "Test",
+          "Test1": {
+            "Fn::GetAtt": [
+              "ImplicitApiFunction",
+              "Arn"
+            ]
+          },
+          "Test2": {
+            "Fn::GetAtt": [
+              "ImplicitApiFunction",
+              "Arn"
+            ]
+          }          
         }
       }
     },
@@ -60,7 +72,7 @@
         }
       }
     },    
-    "ImplicitApiFunctionOneTriggerPermission": {
+    "ImplicitApiFunctionCognitoPermission": {
       "Type": "AWS::Lambda::Permission",
       "Properties": {
         "Action": "lambda:invokeFunction",

--- a/tests/translator/output/cognito_userpool_with_event.json
+++ b/tests/translator/output/cognito_userpool_with_event.json
@@ -1,0 +1,77 @@
+{
+  "Resources": {
+    "UserPool": {
+      "Type": "AWS::Cognito::UserPool",
+      "Properties": {
+        "LambdaConfig": {
+          "PreSignUp": {
+            "Fn::GetAtt": [
+              "ImplicitApiFunction", "Arn"
+            ]
+          },
+          "PreAuthentication": "Test"
+        }
+      }
+    },
+    "ImplicitApiFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "ImplicitApiFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs4.3", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ImplicitApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17",
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },    
+    "ImplicitApiFunctionOneTriggerPermission": {
+      "Type": "AWS::Lambda::Permission",
+      "Properties": {
+        "Action": "lambda:invokeFunction",
+        "FunctionName": {
+          "Ref": "ImplicitApiFunction"
+        },
+        "EventSourceToken": {
+          "Ref": "UserPool"
+        },
+        "Principal": "cognito-idp.amazonaws.com"
+      }
+    }
+  }
+}

--- a/tests/translator/output/error_cognito_userpool_duplicate_trigger.json
+++ b/tests/translator/output/error_cognito_userpool_duplicate_trigger.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [ImplicitApiFunction] is invalid. Event with id [TwoTrigger] is invalid. Cognito trigger \"PreSignUp\" defined multiple times."
+    }
+  ], 
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [ImplicitApiFunction] is invalid. Event with id [TwoTrigger] is invalid. Cognito trigger \"PreSignUp\" defined multiple times."
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -137,6 +137,7 @@ class TestTranslatorEndToEnd(TestCase):
 
     @parameterized.expand(
       itertools.product([
+        'cognito_userpool_with_event',
         's3_with_condition',
         'function_with_condition',
         'basic_function',
@@ -420,6 +421,7 @@ class TestTranslatorEndToEnd(TestCase):
         rest_api_to_swagger_hash[logical_id] = data_hash
 
 @pytest.mark.parametrize('testcase', [
+    'error_cognito_userpool_duplicate_trigger'
     'error_api_duplicate_methods_same_path',
     'error_api_gateway_responses_nonnumeric_status_code',
     'error_api_gateway_responses_unknown_responseparameter',

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -421,7 +421,7 @@ class TestTranslatorEndToEnd(TestCase):
         rest_api_to_swagger_hash[logical_id] = data_hash
 
 @pytest.mark.parametrize('testcase', [
-    'error_cognito_userpool_duplicate_trigger'
+    'error_cognito_userpool_duplicate_trigger',
     'error_api_duplicate_methods_same_path',
     'error_api_gateway_responses_nonnumeric_status_code',
     'error_api_gateway_responses_unknown_responseparameter',

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -389,6 +389,7 @@ Properties:
  - [CloudWatchLogs](#cloudwatchlogs)
  - [IoTRule](#iotrule)
  - [AlexaSkill](#alexaskill)
+ - [Cognito](#cognito)
 
 #### S3
 
@@ -654,6 +655,28 @@ Variables | Map of `string` to `string` | A map (string to string map) that defi
 Variables:
   TABLE_NAME: my-table
   STAGE: prod
+```
+
+#### Cognito
+
+The object describing an event source with type `Cognito`.
+
+##### Properties
+
+Property Name | Type | Description
+---|:---:|---
+UserPool | `string` | **Required.** Reference to UserPool in the same template
+Trigger | `string` <span>&#124;</span> List of `string` | **Required.** See [Amazon S3 supported event types](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-cognito-userpool-lambdaconfig.html) for valid values.
+
+NOTE: To specify a Cognito UserPool as an event source for a Lambda function, both resources have to be declared in the same template. AWS SAM does not support specifying an existing UserPool as an event source.
+
+##### Example: Cognito event source object
+
+```yaml
+Type: Cognito
+Properties:
+  Bucket: Ref: MyUserPool
+  Trigger: PreSignUp
 ```
 
 #### Event source object


### PR DESCRIPTION
*Issue #229, if available:*

*Description of changes:*

Added support for Cognito event sources
It adds only one Permission per Lambda (logical_id de-dupe)
It changes to LambdaConfig property of the Cognito UserPool it refers to

*Description of how you validated changes:*

Updated the example "examples/2016-10-31/api_cognito_auth"
Transformed and created stack in my account
Checked is PreSignUp trigger correctly refers to the Lambda

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`

other todos:

- [x] Check is also "User Migration" can be set this way

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
