### PR TITLE
docs: Clarify `AWS::Serverless::SimpleTable.PrimaryKey` Default Value

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -313,7 +313,7 @@ The `AWS::Serverless::SimpleTable` resource creates a DynamoDB table with a sing
 
 Property Name | Type | Description
 ---|:---:|---
-PrimaryKey | [Primary Key Object](#primary-key-object) | Attribute name and type to be used as the table's primary key. **This cannot be modified without replacing the resource.** Defaults to `String` attribute named ID.
+PrimaryKey | [Primary Key Object](#primary-key-object) | Attribute name and type to be used as the table's primary key. **This cannot be modified without replacing the resource.** Defaults to `String` attribute named `id`.
 ProvisionedThroughput | [Provisioned Throughput Object](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-dynamodb-provisionedthroughput.html) | Read and write throughput provisioning information. If ProvisionedThroughput is not specified BillingMode will be specified as PAY_PER_REQUEST
 Tags | Map of `string` to `string` | A map (string to string) that specifies the tags to be added to this table. Keys and values are limited to alphanumeric characters. 
 TableName | `string` | Name for the DynamoDB Table
@@ -689,7 +689,7 @@ The object describing the properties of a primary key.
 Property Name | Type | Description
 ---|:---:|---
 Name | `string` | Attribute name of the primary key. Defaults to `id`.
-Type | `string` | Attribute type of the primary key. MUST be one of `String`, `Number`, or `Binary`.
+Type | `string` | Attribute type of the primary key. MUST be one of `String`, `Number`, or `Binary`. Defaults to `String`.
 
 ##### Example: Primary key object
 


### PR DESCRIPTION
In the prose of the description for `PrimaryKey`, the default key name is said to be "ID". In the examples and in the translator tests, the default value is "id".

May no one else be bitten by this.

*Description of changes:*

In short, I made the normative and descriptive texts match.

- Changed "ID" to "`id`" in the prose of the specification. This is a non-normative change, as the specified default is in the "Primary Key Object" section -- and it matches the normative value anyway.
- Added text specifying the default `Type` value. (`String`) This one _is_ a normative change, but it's adding something to the specification text which was already specified.

*Description of how you validated changes:*

I checked the values in the normative part of the specification and the output of the translator tests.

*Checklist:*

- [x] Update documentation
- [x] Add/update example to `examples/2016-10-31`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
