### PR TITLE
Request Authorizer, not Token Authorizer

### DIFF
--- a/examples/2016-10-31/api_lambda_request_auth/template.yaml
+++ b/examples/2016-10-31/api_lambda_request_auth/template.yaml
@@ -1,6 +1,6 @@
 AWSTemplateFormatVersion: '2010-09-09'
 Transform: AWS::Serverless-2016-10-31
-Description: API Gateway with Lambda Token Authorizer
+Description: API Gateway with Lambda Request Authorizer
 Resources:
   MyApi:
     Type: AWS::Serverless::Api


### PR DESCRIPTION
Your SAM Description says this is the "API Gateway with Lambda Token Authorizer" when, I believe, this is a Request Authorizer. Your API resource FunctionPayloadType says "REQUEST" and the link below seems to be the Token Authorizer example.

https://github.com/awslabs/serverless-application-model/blob/master/examples/2016-10-31/api_lambda_token_auth/template.yaml

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
