### PR TITLE
Updated DynamoDBCrudPolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -117,7 +117,8 @@
               "dynamodb:UpdateItem",
               "dynamodb:BatchWriteItem",
               "dynamodb:BatchGetItem",
-              "dynamodb:DescribeTable"
+              "dynamodb:DescribeTable",
+              "dynamodb:ConditionCheckItem"
             ],
             "Resource": [
               {

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -120,7 +120,8 @@
                     "dynamodb:UpdateItem",
                     "dynamodb:BatchWriteItem",
                     "dynamodb:BatchGetItem",
-                    "dynamodb:DescribeTable"
+                    "dynamodb:DescribeTable",
+                    "dynamodb:ConditionCheckItem"
                   ],
                   "Resource": [
                     {

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -120,7 +120,8 @@
                     "dynamodb:UpdateItem",
                     "dynamodb:BatchWriteItem",
                     "dynamodb:BatchGetItem",
-                    "dynamodb:DescribeTable"
+                    "dynamodb:DescribeTable",
+                    "dynamodb:ConditionCheckItem"
                   ],
                   "Resource": [
                     {

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -120,7 +120,8 @@
                     "dynamodb:UpdateItem",
                     "dynamodb:BatchWriteItem",
                     "dynamodb:BatchGetItem",
-                    "dynamodb:DescribeTable"
+                    "dynamodb:DescribeTable",
+                    "dynamodb:ConditionCheckItem"
                   ],
                   "Resource": [
                     {


### PR DESCRIPTION
*Description of changes:*
Added the `dynamodb:ConditionCheckItem` action to the DynamoDBCrudPolicy template to allow use of the conditional check item on transactional writes

*Description of how you validated changes:*
Deployed a SAM application using  the template and verified it could preform all the actions on a table in the existing template

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
