### PR TITLE
Changes for EventBusName on CW Event

### DIFF
--- a/examples/2016-10-31/cloudwatch-event-to-msteams/template.yaml
+++ b/examples/2016-10-31/cloudwatch-event-to-msteams/template.yaml
@@ -45,6 +45,7 @@ Resources:
           Type: CloudWatchEvent
           Description: Detects EC2 Security Group Events to Send to Teams
           Properties:
+            EventBusName: default
             Pattern:
               source:
                 - "aws.ec2"

--- a/samtranslator/model/events.py
+++ b/samtranslator/model/events.py
@@ -7,6 +7,7 @@ class EventsRule(Resource):
     resource_type = 'AWS::Events::Rule'
     property_types = {
             'Description': PropertyType(False, is_str()),
+            'EventBusName': PropertyType(False, is_str()),
             'EventPattern': PropertyType(False, is_type(dict)),
             'Name': PropertyType(False, is_str()),
             'RoleArn': PropertyType(False, is_str()),

--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -143,6 +143,7 @@ class CloudWatchEvent(PushEventSource):
     resource_type = 'CloudWatchEvent'
     principal = 'events.amazonaws.com'
     property_types = {
+        'EventBusName': PropertyType(False, is_str()),
         'Pattern': PropertyType(False, is_type(dict)),
         'Input': PropertyType(False, is_str()),
         'InputPath': PropertyType(False, is_str())
@@ -164,6 +165,7 @@ class CloudWatchEvent(PushEventSource):
         resources = []
 
         events_rule = EventsRule(self.logical_id)
+        events_rule.EventBusName = self.EventBusName
         events_rule.EventPattern = self.Pattern
         events_rule.Targets = [self._construct_target(function)]
         if CONDITION in function.resource_attributes:

--- a/samtranslator/validator/sam_schema/schema.json
+++ b/samtranslator/validator/sam_schema/schema.json
@@ -336,6 +336,9 @@
     "AWS::Serverless::Function.CloudWatchEventEvent": {
       "additionalProperties": false,
       "properties": {
+        "EventBusName": {
+          "type": "string"
+        },
         "Input": {
           "type": "string"
         },

--- a/tests/translator/input/cloudwatchevent.yaml
+++ b/tests/translator/input/cloudwatchevent.yaml
@@ -20,6 +20,7 @@ Resources:
         OnTerminate:
           Type: CloudWatchEvent
           Properties:
+            EventBusName: ExternalEventBridge
             Pattern:
               detail:
                 state:

--- a/tests/translator/output/aws-cn/cloudwatchevent.json
+++ b/tests/translator/output/aws-cn/cloudwatchevent.json
@@ -90,6 +90,7 @@
             ]
           }
         }, 
+        "EventBusName": "ExternalEventBridge",
         "Targets": [
           {
             "Id": "TriggeredFunctionOnTerminateLambdaTarget", 

--- a/tests/translator/output/aws-us-gov/cloudwatchevent.json
+++ b/tests/translator/output/aws-us-gov/cloudwatchevent.json
@@ -90,6 +90,7 @@
             ]
           }
         }, 
+        "EventBusName": "ExternalEventBridge",
         "Targets": [
           {
             "Id": "TriggeredFunctionOnTerminateLambdaTarget", 

--- a/tests/translator/output/cloudwatchevent.json
+++ b/tests/translator/output/cloudwatchevent.json
@@ -90,6 +90,7 @@
             ]
           }
         }, 
+        "EventBusName": "ExternalEventBridge",
         "Targets": [
           {
             "Id": "TriggeredFunctionOnTerminateLambdaTarget", 

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -585,6 +585,7 @@ The object describing an event source with type `CloudWatchEvent`.
 Property Name | Type | Description
 ---|:---:|---
 Pattern | [Event Pattern Object](http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/CloudWatchEventsandEventPatterns.html) | **Required.** Pattern describing which CloudWatch events trigger the function. Only matching events trigger the function.
+EventBusName | `string` | The event bus to associate with this rule. If you omit this, the default event bus is used.
 Input | `string` | JSON-formatted string to pass to the function as the event body. This value overrides the matched event.
 InputPath | `string` | JSONPath describing the part of the event to pass to the function.
 


### PR DESCRIPTION
*Issue #, if available:*
#1067

*Description of changes:*
Add field `EventBusName` to events that are triggers to functions

*Description of how you validated changes:*

Changes the input yaml and output CFN Templates to make sure it was put correctly. Even though it is supporting the "EventBridge" service the field is called ["EventBusName" on the rule](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/AWS_Events.html)

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
