### PR TITLE
fix slack channel link

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Read the [SAM Documentation Contribution Guide](https://github.com/awsdocs/aws-s
 started. 
 
 ### Join the SAM Community on Slack
-[Join the SAM developers channel (#samdev)](https://join.slack.com/t/awsdevelopers/shared_invite/enQtMzg3NTc5OTM2MzcxLTdjYTdhYWE3OTQyYTU4Njk1ZWY4Y2ZjYjBhMTUxNGYzNDg5MWQ1ZTc5MTRlOGY0OTI4NTdlZTMwNmI5YTgwOGM/) on Slack to collaborate with fellow community members and the AWS SAM team.
+[Join the SAM developers channel (#samdev)](https://join.slack.com/t/awsdevelopers/shared_invite/enQtMzg3NTc5OTM2MzcxLTIxNjc0ZTJkNmYyNWY3OWE4NTFiNzU1ZTM2Y2VkNmFlNjQ2YjI3YTE1ZDA5YjE5NDE2MjVmYWFlYWIxNjE2NjU) on Slack to collaborate with fellow community members and the AWS SAM team.
 
 
 


### PR DESCRIPTION
*Issue #, if available:*
[#1163](https://github.com/awslabs/serverless-application-model/issues/1163)

*Description of changes:*
added a new slack invite link

*Description of how you validated changes:*
checked if the new link is redirecting to the correct page

*Checklist:*
- [x] `make pr` passes
- [x] Update documentation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
