### PR TITLE
Add code commit policy templates

### DIFF
--- a/examples/2016-10-31/policy_templates/all_policy_templates.yaml
+++ b/examples/2016-10-31/policy_templates/all_policy_templates.yaml
@@ -90,3 +90,9 @@ Resources:
 
         - StepFunctionsExecutionPolicy:
             StateMachineName: name
+
+        - CodeCommitCrudPolicy:
+            RepositoryName: name
+
+        - CodeCommitReadPolicy:
+            RepositoryName: name

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1587,6 +1587,155 @@
           }
         ]
       }
+    },
+    "CodeCommitCrudPolicy": {
+      "Description": "Gives permissions to create/read/update/delete objects within a specific codecommit repository",
+      "Parameters": {
+        "RepositoryName": {
+          "Description": "Name of the CodeCommit Repository"
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "codecommit:GitPull",
+              "codecommit:GitPush",
+              "codecommit:CreateBranch",
+              "codecommit:DeleteBranch",
+              "codecommit:GetBranch",
+              "codecommit:ListBranches",
+              "codecommit:MergeBranchesByFastForward",
+              "codecommit:MergeBranchesBySquash",
+              "codecommit:MergeBranchesByThreeWay",
+              "codecommit:UpdateDefaultBranch",
+              "codecommit:BatchDescribeMergeConflicts",
+              "codecommit:CreateUnreferencedMergeCommit",
+              "codecommit:DescribeMergeConflicts",
+              "codecommit:GetMergeCommit",
+              "codecommit:GetMergeOptions",
+              "codecommit:BatchGetPullRequests",
+              "codecommit:CreatePullRequest",
+              "codecommit:DescribePullRequestEvents",
+              "codecommit:GetCommentsForPullRequest",
+              "codecommit:GetCommitsFromMergeBase",
+              "codecommit:GetMergeConflicts",
+              "codecommit:GetPullRequest",
+              "codecommit:ListPullRequests",
+              "codecommit:MergePullRequestByFastForward",
+              "codecommit:MergePullRequestBySquash",
+              "codecommit:MergePullRequestByThreeWay",
+              "codecommit:PostCommentForPullRequest",
+              "codecommit:UpdatePullRequestDescription",
+              "codecommit:UpdatePullRequestStatus",
+              "codecommit:UpdatePullRequestTitle",
+              "codecommit:DeleteFile",
+              "codecommit:GetBlob",
+              "codecommit:GetFile",
+              "codecommit:GetFolder",
+              "codecommit:PutFile",
+              "codecommit:DeleteCommentContent",
+              "codecommit:GetComment",
+              "codecommit:GetCommentsForComparedCommit",
+              "codecommit:PostCommentForComparedCommit",
+              "codecommit:PostCommentReply",
+              "codecommit:UpdateComment",
+              "codecommit:BatchGetCommits",
+              "codecommit:CreateCommit",
+              "codecommit:GetCommit",
+              "codecommit:GetCommitHistory",
+              "codecommit:GetDifferences",
+              "codecommit:GetObjectIdentifier",
+              "codecommit:GetReferences",
+              "codecommit:GetTree",
+              "codecommit:GetRepository",
+              "codecommit:UpdateRepositoryDescription",
+              "codecommit:ListTagsForResource",
+              "codecommit:TagResource",
+              "codecommit:UntagResource",
+              "codecommit:GetRepositoryTriggers",
+              "codecommit:PutRepositoryTriggers",
+              "codecommit:TestRepositoryTriggers",
+              "codecommit:GetBranch",
+              "codecommit:GetCommit",
+              "codecommit:UploadArchive",
+              "codecommit:GetUploadArchiveStatus",
+              "codecommit:CancelUploadArchive"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${repositoryName}",
+                {
+                  "repositoryName": {
+                    "Ref": "RepositoryName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    "CodeCommitReadPolicy": {
+      "Description": "Gives permissions to read objects within a specific codecommit repository",
+      "Parameters": {
+        "RepositoryName": {
+          "Description": "Name of the CodeCommit Repository"
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "codecommit:GitPull",
+              "codecommit:GetBranch",
+              "codecommit:ListBranches",
+              "codecommit:BatchDescribeMergeConflicts",
+              "codecommit:DescribeMergeConflicts",
+              "codecommit:GetMergeCommit",
+              "codecommit:GetMergeOptions",
+              "codecommit:BatchGetPullRequests",
+              "codecommit:DescribePullRequestEvents",
+              "codecommit:GetCommentsForPullRequest",
+              "codecommit:GetCommitsFromMergeBase",
+              "codecommit:GetMergeConflicts",
+              "codecommit:GetPullRequest",
+              "codecommit:ListPullRequests",
+              "codecommit:GetBlob",
+              "codecommit:GetFile",
+              "codecommit:GetFolder",
+              "codecommit:GetComment",
+              "codecommit:GetCommentsForComparedCommit",
+              "codecommit:BatchGetCommits",
+              "codecommit:GetCommit",
+              "codecommit:GetCommitHistory",
+              "codecommit:GetDifferences",
+              "codecommit:GetObjectIdentifier",
+              "codecommit:GetReferences",
+              "codecommit:GetTree",
+              "codecommit:GetRepository",
+              "codecommit:ListTagsForResource",
+              "codecommit:GetRepositoryTriggers",
+              "codecommit:TestRepositoryTriggers",
+              "codecommit:GetBranch",
+              "codecommit:GetCommit",
+              "codecommit:GetUploadArchiveStatus"
+            ],
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:codecommit:${AWS::Region}:${AWS::AccountId}:${repositoryName}",
+                {
+                  "repositoryName": {
+                    "Ref": "RepositoryName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding policy templates for read and crud for codecommit

*Description of how you validated changes:*

I ran policy_templates.json through jq to ensure that the syntax is still valid

Here's a diff between the full apis and the ones I used under crud

```
/workspace/castaren/serverless-application-model
20:56:29 castaren-> diff full.txt write.txt 
50,52d49
< "codecommit:BatchGetRepositories",
< "codecommit:CreateRepository",
< "codecommit:DeleteRepository",
54d50
< "codecommit:ListRepositories",
56d51
< "codecommit:UpdateRepositoryName",
67c62
< "codecommit:CancelUploadArchive",
---
> "codecommit:CancelUploadArchive"
```

Here's a diff between the crud apis and the ones I used for read

```
/workspace/castaren/serverless-application-model
20:56:56 castaren-> diff write.txt read.txt 
2,4d1
< "codecommit:GitPush",
< "codecommit:CreateBranch",
< "codecommit:DeleteBranch",
7,10d3
< "codecommit:MergeBranchesByFastForward",
< "codecommit:MergeBranchesBySquash",
< "codecommit:MergeBranchesByThreeWay",
< "codecommit:UpdateDefaultBranch",
12d4
< "codecommit:CreateUnreferencedMergeCommit",
17d8
< "codecommit:CreatePullRequest",
24,31d14
< "codecommit:MergePullRequestByFastForward",
< "codecommit:MergePullRequestBySquash",
< "codecommit:MergePullRequestByThreeWay",
< "codecommit:PostCommentForPullRequest",
< "codecommit:UpdatePullRequestDescription",
< "codecommit:UpdatePullRequestStatus",
< "codecommit:UpdatePullRequestTitle",
< "codecommit:DeleteFile",
35,36d17
< "codecommit:PutFile",
< "codecommit:DeleteCommentContent",
39,41d19
< "codecommit:PostCommentForComparedCommit",
< "codecommit:PostCommentReply",
< "codecommit:UpdateComment",
43d20
< "codecommit:CreateCommit",
51d27
< "codecommit:UpdateRepositoryDescription",
53,54d28
< "codecommit:TagResource",
< "codecommit:UntagResource",
56d29
< "codecommit:PutRepositoryTriggers",
60,62c33
< "codecommit:UploadArchive",
< "codecommit:GetUploadArchiveStatus",
< "codecommit:CancelUploadArchive"
---
> "codecommit:GetUploadArchiveStatus"
```

*Checklist:*

- [ N ] Write/update tests
There aren't tests for config files
- [ Y ] `make pr` passes
- [ N ] Update documentation
 `docs/policy_templates.rst` doesn't list all policies
I'm assuming `2016-10-31/policy_templates/all_policy_templates.yaml` shouldn't be updated with policies from new versions
- [ Y? ] Verify transformed template deploys and application functions as expected
I setup a managed template as follows, and that worked as expected

```
  CodeCommitReadPolicy: 
      Type: AWS::IAM::ManagedPolicy
      Properties:
          PolicyName: CodeCommitReadPolicy
          PolicyDocument: {
            "Version": "0.0.1",
            "Statement": [
              {
                "Effect": "Allow",
                "Action": [
                  "codecommit:GitPull",
                  "codecommit:GetBranch",
                  "codecommit:ListBranches",
                  "codecommit:BatchDescribeMergeConflicts",
                  "codecommit:DescribeMergeConflicts",
                  "codecommit:GetMergeCommit",
                  "codecommit:GetMergeOptions",
                  "codecommit:BatchGetPullRequests",
                  "codecommit:DescribePullRequestEvents",
                  "codecommit:GetCommentsForPullRequest",
                  "codecommit:GetCommitsFromMergeBase",
                  "codecommit:GetMergeConflicts",
                  "codecommit:GetPullRequest",
                  "codecommit:ListPullRequests",
                  "codecommit:GetBlob",
                  "codecommit:GetFile",
                  "codecommit:GetFolder",
                  "codecommit:GetComment",
                  "codecommit:GetCommentsForComparedCommit",
                  "codecommit:BatchGetCommits",
                  "codecommit:GetCommit",
                  "codecommit:GetCommitHistory",
                  "codecommit:GetDifferences",
                  "codecommit:GetObjectIdentifier",
                  "codecommit:GetReferences",
                  "codecommit:GetTree",
                  "codecommit:GetRepository",
                  "codecommit:ListTagsForResource",
                  "codecommit:GetRepositoryTriggers",
                  "codecommit:TestRepositoryTriggers",
                  "codecommit:GetBranch",
                  "codecommit:GetCommit",
                  "codecommit:GetUploadArchiveStatus"
                ],
                "Resource": {
                  "arn:aws:codecommit:us-west-2:475031329963:omnisearch"
                }
              }
            ]
          }
```
- [ Y ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
