### PR TITLE
fix: openapiversion bails if it is not a string

### DIFF
--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -1,7 +1,7 @@
 ﻿from samtranslator.public.sdk.resource import SamResourceType
 from samtranslator.public.intrinsics import is_intrinsics
 from samtranslator.swagger.swagger import SwaggerEditor
-import re
+from six import string_types
 
 
 class Globals(object):
@@ -135,8 +135,11 @@ class Globals(object):
             if ("Type" in resource) and (resource["Type"] == cls._API_TYPE):
                 properties = resource["Properties"]
                 if (cls._OPENAPIVERSION in properties) and (cls._MANAGE_SWAGGER in properties) and \
-                    (re.match(SwaggerEditor.get_openapi_version_3_regex(),
-                              properties[cls._OPENAPIVERSION]) is not None):
+                    SwaggerEditor.safe_compare_regex_with_string(
+                        SwaggerEditor.get_openapi_version_3_regex(), properties[cls._OPENAPIVERSION]):
+                    if not isinstance(properties[cls._OPENAPIVERSION], string_types):
+                        properties[cls._OPENAPIVERSION] = str(properties[cls._OPENAPIVERSION])
+                        resource["Properties"] = properties
                     if "DefinitionBody" in properties:
                         definition_body = properties['DefinitionBody']
                         definition_body['openapi'] = properties[cls._OPENAPIVERSION]

--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -740,8 +740,8 @@ class SwaggerEditor(object):
                 method_definition['parameters'] = existing_parameters
 
             elif self._doc.get("openapi") and \
-                    re.search(SwaggerEditor.get_openapi_version_3_regex(), self._doc["openapi"]) is not None:
-
+                    SwaggerEditor.safe_compare_regex_with_string(
+                        SwaggerEditor.get_openapi_version_3_regex(), self._doc["openapi"]):
                 method_definition['requestBody'] = {
                     'content': {
                         "application/json": {
@@ -901,8 +901,8 @@ class SwaggerEditor(object):
             if bool(data.get("swagger")):
                 return True
             elif bool(data.get("openapi")):
-                return re.search(SwaggerEditor.get_openapi_version_3_regex(), data["openapi"]) is not None
-            return False
+                return SwaggerEditor.safe_compare_regex_with_string(
+                    SwaggerEditor.get_openapi_version_3_regex(), data["openapi"])
         return False
 
     @staticmethod
@@ -951,3 +951,7 @@ class SwaggerEditor(object):
     def get_openapi_version_3_regex():
         openapi_version_3_regex = r"\A3(\.\d)(\.\d)?$"
         return openapi_version_3_regex
+
+    @staticmethod
+    def safe_compare_regex_with_string(regex, data):
+        return re.match(regex, str(data)) is not None

--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -1,5 +1,4 @@
 import copy
-
 from samtranslator.model import ResourceTypeResolver, sam_resources
 from samtranslator.translator.verify_logical_id import verify_unique_logical_id
 from samtranslator.model.preferences.deployment_preference_collection import DeploymentPreferenceCollection

--- a/tests/translator/input/api_request_model_openapi_3.yaml
+++ b/tests/translator/input/api_request_model_openapi_3.yaml
@@ -33,7 +33,7 @@ Resources:
     Type: AWS::Serverless::Api
     Properties:
       StageName: Prod
-      OpenApiVersion: '3.0.1'
+      OpenApiVersion: 3.0
       Models:
         User:
           type: object

--- a/tests/translator/input/api_with_open_api_version.yaml
+++ b/tests/translator/input/api_with_open_api_version.yaml
@@ -1,6 +1,6 @@
 Globals:
   Api:
-    OpenApiVersion: '3.0.1'
+    OpenApiVersion: 3.0.1
     Cors: '*'
 
 Resources:

--- a/tests/translator/input/error_api_with_invalid_open_api_version_type.yaml
+++ b/tests/translator/input/error_api_with_invalid_open_api_version_type.yaml
@@ -1,0 +1,21 @@
+Resources:
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      DefinitionBody: {}
+      OpenApiVersion: 3
+      StageName: 'prod'
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: lambda.handler
+      CodeUri: s3://bucket/api
+      Runtime: nodejs8.10
+      Events:
+        ProxyApiRoot:
+          Type: Api
+          Properties:
+            RestApiId:
+              Ref: MyApi
+            Path: "/"
+            Method: ANY

--- a/tests/translator/output/api_request_model_openapi_3.json
+++ b/tests/translator/output/api_request_model_openapi_3.json
@@ -21,15 +21,6 @@
         }
       }
     }, 
-    "HtmlApiDeploymentefb667b26e": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: efb667b26e8a0b0f733f5dfc27d039c1a2867db0"
-      }
-    }, 
     "HtmlFunctionRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -58,7 +49,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentefb667b26e"
+          "Ref": "HtmlApiDeployment59eeb787ee"
         }, 
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -149,7 +140,7 @@
               }
             }
           }, 
-          "openapi": "3.0.1", 
+          "openapi": "3.0", 
           "components": {
             "securitySchemes": {
               "AWS_IAM": {
@@ -171,6 +162,15 @@
             }
           }
         }
+      }
+    }, 
+    "HtmlApiDeployment59eeb787ee": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        }, 
+        "Description": "RestApi deployment id: 59eeb787ee1561329a07e10162ac3718998e9f91"
       }
     }, 
     "HtmlFunctionGetHtmlPermissionTest": {

--- a/tests/translator/output/aws-cn/api_request_model_openapi_3.json
+++ b/tests/translator/output/aws-cn/api_request_model_openapi_3.json
@@ -1,5 +1,14 @@
 {
   "Resources": {
+    "HtmlApiDeployment5ae7e42cea": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        }, 
+        "Description": "RestApi deployment id: 5ae7e42cea0640a3318bf508535850cd792a52dc"
+      }
+    }, 
     "HtmlFunctionIamPermissionTest": {
       "Type": "AWS::Lambda::Permission", 
       "Properties": {
@@ -19,15 +28,6 @@
             }
           ]
         }
-      }
-    }, 
-    "HtmlApiDeploymentbe02cbff83": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: be02cbff831c2acb5672650bc54b204366bef429"
       }
     }, 
     "HtmlFunctionRole": {
@@ -58,7 +58,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymentbe02cbff83"
+          "Ref": "HtmlApiDeployment5ae7e42cea"
         }, 
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -149,7 +149,7 @@
               }
             }
           }, 
-          "openapi": "3.0.1", 
+          "openapi": "3.0", 
           "components": {
             "securitySchemes": {
               "AWS_IAM": {

--- a/tests/translator/output/aws-us-gov/api_request_model_openapi_3.json
+++ b/tests/translator/output/aws-us-gov/api_request_model_openapi_3.json
@@ -21,15 +21,6 @@
         }
       }
     }, 
-    "HtmlApiDeploymente91bc94e87": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "HtmlApi"
-        }, 
-        "Description": "RestApi deployment id: e91bc94e874a30084312552d628dd248890ad7f9"
-      }
-    }, 
     "HtmlFunctionRole": {
       "Type": "AWS::IAM::Role", 
       "Properties": {
@@ -58,7 +49,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "HtmlApiDeploymente91bc94e87"
+          "Ref": "HtmlApiDeploymenta488cfa4f9"
         }, 
         "RestApiId": {
           "Ref": "HtmlApi"
@@ -149,7 +140,7 @@
               }
             }
           }, 
-          "openapi": "3.0.1", 
+          "openapi": "3.0", 
           "components": {
             "securitySchemes": {
               "AWS_IAM": {
@@ -179,6 +170,15 @@
         "Parameters": {
           "endpointConfigurationTypes": "REGIONAL"
         }
+      }
+    }, 
+    "HtmlApiDeploymenta488cfa4f9": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "HtmlApi"
+        }, 
+        "Description": "RestApi deployment id: a488cfa4f9c73604187a3a5dfa5f333ef2c52e1e"
       }
     }, 
     "HtmlFunctionGetHtmlPermissionTest": {

--- a/tests/translator/output/error_api_with_invalid_open_api_version.json
+++ b/tests/translator/output/error_api_with_invalid_open_api_version.json
@@ -1,8 +1,8 @@
 {
     "errors": [
       {
-        "errorMessage": "Resource with id [MyApi] is invalid. The OpenApiVersion value must be of the format 3.0.0"
+        "errorMessage": "Resource with id [MyApi] is invalid. The OpenApiVersion value must be of the format \"3.0.0\""
       }
     ], 
-    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyApi] is invalid. The OpenApiVersion value must be of the format 3.0.0"
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyApi] is invalid. The OpenApiVersion value must be of the format \"3.0.0\""
   }

--- a/tests/translator/output/error_api_with_invalid_open_api_version_type.json
+++ b/tests/translator/output/error_api_with_invalid_open_api_version_type.json
@@ -1,0 +1,8 @@
+{
+    "errors": [
+      {
+        "errorMessage": "Resource with id [MyApi] is invalid. Type of property 'OpenApiVersion' is invalid."
+      }
+    ], 
+    "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyApi] is invalid. Type of property 'OpenApiVersion' is invalid."
+  }

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -490,7 +490,8 @@ class TestTranslatorEndToEnd(TestCase):
     'error_function_with_unknown_policy_template',
     'error_function_with_invalid_policy_statement',
     'error_function_with_invalid_condition_name',
-    'error_invalid_document_empty_semantic_version'
+    'error_invalid_document_empty_semantic_version',
+    'error_api_with_invalid_open_api_version_type'
 ])
 @patch('boto3.session.Session.region_name', 'ap-southeast-1')
 @patch('samtranslator.plugins.application.serverless_app_plugin.ServerlessAppPlugin._sar_service_call', mock_sar_service_call)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
I am seeing tons of errors where SAM is bailing when the template defines openapi without the quotes. 
*Description of how you validated changes:*
Modified existing tests to remove the quotes from openapiversion value, and the output does not change.
*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
