### PR TITLE
bugfix: redeploy api when a function name changes

### DIFF
--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -173,7 +173,7 @@ class ApiGenerator(object):
 
         return deployment
 
-    def _construct_stage(self, deployment, swagger):
+    def _construct_stage(self, deployment, swagger, function_name):
         """Constructs and returns the ApiGateway Stage.
 
         :param model.apigateway.ApiGatewayDeployment deployment: the Deployment for this Stage
@@ -199,14 +199,14 @@ class ApiGenerator(object):
         stage.TracingEnabled = self.tracing_enabled
 
         if swagger is not None:
-            deployment.make_auto_deployable(stage, self.remove_extra_stage, swagger)
+            deployment.make_auto_deployable(stage, self.remove_extra_stage, function_name, swagger)
 
         if self.tags is not None:
             stage.Tags = get_tag_list(self.tags)
 
         return stage
 
-    def to_cloudformation(self):
+    def to_cloudformation(self, function_name):
         """Generates CloudFormation resources from a SAM API resource
 
         :returns: a tuple containing the RestApi, Deployment, and Stage for an empty Api.
@@ -222,7 +222,7 @@ class ApiGenerator(object):
         elif rest_api.BodyS3Location is not None:
             swagger = rest_api.BodyS3Location
 
-        stage = self._construct_stage(deployment, swagger)
+        stage = self._construct_stage(deployment, swagger, function_name)
         permissions = self._construct_authorizer_lambda_permission()
 
         return rest_api, deployment, stage, permissions

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -76,7 +76,7 @@ class ApiGatewayDeployment(Resource):
         "deployment_id": lambda self: ref(self.logical_id),
     }
 
-    def make_auto_deployable(self, stage, openapi_version=None, swagger=None):
+    def make_auto_deployable(self, stage, openapi_version=None, function_name=None, swagger=None):
         """
         Sets up the resource such that it will trigger a re-deployment when Swagger changes
         or the openapi version changes.
@@ -95,6 +95,9 @@ class ApiGatewayDeployment(Resource):
         hash_input = [str(swagger)]
         if openapi_version:
             hash_input.append(str(openapi_version))
+
+        if function_name:
+            hash_input.append(str(function_name))
 
         data = self._X_HASH_DELIMITER.join(hash_input)
         generator = logical_id_generator.LogicalIdGenerator(self.logical_id, data)

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -502,6 +502,7 @@ class SamApi(SamResourceMacro):
 
         intrinsics_resolver = kwargs["intrinsics_resolver"]
         self.BinaryMediaTypes = intrinsics_resolver.resolve_parameter_refs(self.BinaryMediaTypes)
+        function_name = kwargs.get('function_name')
 
         api_generator = ApiGenerator(self.logical_id,
                                      self.CacheClusterEnabled,
@@ -528,7 +529,7 @@ class SamApi(SamResourceMacro):
                                      open_api_version=self.OpenApiVersion,
                                      models=self.Models)
 
-        rest_api, deployment, stage, permissions = api_generator.to_cloudformation()
+        rest_api, deployment, stage, permissions = api_generator.to_cloudformation(function_name)
 
         resources.extend([rest_api, deployment, stage])
         resources.extend(permissions)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Added function name of the function that belongs to an API to the hash.
If a function name changes so does the hash and the API will be redeployed automatically

*Description of how you validated changes:*
I have manually deployed a stack and validated this
I will add unit tests and make sure this code fix works

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
