### PR TITLE
chore: actually exclude test files from being installed

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     url='https://github.com/awslabs/serverless-application-model',
     license='Apache License 2.0',
     # Exclude all but the code folders
-    packages=find_packages(exclude=('tests', 'docs', 'examples', 'versions')),
+    packages=find_packages(exclude=('tests*', 'docs', 'examples', 'versions')),
     install_requires=read_requirements('base.txt'),
     include_package_data=True,
     extras_require={


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

In Arch Linux, we build [python-aws-sam-translator](https://www.archlinux.org/packages/community/any/python-aws-sam-translator/) package from sources. Before this change, test files are installed:
```
$ python setup.py install --root=arch-pkgdir
$ ls arch-pkgdir/usr/lib/python3.7/site-packages/tests
intrinsics  model  plugins  policy_template_processor  sdk  swagger  translator
```
This is a problem as the directory `/usr/lib/python3.7/site-packages/tests` conflicts with other packages.

*Description of how you validated changes:*

After this change, there are no longer test files
```
$ python setup.py install --root=arch-pkgdir
$ ls arch-pkgdir/usr/lib/python3.7/site-packages
aws_sam_translator-1.15.0-py3.7.egg-info  samtranslator
```

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`

I think these checks are irrelevant are this is a packaging fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
