### PR TITLE
fix: allow intrinsics in NotificationARNs property

### DIFF
--- a/samtranslator/model/cloudformation.py
+++ b/samtranslator/model/cloudformation.py
@@ -1,5 +1,5 @@
 from samtranslator.model import PropertyType, Resource
-from samtranslator.model.types import is_type, is_str, list_of
+from samtranslator.model.types import is_type, is_str, list_of, one_of
 from samtranslator.model.intrinsics import ref
 
 
@@ -9,7 +9,7 @@ class NestedStack(Resource):
     property_types = {
         'TemplateURL': PropertyType(True, is_str()),
         'Parameters': PropertyType(False, is_type(dict)),
-        'NotificationARNs': PropertyType(False, list_of(is_str())),
+        'NotificationARNs': PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
         'Tags': PropertyType(False, list_of(is_type(dict))),
         'TimeoutInMinutes': PropertyType(False, is_type(int))
     }

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -617,7 +617,7 @@ class SamApplication(SamResourceMacro):
         'Location': PropertyType(True, one_of(is_str(), is_type(dict))),
         'TemplateUrl': PropertyType(False, is_str()),
         'Parameters': PropertyType(False, is_type(dict)),
-        'NotificationARNs': PropertyType(False, list_of(is_str())),
+        'NotificationARNs': PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
         'Tags': PropertyType(False, is_type(dict)),
         'TimeoutInMinutes': PropertyType(False, is_type(int))
     }

--- a/tests/translator/input/application_with_intrinsics.yaml
+++ b/tests/translator/input/application_with_intrinsics.yaml
@@ -38,3 +38,7 @@ Resources:
         - ApplicationLocations
         - !Ref 'AWS::Region'
         - Version
+      NotificationARNs:
+        - !Ref Sns
+  Sns:
+    Type: AWS::SNS::Topic

--- a/tests/translator/output/application_with_intrinsics.json
+++ b/tests/translator/output/application_with_intrinsics.json
@@ -1,70 +1,78 @@
 {
-  "Resources": {
-    "ApplicationRefParameter": {
-      "Type": "AWS::CloudFormation::Stack",
-      "Properties": {
-        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          },
-          {
-            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world",
-            "Key": "serverlessrepo:applicationId"
-          },
-          {
-            "Value": "1.0.0",
-            "Key": "serverlessrepo:semanticVersion"
-          }
-        ]
-      }
-    },
-    "ApplicationFindInMap": {
-      "Type": "AWS::CloudFormation::Stack",
-      "Properties": {
-        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          },
-          {
-            "Value": "arn:aws:serverlessrepo:ap-southeast-1:123456789012:applications/hello-world",
-            "Key": "serverlessrepo:applicationId"
-          },
-          {
-            "Value": "1.0.1",
-            "Key": "serverlessrepo:semanticVersion"
-          }
-        ]
-      }
-    }
-  },
   "Parameters": {
     "ApplicationIdParam": {
-      "Type": "String",
-      "Default": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world"
-    },
+      "Default": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world", 
+      "Type": "String"
+    }, 
     "VersionParam": {
-      "Type": "String",
-      "Default": "1.0.0"
+      "Default": "1.0.0", 
+      "Type": "String"
     }
-  },
+  }, 
   "Mappings": {
     "ApplicationLocations": {
-      "ap-southeast-1": {
-        "ApplicationId": "arn:aws:serverlessrepo:ap-southeast-1:123456789012:applications/hello-world",
-        "Version": "1.0.1"
-      },
       "cn-north-1": {
-        "ApplicationId": "arn:aws-cn:serverlessrepo:cn-north-1:123456789012:applications/hello-world",
-        "Version": "1.0.2"
-      },
+        "Version": "1.0.2", 
+        "ApplicationId": "arn:aws-cn:serverlessrepo:cn-north-1:123456789012:applications/hello-world"
+      }, 
       "us-gov-west-1": {
-        "ApplicationId": "arn:aws-gov:serverlessrepo:us-gov-west-1:123456789012:applications/hello-world",
-        "Version": "1.0.3"
+        "Version": "1.0.3", 
+        "ApplicationId": "arn:aws-gov:serverlessrepo:us-gov-west-1:123456789012:applications/hello-world"
+      }, 
+      "ap-southeast-1": {
+        "Version": "1.0.1", 
+        "ApplicationId": "arn:aws:serverlessrepo:ap-southeast-1:123456789012:applications/hello-world"
       }
+    }
+  }, 
+  "Resources": {
+    "ApplicationFindInMap": {
+      "Type": "AWS::CloudFormation::Stack", 
+      "Properties": {
+        "NotificationARNs": [
+          {
+            "Ref": "Sns"
+          }
+        ], 
+        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }, 
+          {
+            "Value": "arn:aws:serverlessrepo:ap-southeast-1:123456789012:applications/hello-world", 
+            "Key": "serverlessrepo:applicationId"
+          }, 
+          {
+            "Value": "1.0.1", 
+            "Key": "serverlessrepo:semanticVersion"
+          }
+        ]
+      }
+    }, 
+    "ApplicationRefParameter": {
+      "Type": "AWS::CloudFormation::Stack", 
+      "Properties": {
+        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }, 
+          {
+            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world", 
+            "Key": "serverlessrepo:applicationId"
+          }, 
+          {
+            "Value": "1.0.0", 
+            "Key": "serverlessrepo:semanticVersion"
+          }
+        ]
+      }
+    }, 
+    "Sns": {
+      "Type": "AWS::SNS::Topic"
     }
   }
 }

--- a/tests/translator/output/aws-cn/application_with_intrinsics.json
+++ b/tests/translator/output/aws-cn/application_with_intrinsics.json
@@ -1,70 +1,78 @@
 {
-  "Resources": {
-    "ApplicationRefParameter": {
-      "Type": "AWS::CloudFormation::Stack",
-      "Properties": {
-        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          },
-          {
-            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world",
-            "Key": "serverlessrepo:applicationId"
-          },
-          {
-            "Value": "1.0.0",
-            "Key": "serverlessrepo:semanticVersion"
-          }
-        ]
-      }
-    },
-    "ApplicationFindInMap": {
-      "Type": "AWS::CloudFormation::Stack",
-      "Properties": {
-        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          },
-          {
-            "Value": "arn:aws-cn:serverlessrepo:cn-north-1:123456789012:applications/hello-world",
-            "Key": "serverlessrepo:applicationId"
-          },
-          {
-            "Value": "1.0.2",
-            "Key": "serverlessrepo:semanticVersion"
-          }
-        ]
-      }
-    }
-  },
   "Parameters": {
     "ApplicationIdParam": {
-      "Type": "String",
-      "Default": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world"
-    },
+      "Default": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world", 
+      "Type": "String"
+    }, 
     "VersionParam": {
-      "Type": "String",
-      "Default": "1.0.0"
+      "Default": "1.0.0", 
+      "Type": "String"
     }
-  },
+  }, 
   "Mappings": {
     "ApplicationLocations": {
-      "ap-southeast-1": {
-        "ApplicationId": "arn:aws:serverlessrepo:ap-southeast-1:123456789012:applications/hello-world",
-        "Version": "1.0.1"
-      },
       "cn-north-1": {
-        "ApplicationId": "arn:aws-cn:serverlessrepo:cn-north-1:123456789012:applications/hello-world",
-        "Version": "1.0.2"
-      },
+        "Version": "1.0.2", 
+        "ApplicationId": "arn:aws-cn:serverlessrepo:cn-north-1:123456789012:applications/hello-world"
+      }, 
       "us-gov-west-1": {
-        "ApplicationId": "arn:aws-gov:serverlessrepo:us-gov-west-1:123456789012:applications/hello-world",
-        "Version": "1.0.3"
+        "Version": "1.0.3", 
+        "ApplicationId": "arn:aws-gov:serverlessrepo:us-gov-west-1:123456789012:applications/hello-world"
+      }, 
+      "ap-southeast-1": {
+        "Version": "1.0.1", 
+        "ApplicationId": "arn:aws:serverlessrepo:ap-southeast-1:123456789012:applications/hello-world"
       }
+    }
+  }, 
+  "Resources": {
+    "ApplicationFindInMap": {
+      "Type": "AWS::CloudFormation::Stack", 
+      "Properties": {
+        "NotificationARNs": [
+          {
+            "Ref": "Sns"
+          }
+        ], 
+        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }, 
+          {
+            "Value": "arn:aws-cn:serverlessrepo:cn-north-1:123456789012:applications/hello-world", 
+            "Key": "serverlessrepo:applicationId"
+          }, 
+          {
+            "Value": "1.0.2", 
+            "Key": "serverlessrepo:semanticVersion"
+          }
+        ]
+      }
+    }, 
+    "ApplicationRefParameter": {
+      "Type": "AWS::CloudFormation::Stack", 
+      "Properties": {
+        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }, 
+          {
+            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world", 
+            "Key": "serverlessrepo:applicationId"
+          }, 
+          {
+            "Value": "1.0.0", 
+            "Key": "serverlessrepo:semanticVersion"
+          }
+        ]
+      }
+    }, 
+    "Sns": {
+      "Type": "AWS::SNS::Topic"
     }
   }
 }

--- a/tests/translator/output/aws-us-gov/application_with_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/application_with_intrinsics.json
@@ -1,70 +1,78 @@
 {
-  "Resources": {
-    "ApplicationRefParameter": {
-      "Type": "AWS::CloudFormation::Stack",
-      "Properties": {
-        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          },
-          {
-            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world",
-            "Key": "serverlessrepo:applicationId"
-          },
-          {
-            "Value": "1.0.0",
-            "Key": "serverlessrepo:semanticVersion"
-          }
-        ]
-      }
-    },
-    "ApplicationFindInMap": {
-      "Type": "AWS::CloudFormation::Stack",
-      "Properties": {
-        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url",
-        "Tags": [
-          {
-            "Value": "SAM",
-            "Key": "lambda:createdBy"
-          },
-          {
-            "Value": "arn:aws-gov:serverlessrepo:us-gov-west-1:123456789012:applications/hello-world",
-            "Key": "serverlessrepo:applicationId"
-          },
-          {
-            "Value": "1.0.3",
-            "Key": "serverlessrepo:semanticVersion"
-          }
-        ]
-      }
-    }
-  },
   "Parameters": {
     "ApplicationIdParam": {
-      "Type": "String",
-      "Default": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world"
-    },
+      "Default": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world", 
+      "Type": "String"
+    }, 
     "VersionParam": {
-      "Type": "String",
-      "Default": "1.0.0"
+      "Default": "1.0.0", 
+      "Type": "String"
     }
-  },
+  }, 
   "Mappings": {
     "ApplicationLocations": {
-      "ap-southeast-1": {
-        "ApplicationId": "arn:aws:serverlessrepo:ap-southeast-1:123456789012:applications/hello-world",
-        "Version": "1.0.1"
-      },
       "cn-north-1": {
-        "ApplicationId": "arn:aws-cn:serverlessrepo:cn-north-1:123456789012:applications/hello-world",
-        "Version": "1.0.2"
-      },
+        "Version": "1.0.2", 
+        "ApplicationId": "arn:aws-cn:serverlessrepo:cn-north-1:123456789012:applications/hello-world"
+      }, 
       "us-gov-west-1": {
-        "ApplicationId": "arn:aws-gov:serverlessrepo:us-gov-west-1:123456789012:applications/hello-world",
-        "Version": "1.0.3"
+        "Version": "1.0.3", 
+        "ApplicationId": "arn:aws-gov:serverlessrepo:us-gov-west-1:123456789012:applications/hello-world"
+      }, 
+      "ap-southeast-1": {
+        "Version": "1.0.1", 
+        "ApplicationId": "arn:aws:serverlessrepo:ap-southeast-1:123456789012:applications/hello-world"
       }
+    }
+  }, 
+  "Resources": {
+    "ApplicationFindInMap": {
+      "Type": "AWS::CloudFormation::Stack", 
+      "Properties": {
+        "NotificationARNs": [
+          {
+            "Ref": "Sns"
+          }
+        ], 
+        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }, 
+          {
+            "Value": "arn:aws-gov:serverlessrepo:us-gov-west-1:123456789012:applications/hello-world", 
+            "Key": "serverlessrepo:applicationId"
+          }, 
+          {
+            "Value": "1.0.3", 
+            "Key": "serverlessrepo:semanticVersion"
+          }
+        ]
+      }
+    }, 
+    "ApplicationRefParameter": {
+      "Type": "AWS::CloudFormation::Stack", 
+      "Properties": {
+        "TemplateURL": "https://awsserverlessrepo-changesets-xxx.s3.amazonaws.com/signed-url", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }, 
+          {
+            "Value": "arn:aws:serverlessrepo:us-east-1:123456789012:applications/hello-world", 
+            "Key": "serverlessrepo:applicationId"
+          }, 
+          {
+            "Value": "1.0.0", 
+            "Key": "serverlessrepo:semanticVersion"
+          }
+        ]
+      }
+    }, 
+    "Sns": {
+      "Type": "AWS::SNS::Topic"
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
#1087 

*Description of changes:*
Allow `!Ref` and other intrinsics in `NotificationARNs` property of a Serverless::Application.

*Description of how you validated changes:*
Tests updated and pass. Deployed a template with desired changes.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
