### PR TITLE
Adding VPC Access Policy when VpcConfig is present

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -198,6 +198,10 @@ class SamFunction(SamResourceMacro):
         managed_policy_arns = [ArnGenerator.generate_aws_managed_policy_arn('service-role/AWSLambdaBasicExecutionRole')]
         if self.Tracing:
             managed_policy_arns.append(ArnGenerator.generate_aws_managed_policy_arn('AWSXrayWriteOnlyAccess'))
+        if self.VpcConfig:
+            managed_policy_arns.append(
+                ArnGenerator.generate_aws_managed_policy_arn('service-role/AWSLambdaVPCAccessExecutionRoles')
+            )
 
         function_policies = FunctionPolicies({"Policies": self.Policies},
                                              # No support for policy templates in the "core"

--- a/tests/translator/output/aws-cn/globals_for_function.json
+++ b/tests/translator/output/aws-cn/globals_for_function.json
@@ -5,7 +5,8 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRoles"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/OverridePermissionsBoundary", 
         "AssumeRolePolicyDocument": {
@@ -92,7 +93,8 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRoles"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/aws-us-gov/globals_for_function.json
+++ b/tests/translator/output/aws-us-gov/globals_for_function.json
@@ -5,7 +5,8 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRoles"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/OverridePermissionsBoundary", 
         "AssumeRolePolicyDocument": {
@@ -92,7 +93,8 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRoles"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
         "AssumeRolePolicyDocument": {

--- a/tests/translator/output/globals_for_function.json
+++ b/tests/translator/output/globals_for_function.json
@@ -5,7 +5,8 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRoles"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/OverridePermissionsBoundary", 
         "AssumeRolePolicyDocument": {
@@ -92,7 +93,8 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
+          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess",
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRoles"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary", 
         "AssumeRolePolicyDocument": {


### PR DESCRIPTION
*Issue #, if available:*
#1169 

*Description of changes:*
The managed role `service-role/AWSLambdaVPCAccessExecutionRoles` is added when the property `VpcConfig` is present .

*Description of how you validated changes:*
I updated the tests to check that the generated role contains `service-role/AWSLambdaVPCAccessExecutionRoles`

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
