### PR TITLE
Fix malformed response in example

### DIFF
--- a/examples/apps/cloudfront-http-redirect/index.js
+++ b/examples/apps/cloudfront-http-redirect/index.js
@@ -1,18 +1,15 @@
 'use strict';
 
 exports.handler = (event, context, callback) => {
-    /*
-     * Generate HTTP redirect response with 302 status code and Location header.
-     */
-    const response = {
-        status: '302',
-        statusDescription: 'Found',
-        headers: {
-            location: [{
-                key: 'Location',
-                value: 'http://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html',
-            }],
+    
+    var response = {
+        "statusCode": 302,
+        "headers": {
+            "Location": "http://docs.aws.amazon.com/lambda/latest/dg/lambda-edge.html"
         },
+        "body": "{}",
+        "isBase64Encoded": false
     };
     callback(null, response);
 };
+


### PR DESCRIPTION
The required `isBase64Encoded` field was missing, and `headers` was not correctly formatted. This fixes the "Malformed Lambda proxy response" that caused the method to fail with a 502 status.

Some additional information here:
https://aws.amazon.com/premiumsupport/knowledge-center/malformed-502-api-gateway/

*Description of how you validated changes:*
I have first created a `Function` with the javascript in this example, and got the `502`. I have then made changes according to the documentation above, and now the correct redirect is returned.

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
