### PR TITLE
fix: Use scoped logger instead of root

### DIFF
--- a/samtranslator/plugins/__init__.py
+++ b/samtranslator/plugins/__init__.py
@@ -3,6 +3,8 @@ import logging
 from samtranslator.model.exceptions import InvalidResourceException, InvalidDocumentException
 from enum import Enum
 
+LOG = logging.getLogger(__name__)
+
 
 class SamPlugins(object):
     """
@@ -132,7 +134,7 @@ class SamPlugins(object):
                 # Don't need to log these because they don't result in crashes
                 raise ex
             except Exception as ex:
-                logging.exception("Plugin '%s' raised an exception: %s", plugin.name, ex)
+                LOG.exception("Plugin '%s' raised an exception: %s", plugin.name, ex)
                 raise ex
 
     def __len__(self):

--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -13,6 +13,8 @@ from samtranslator.public.sdk.template import SamTemplate
 from samtranslator.intrinsics.resolver import IntrinsicsResolver
 from samtranslator.intrinsics.actions import FindInMapAction
 
+LOG = logging.getLogger(__name__)
+
 
 class ServerlessAppPlugin(BasePlugin):
     """
@@ -156,7 +158,7 @@ class ServerlessAppPlugin(BasePlugin):
         except EndpointConnectionError as e:
             # No internet connection. Don't break verification, but do show a warning.
             warning_message = "{}. Unable to verify access to {}/{}.".format(e, app_id, semver)
-            logging.warning(warning_message)
+            LOG.warning(warning_message)
             self._applications[key] = {'Unable to verify'}
 
     def _handle_create_cfn_template_request(self, app_id, semver, key, logical_id):
@@ -326,7 +328,7 @@ class ServerlessAppPlugin(BasePlugin):
         """
         try:
             response = service_call_lambda(*args)
-            logging.info(response)
+            LOG.info(response)
             return response
         except ClientError as e:
             error_code = e.response['Error']['Code']
@@ -334,7 +336,7 @@ class ServerlessAppPlugin(BasePlugin):
                 raise InvalidResourceException(logical_id, e.response['Error']['Message'])
 
             # 'ForbiddenException'- SAR rejects connection
-            logging.exception(e)
+            LOG.exception(e)
             raise e
 
     def _resource_is_supported(self, resource_type):


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
When catching some exceptions that cause a crash in `sam validate`, I noticed that stack traces where still being printing to console from the CLI. This is due to the translator using the root logger in some cases. Best practice is to use a scoped logger (to the module), so that users can set the logging how they wish (in our case not print stack traces to console from the cli). This PR addresses two spots in the codebase that where still using the root logger. This has no impact to logging within the translator (in the cloud), since it only changes what logger is used.

*Description of how you validated changes:*
`make pr`

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
