### PR TITLE
Add Missing Escape Character To Cors Section In Documentation

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -785,7 +785,7 @@ Cors:
   # Header is omitted when false. Checkout [HTTP Spec](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Credentials) for more details on this value.
 ```
 
-> NOTE: HTTP spec requires the value of Allow properties to be a quoted string. So don't forget the additional quotes in the value. ie. "'www.example.com'" is correct whereas "www.example.com" is wrong
+> NOTE: HTTP spec requires the value of Allow properties to be a quoted string. So don't forget the additional quotes in the value. ie. "\'www.example.com\'" is correct whereas "www.example.com" is wrong
 
 #### API Auth Object
 


### PR DESCRIPTION
Without escape character sentence was confusing.  🍮  🍦

*Issue #, if available:*
Missing escape character in sentence means reading docs on github was confusing
 
*Description of changes:*
Adding the escape character 

*Description of how you validated changes:*
It's only a change to docs :) 

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
