### PR TITLE
Add intrinsic support for Serverless::Function.DeploymentPreference.Enabled

### DIFF
--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -166,7 +166,7 @@ resource:
       Runtime: nodejs8.10
       FunctionName: 'CodeDeployHook_preTrafficHook'
       DeploymentPreference:
-        Enabled: false
+        Enabled: False
         Role: ""
       Environment:
         Variables:
@@ -273,7 +273,7 @@ Hooks are extremely powerful because:
 
     FunctionName: 'CodeDeployHook_preTrafficHook'
     DeploymentPreference:
-        Enabled: false
+        Enabled: False
     Policies:
         - Version: "2012-10-17"
           Statement:

--- a/examples/2016-10-31/lambda_safe_deployments/template.yaml
+++ b/examples/2016-10-31/lambda_safe_deployments/template.yaml
@@ -38,7 +38,7 @@ Resources:
       Runtime: nodejs8.10
       FunctionName: 'CodeDeployHook_preTrafficHook'
       DeploymentPreference:
-        Enabled: false
+        Enabled: False
       Environment:
         Variables:
           CurrentVersion: !Ref safeTest.Version

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -421,10 +421,11 @@ class SamFunction(SamResourceMacro):
     def _validate_deployment_preference_and_add_update_policy(self, deployment_preference_collection, lambda_alias,
                                                               intrinsics_resolver, mappings_resolver):
         if 'Enabled' in self.DeploymentPreference:
-            self.DeploymentPreference['Enabled'] = intrinsics_resolver.resolve_parameter_refs(
-                self.DeploymentPreference['Enabled'])
-            if isinstance(self.DeploymentPreference['Enabled'], dict):
-                raise InvalidResourceException(self.logical_id, "'Enabled' must be a boolean value")
+            # resolve intrinsics and mappings for Type
+            enabled = self.DeploymentPreference['Enabled']
+            enabled = intrinsics_resolver.resolve_parameter_refs(enabled)
+            enabled = mappings_resolver.resolve_parameter_refs(enabled)
+            self.DeploymentPreference['Enabled'] = enabled
 
         if 'Type' in self.DeploymentPreference:
             # resolve intrinsics and mappings for Type

--- a/samtranslator/sdk/parameter.py
+++ b/samtranslator/sdk/parameter.py
@@ -65,3 +65,14 @@ class SamParameterValues(object):
         """
         if 'AWS::Region' not in self.parameter_values:
             self.parameter_values['AWS::Region'] = boto3.session.Session().region_name
+
+        if 'AWS::Partition' not in self.parameter_values:
+            region = boto3.session.Session().region_name
+
+            # neither boto nor botocore has any way of returning the partition value yet
+            if region.startswith('cn-'):
+                self.parameter_values['AWS::Partition'] = 'aws-cn'
+            elif region.startswith('us-gov-'):
+                self.parameter_values['AWS::Partition'] = 'aws-us-gov'
+            else:
+                self.parameter_values['AWS::Partition'] = 'aws'

--- a/tests/sdk/test_parameter.py
+++ b/tests/sdk/test_parameter.py
@@ -114,7 +114,8 @@ class TestSAMParameterValues(TestCase):
 
         expected = {
             "Param1": "value1",
-            "AWS::Region": "ap-southeast-1"
+            "AWS::Region": "ap-southeast-1",
+            "AWS::Partition": "aws"
         }
 
         sam_parameter_values = SamParameterValues(parameter_values)
@@ -128,7 +129,39 @@ class TestSAMParameterValues(TestCase):
         }
 
         expected = {
-            "AWS::Region": "value1"
+            "AWS::Region": "value1",
+            "AWS::Partition": "aws"
+        }
+
+        sam_parameter_values = SamParameterValues(parameter_values)
+        sam_parameter_values.add_pseudo_parameter_values()
+        self.assertEqual(expected, sam_parameter_values.parameter_values)
+
+    @patch('boto3.session.Session.region_name', 'us-gov-west-1')
+    def test_add_pseudo_parameter_values_aws_partition(self):
+        parameter_values = {
+            "Param1": "value1"
+        }
+
+        expected = {
+            "Param1": "value1",
+            "AWS::Region": "us-gov-west-1",
+            "AWS::Partition": "aws-us-gov"
+        }
+
+        sam_parameter_values = SamParameterValues(parameter_values)
+        sam_parameter_values.add_pseudo_parameter_values()
+        self.assertEqual(expected, sam_parameter_values.parameter_values)
+
+    @patch('boto3.session.Session.region_name', 'us-gov-west-1')
+    def test_add_pseudo_parameter_values_aws_partition_not_override(self):
+        parameter_values = {
+            "AWS::Partition": "aws"
+        }
+
+        expected = {
+            "AWS::Partition": "aws",
+            "AWS::Region": "us-gov-west-1"
         }
 
         sam_parameter_values = SamParameterValues(parameter_values)

--- a/tests/translator/input/function_with_deployment_preference_all_parameters.yaml
+++ b/tests/translator/input/function_with_deployment_preference_all_parameters.yaml
@@ -7,7 +7,7 @@ Resources:
       Runtime: python2.7
       AutoPublishAlias: live
       DeploymentPreference:
-        Enabled: true
+        Enabled: True
         Type: Linear10PercentEvery1Minute
         Hooks:
           PreTraffic: !Ref MySanityTestFunction
@@ -22,7 +22,7 @@ Resources:
       Runtime: python2.7
       CodeUri: s3://my-bucket/mySanityTestFunction.zip
       DeploymentPreference:
-        Enabled: false
+        Enabled: False
 
   MyValidationTestFunction:
     Type: 'AWS::Serverless::Function'
@@ -31,7 +31,7 @@ Resources:
       Runtime: python2.7
       CodeUri: s3://my-bucket/myValidationTestFunction.zip
       DeploymentPreference:
-        Enabled: false
+        Enabled: False
 
   MyCloudWatchAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/tests/translator/input/function_with_deployment_preference_multiple_combinations.yaml
+++ b/tests/translator/input/function_with_deployment_preference_multiple_combinations.yaml
@@ -39,7 +39,7 @@ Resources:
       Runtime: python2.7
       CodeUri: s3://my-bucket/mySanityTestFunction.zip
       DeploymentPreference:
-        Enabled: false
+        Enabled: False
 
   MyValidationTestFunction:
     Type: 'AWS::Serverless::Function'
@@ -48,7 +48,7 @@ Resources:
       Runtime: python2.7
       CodeUri: s3://my-bucket/myValidationTestFunction.zip
       DeploymentPreference:
-        Enabled: false
+        Enabled: False
 
   MyCloudWatchAlarm:
     Type: AWS::CloudWatch::Alarm

--- a/tests/translator/input/function_with_disabled_deployment_preference.yaml
+++ b/tests/translator/input/function_with_disabled_deployment_preference.yaml
@@ -7,5 +7,5 @@ Resources:
       Runtime: python2.7
       AutoPublishAlias: live
       DeploymentPreference:
-        Enabled: false
+        Enabled: False
         Type: AllAtOnce

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -779,6 +779,7 @@ class TestFunctionVersionWithParameterReferences(TestCase):
 
 class TestTemplateValidation(TestCase):
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
     def test_throws_when_resource_not_found(self):
         template = {
@@ -790,6 +791,7 @@ class TestTemplateValidation(TestCase):
             translator = Translator({}, sam_parser)
             translator.translate(template, {})
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
     def test_throws_when_resource_is_empty(self):
         template = {
@@ -802,6 +804,7 @@ class TestTemplateValidation(TestCase):
             translator.translate(template, {})
 
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
     def test_throws_when_resource_is_not_dict(self):
         template = {
@@ -814,6 +817,7 @@ class TestTemplateValidation(TestCase):
             translator.translate(template, {})
 
 
+    @patch('boto3.session.Session.region_name', 'ap-southeast-1')
     @patch('botocore.client.ClientEndpointBridge._check_default_region', mock_get_region)
     def test_throws_when_resources_not_all_dicts(self):
         template = {
@@ -915,7 +919,7 @@ class TestPluginsUsage(TestCase):
         resource_from_dict_mock.assert_called_with("MyTable",
                                                         manifest["Resources"]["MyTable"],
                                                         sam_plugins=sam_plugins_object_mock)
-        prepare_plugins_mock.assert_called_once_with(initial_plugins, {"AWS::Region": "ap-southeast-1"})
+        prepare_plugins_mock.assert_called_once_with(initial_plugins, {"AWS::Region": "ap-southeast-1", "AWS::Partition": "aws"})
 
 def get_policy_mock():
     mock_policy_loader = MagicMock()

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -782,7 +782,7 @@ Specifies the configurations to enable Safe Lambda Deployments. Read the [usage 
 
 ```yaml
 DeploymentPreference:
-  Enabled: true
+  Enabled: True # Set to False to disable. Supports all intrinsics.
   Type: Linear10PercentEvery10Minutes
   Alarms:
     # A list of alarms that you want to monitor


### PR DESCRIPTION
Add intrinsic support for Serverless::Function.DeploymentPreference.Enabled

*Issue #, if available:*

*Description of changes:*
Added intrinsics for Serverless::Function.DeploymentPreferences.Enabled. It now supports Fn::If, Fn::FindInMap, !Ref, etc.

*Description of how you validated changes:*
Wrote/updated unit tests validating the changes. Tested changes with a production template to verify changes manually.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
