### PR TITLE
GetAtt for Role ARN

### DIFF
--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -107,7 +107,7 @@ resource:
           PostTraffic: !Ref PostTrafficLambdaFunction
         # Provide a custom role for CodeDeploy traffic shifting here, if you don't supply one
         # SAM will create one for you with default permissions
-        Role: !Ref IAMRoleForCodeDeploy # Parameter example, you can pass an IAM ARN
+        Role: !GetAtt IAMRoleForCodeDeploy.Arn # Parameter example, you can pass an IAM ARN
 
   AliasErrorMetricGreaterThanZeroAlarm:
     Type: "AWS::CloudWatch::Alarm"


### PR DESCRIPTION
Ref doesn't return an ARN

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
