### PR TITLE
Fix link to Github issues in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,7 +87,7 @@ Here are some questions that you should answer in your plan:
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/awslabs/PRIVATE-aws-sam-development/issues), or [recently closed](https://github.com/awslabs/PRIVATE-aws-sam-development/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
+When filing an issue, please check [existing open](https://github.com/awslabs/serverless-application-model/issues), or [recently closed](https://github.com/awslabs/serverless-application-model/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 - A reproducible test case or series of steps


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
CONTRIBUTING.md contained a link to an non-existing Github repository. Changed it to this repo.

*Description of how you validated changes:*
Both links work now.

*Checklist:*

- [ ] ~~Write/update tests~~
- [ ] ~~`make pr` passes~~
- [ ] ~~Update documentation~~
- [ ] ~~Verify transformed template deploys and application functions as expected~~
- [ ] ~~Add/update example to `examples/2016-10-31`~~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
