### PR TITLE
Add policy for EventBridge putEvents

### DIFF
--- a/examples/2016-10-31/policy_templates/all_policy_templates.yaml
+++ b/examples/2016-10-31/policy_templates/all_policy_templates.yaml
@@ -96,3 +96,5 @@ Resources:
 
         - CodeCommitReadPolicy:
             RepositoryName: name
+
+        - EventBridgePutEventsPolicy: {}

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1736,6 +1736,20 @@
           }
         ]
       }
+    },
+    "EventBridgePutEventsPolicy": {
+      "Description": "Gives permission to put Events to event buses",
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "events:PutEvents"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
     }
   }
 }

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1739,6 +1739,7 @@
     },
     "EventBridgePutEventsPolicy": {
       "Description": "Gives permission to put Events to event buses",
+      "Parameters": {},
       "Definition": {
         "Statement": [
           {

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -151,3 +151,5 @@ Resources:
 
         - CodeCommitReadPolicy:
             RepositoryName: name
+
+        - EventBridgePutEventsPolicy: {}

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1372,6 +1372,20 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy52",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "events:PutEvents"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1371,6 +1371,20 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy52",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "events:PutEvents"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1372,6 +1372,20 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy52",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Effect": "Allow",
+                  "Action": [
+                    "events:PutEvents"
+                  ],
+                  "Resource": "*"
+                }
+              ]
+            }
           }
         ],
         "AssumeRolePolicyDocument": {


### PR DESCRIPTION
*Issue #, if available:*
#1187 

*Description of changes:*
Added a policy for EventBridge putEvents.
This supports putting events for all event buses at this time.

*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
