### PR TITLE
fix: adding support to point to api gateway distribution 

### DIFF
--- a/examples/2016-10-31/custom_domains_with_route53/README.md
+++ b/examples/2016-10-31/custom_domains_with_route53/README.md
@@ -6,7 +6,6 @@ Example SAM template for setting up Api Gateway resources for custom domains.
 1. A domain name. You can purchase a domain name from a domain name provider.
 1. A certificate ARN. Set up or import a valid certificate into AWS Certificate Manager. If the endpoint is EDGE, the certificate must be created in us-east-1.
 1. A HostedZone in Route53 for the domain name.
-1. A Cloudfront Distribution for the domain if the endpoint is set to EDGE.
 
 ## PostRequisites
 After deploying the template, make sure you configure the DNS settings on the domain name provider's website. You will need to add Type A and Type AAAA DNS records that are point to ApiGateway's Hosted Zone Id. Read more [here](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-to-api-gateway.html)
@@ -19,3 +18,5 @@ $ sam deploy \
     --stack-name my-new-stack \
     --capabilities CAPABILITY_IAM
 ```
+
+Curl to the endpoint "http://example.com/home/fetch" should hit the Api.

--- a/examples/2016-10-31/custom_domains_with_route53/template.yaml
+++ b/examples/2016-10-31/custom_domains_with_route53/template.yaml
@@ -37,11 +37,12 @@ Resources:
         CertificateArn: !Ref ACMCertificateArn
         EndpointConfiguration: EDGE
         BasePath:
-          - /fetch
+          - /home
         Route53:
          HostedZoneId: ZQ1UAL4EFZVME
          IpV6: true
-         DistributionDomainName: !GetAtt Distribution.DomainName
+## ====== Everything below here is optional, leave this out if you want to use the internal Api Gateway distribution =======
+         DistributionDomainName: !GetAtt Distribution.DomainName 
 
   Distribution:
     Type: AWS::CloudFront::Distribution

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -326,9 +326,7 @@ class ApiGenerator(object):
             alias_target['DNSName'] = fnGetAtt(self.domain.get('ApiDomainName'), 'RegionalDomainName')
         else:
             if route53.get('DistributionDomainName') is None:
-                raise InvalidResourceException(self.logical_id,
-                                               "Custom Domains support for EDGE requires the name "
-                                               "of a Distribution resource")
+                route53['DistributionDomainName'] = fnGetAtt(self.domain.get('ApiDomainName'), 'DistributionDomainName')
             alias_target['HostedZoneId'] = 'Z2FDTNDATAQYW2'
             alias_target['DNSName'] = route53.get('DistributionDomainName')
         return alias_target

--- a/samtranslator/model/apigateway.py
+++ b/samtranslator/model/apigateway.py
@@ -98,7 +98,6 @@ class ApiGatewayDeployment(Resource):
         if openapi_version:
             hash_input.append(str(openapi_version))
         if domain:
-            hash_input.append(self._X_HASH_DELIMITER)
             hash_input.append(json.dumps(domain))
 
         data = self._X_HASH_DELIMITER.join(hash_input)

--- a/tests/translator/input/api_with_custom_domain_route53.yaml
+++ b/tests/translator/input/api_with_custom_domain_route53.yaml
@@ -37,34 +37,7 @@ Resources:
         CertificateArn: !Ref ACMCertificateArn
         EndpointConfiguration: EDGE
         BasePath:
-          - /fetch
+          - /one
         Route53:
          HostedZoneId: ZQ1UAL4EFZVME
          IpV6: true
-         DistributionDomainName: !GetAtt Distribution.DomainName
-
-  Distribution:
-    Type: AWS::CloudFront::Distribution
-    Properties:
-      DistributionConfig:
-        Enabled: true
-        HttpVersion: http2
-        Origins:
-        - DomainName: !Ref DomainName
-          Id: !Ref DomainName
-          CustomOriginConfig:
-            HTTPPort: 80
-            HTTPSPort: 443
-            OriginProtocolPolicy: https-only
-        DefaultCacheBehavior:
-          AllowedMethods: [ HEAD, DELETE, POST, GET, OPTIONS, PUT, PATCH ]
-          ForwardedValues:
-            QueryString: false
-          SmoothStreaming: false
-          Compress: true
-          TargetOriginId: !Ref DomainName
-          ViewerProtocolPolicy: redirect-to-https
-        PriceClass: PriceClass_100
-        ViewerCertificate:
-          SslSupportMethod: sni-only
-          AcmCertificateArn: !Ref ACMCertificateArn

--- a/tests/translator/output/api_with_basic_custom_domain.json
+++ b/tests/translator/output/api_with_basic_custom_domain.json
@@ -90,7 +90,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyAnotherApiDeploymente89573907a"
+          "Ref": "MyAnotherApiDeployment48a61be119"
         }, 
         "RestApiId": {
           "Ref": "MyAnotherApi"
@@ -116,18 +116,6 @@
               }
             }
           ]
-        }
-      }
-    }, 
-    "MyAnotherApiBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
-      "Properties": {
-        "DomainName": "another-example.com", 
-        "RestApiId": {
-          "Ref": "MyAnotherApi"
-        }, 
-        "Stage": {
-          "Ref": "MyAnotherApiProdStage"
         }
       }
     }, 
@@ -159,13 +147,17 @@
         }
       }
     }, 
-    "MyApiDeploymentddf2dae73e": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "MyApifetchBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping", 
       "Properties": {
+        "BasePath": "fetch", 
+        "DomainName": "api-example.com", 
         "RestApiId": {
           "Ref": "MyApi"
         }, 
-        "Description": "RestApi deployment id: ddf2dae73e4e91595e8de4be7a30a1d207f32aab"
+        "Stage": {
+          "Ref": "MyApiProdStage"
+        }
       }
     }, 
     "MyFunctionRole": {
@@ -245,13 +237,16 @@
         }
       }
     }, 
-    "MyAnotherApiDeploymente89573907a": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "MyAnotherApiBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping", 
       "Properties": {
+        "DomainName": "another-example.com", 
         "RestApiId": {
           "Ref": "MyAnotherApi"
         }, 
-        "Description": "RestApi deployment id: e89573907aa0c18379ba3bcc497b31454e88a664"
+        "Stage": {
+          "Ref": "MyAnotherApiProdStage"
+        }
       }
     }, 
     "ApiGatewayDomainNameeab65c1531": {
@@ -266,24 +261,21 @@
         "DomainName": "another-example.com"
       }
     }, 
-    "MyApifetchBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
+    "ServerlessRestApiDeployment3c44da8ffd": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
-        "BasePath": "fetch", 
-        "DomainName": "api-example.com", 
         "RestApiId": {
-          "Ref": "MyApi"
+          "Ref": "ServerlessRestApi"
         }, 
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
+        "Description": "RestApi deployment id: 3c44da8ffdf3025dc792391a61590b92e8e2ff48", 
+        "StageName": "Stage"
       }
     }, 
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment7db01b740c"
+          "Ref": "ServerlessRestApiDeployment3c44da8ffd"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
@@ -291,14 +283,13 @@
         "StageName": "Prod"
       }
     }, 
-    "ServerlessRestApiDeployment7db01b740c": {
+    "MyApiDeploymentbfb0243af9": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
-          "Ref": "ServerlessRestApi"
+          "Ref": "MyApi"
         }, 
-        "Description": "RestApi deployment id: 7db01b740cb897c4fc4175031f25e8123cc57ca9", 
-        "StageName": "Stage"
+        "Description": "RestApi deployment id: bfb0243af9bffaabaf3bbc9d980266c6d6eb8471"
       }
     }, 
     "ServerlessRestApiBasePathMapping": {
@@ -317,12 +308,21 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentddf2dae73e"
+          "Ref": "MyApiDeploymentbfb0243af9"
         }, 
         "RestApiId": {
           "Ref": "MyApi"
         }, 
         "StageName": "Prod"
+      }
+    }, 
+    "MyAnotherApiDeployment48a61be119": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyAnotherApi"
+        }, 
+        "Description": "RestApi deployment id: 48a61be119a247807ea0ef8378e6aa16592f90fa"
       }
     }, 
     "ServerlessRestApi": {

--- a/tests/translator/output/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/api_with_basic_custom_domain_intrinsics.json
@@ -78,16 +78,6 @@
       }, 
       "Condition": "C1"
     }, 
-    "MyApiDeployment6e1ee39b06": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 6e1ee39b068c65688d05f859c3952e41396ecede"
-      }, 
-      "Condition": "C1"
-    }, 
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
@@ -226,12 +216,22 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment6e1ee39b06"
+          "Ref": "MyApiDeployment462f07ab8f"
         }, 
         "RestApiId": {
           "Ref": "MyApi"
         }, 
         "StageName": "Prod"
+      }, 
+      "Condition": "C1"
+    }, 
+    "MyApiDeployment462f07ab8f": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "Description": "RestApi deployment id: 462f07ab8fcdc437955985b08464280d2a9244be"
       }, 
       "Condition": "C1"
     }, 

--- a/tests/translator/output/api_with_custom_domain_route53.json
+++ b/tests/translator/output/api_with_custom_domain_route53.json
@@ -65,18 +65,6 @@
         "DomainName": "example.com"
       }
     }, 
-    "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiDeployment967cf1a6ff"
-        }, 
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "StageName": "Prod"
-      }
-    }, 
     "RecordSetGroupbd00d962a4": {
       "Type": "AWS::Route53::RecordSetGroup", 
       "Properties": {
@@ -87,8 +75,8 @@
               "HostedZoneId": "Z2FDTNDATAQYW2", 
               "DNSName": {
                 "Fn::GetAtt": [
-                  "Distribution", 
-                  "DomainName"
+                  "ApiGatewayDomainName0caaf24ab1", 
+                  "DistributionDomainName"
                 ]
               }
             }, 
@@ -100,8 +88,8 @@
               "HostedZoneId": "Z2FDTNDATAQYW2", 
               "DNSName": {
                 "Fn::GetAtt": [
-                  "Distribution", 
-                  "DomainName"
+                  "ApiGatewayDomainName0caaf24ab1", 
+                  "DistributionDomainName"
                 ]
               }
             }, 
@@ -111,10 +99,19 @@
         ]
       }
     }, 
-    "MyApifetchBasePathMapping": {
+    "MyApiDeploymentf643ef7f59": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "Description": "RestApi deployment id: f643ef7f592a69a57638dd25e64dc12d2b4abf2d"
+      }
+    }, 
+    "MyApioneBasePathMapping": {
       "Type": "AWS::ApiGateway::BasePathMapping", 
       "Properties": {
-        "BasePath": "fetch", 
+        "BasePath": "one", 
         "DomainName": "example.com", 
         "RestApiId": {
           "Ref": "MyApi"
@@ -124,64 +121,16 @@
         }
       }
     }, 
-    "Distribution": {
-      "Type": "AWS::CloudFront::Distribution", 
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
-        "DistributionConfig": {
-          "Origins": [
-            {
-              "DomainName": {
-                "Ref": "DomainName"
-              }, 
-              "Id": {
-                "Ref": "DomainName"
-              }, 
-              "CustomOriginConfig": {
-                "OriginProtocolPolicy": "https-only", 
-                "HTTPPort": 80, 
-                "HTTPSPort": 443
-              }
-            }
-          ], 
-          "PriceClass": "PriceClass_100", 
-          "Enabled": true, 
-          "DefaultCacheBehavior": {
-            "Compress": true, 
-            "TargetOriginId": {
-              "Ref": "DomainName"
-            }, 
-            "ViewerProtocolPolicy": "redirect-to-https", 
-            "ForwardedValues": {
-              "QueryString": false
-            }, 
-            "SmoothStreaming": false, 
-            "AllowedMethods": [
-              "HEAD", 
-              "DELETE", 
-              "POST", 
-              "GET", 
-              "OPTIONS", 
-              "PUT", 
-              "PATCH"
-            ]
-          }, 
-          "ViewerCertificate": {
-            "SslSupportMethod": "sni-only", 
-            "AcmCertificateArn": {
-              "Ref": "ACMCertificateArn"
-            }
-          }, 
-          "HttpVersion": "http2"
-        }
-      }
-    }, 
-    "MyApiDeployment967cf1a6ff": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeploymentf643ef7f59"
+        }, 
         "RestApiId": {
           "Ref": "MyApi"
         }, 
-        "Description": "RestApi deployment id: 967cf1a6ff8e58a6e739bf5b7b59a7d658e01a40"
+        "StageName": "Prod"
       }
     }, 
     "MyFunctionRole": {

--- a/tests/translator/output/aws-cn/api_with_basic_custom_domain.json
+++ b/tests/translator/output/aws-cn/api_with_basic_custom_domain.json
@@ -53,25 +53,16 @@
         }
       }
     }, 
-    "MyApiDeploymentf93c9d77b0": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeployment062deb3f92"
+        }, 
         "RestApiId": {
           "Ref": "MyApi"
         }, 
-        "Description": "RestApi deployment id: f93c9d77b03a49d41597a99e8aaecf51eb585698"
-      }
-    }, 
-    "ApiGatewayDomainName23cdccdf9c": {
-      "Type": "AWS::ApiGateway::DomainName", 
-      "Properties": {
-        "CertificateArn": "my-api-cert-arn", 
-        "EndpointConfiguration": {
-          "Types": [
-            "EDGE"
-          ]
-        }, 
-        "DomainName": "api-example.com"
+        "StageName": "Prod"
       }
     }, 
     "MyFunctionImplicitGetPermissionProd": {
@@ -99,7 +90,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyAnotherApiDeployment78a7819e1c"
+          "Ref": "MyAnotherApiDeployment989ae20f23"
         }, 
         "RestApiId": {
           "Ref": "MyAnotherApi"
@@ -286,35 +277,37 @@
         "DomainName": "another-example.com"
       }
     }, 
-    "ServerlessRestApiDeployment06e2333f46": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "ApiGatewayDomainName23cdccdf9c": {
+      "Type": "AWS::ApiGateway::DomainName", 
       "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
+        "CertificateArn": "my-api-cert-arn", 
+        "EndpointConfiguration": {
+          "Types": [
+            "EDGE"
+          ]
         }, 
-        "Description": "RestApi deployment id: 06e2333f46f9e8ce75b6d105e0fb5b1b7fed3aca", 
-        "StageName": "Stage"
-      }
-    }, 
-    "MyAnotherApiDeployment78a7819e1c": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyAnotherApi"
-        }, 
-        "Description": "RestApi deployment id: 78a7819e1cd42aa753a8dfc29d0026d44aaf6335"
+        "DomainName": "api-example.com"
       }
     }, 
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment06e2333f46"
+          "Ref": "ServerlessRestApiDeployment6aef2b756e"
         }, 
         "RestApiId": {
           "Ref": "ServerlessRestApi"
         }, 
         "StageName": "Prod"
+      }
+    }, 
+    "MyApiDeployment062deb3f92": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "Description": "RestApi deployment id: 062deb3f92aa9993cabcc1ae62b31c0411a7c2ce"
       }
     }, 
     "ServerlessRestApiBasePathMapping": {
@@ -329,16 +322,23 @@
         }
       }
     }, 
-    "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+    "ServerlessRestApiDeployment6aef2b756e": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiDeploymentf93c9d77b0"
-        }, 
         "RestApiId": {
-          "Ref": "MyApi"
+          "Ref": "ServerlessRestApi"
         }, 
-        "StageName": "Prod"
+        "Description": "RestApi deployment id: 6aef2b756ee814f8722e71ca5e3f0d187e05aed5", 
+        "StageName": "Stage"
+      }
+    }, 
+    "MyAnotherApiDeployment989ae20f23": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyAnotherApi"
+        }, 
+        "Description": "RestApi deployment id: 989ae20f23c53c333389afc4e570683e5665c797"
       }
     }, 
     "ServerlessRestApi": {

--- a/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/aws-cn/api_with_basic_custom_domain_intrinsics.json
@@ -79,6 +79,16 @@
       }, 
       "Condition": "C1"
     }, 
+    "MyApiDeployment39d61c7d9b": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "Description": "RestApi deployment id: 39d61c7d9b47f6d3002c3e6706e1862ec03914dc"
+      }, 
+      "Condition": "C1"
+    }, 
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
@@ -89,16 +99,6 @@
           "Ref": "ServerlessRestApi"
         }, 
         "StageName": "Prod"
-      }, 
-      "Condition": "C1"
-    }, 
-    "MyApiDeploymentf260697bb0": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: f260697bb02eda112f7c58d850cf875f82e745a4"
       }, 
       "Condition": "C1"
     }, 
@@ -219,7 +219,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentf260697bb0"
+          "Ref": "MyApiDeployment39d61c7d9b"
         }, 
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-cn/api_with_custom_domain_route53.json
+++ b/tests/translator/output/aws-cn/api_with_custom_domain_route53.json
@@ -65,19 +65,6 @@
         "DomainName": "example.com"
       }
     }, 
-    "MyApifetchBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
-      "Properties": {
-        "BasePath": "fetch", 
-        "DomainName": "example.com", 
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
-      }
-    }, 
     "RecordSetGroupbd00d962a4": {
       "Type": "AWS::Route53::RecordSetGroup", 
       "Properties": {
@@ -88,8 +75,8 @@
               "HostedZoneId": "Z2FDTNDATAQYW2", 
               "DNSName": {
                 "Fn::GetAtt": [
-                  "Distribution", 
-                  "DomainName"
+                  "ApiGatewayDomainName0caaf24ab1", 
+                  "DistributionDomainName"
                 ]
               }
             }, 
@@ -101,8 +88,8 @@
               "HostedZoneId": "Z2FDTNDATAQYW2", 
               "DNSName": {
                 "Fn::GetAtt": [
-                  "Distribution", 
-                  "DomainName"
+                  "ApiGatewayDomainName0caaf24ab1", 
+                  "DistributionDomainName"
                 ]
               }
             }, 
@@ -112,71 +99,33 @@
         ]
       }
     }, 
-    "MyApiDeployment22e6f8d813": {
+    "MyApioneBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Properties": {
+        "BasePath": "one", 
+        "DomainName": "example.com", 
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "Stage": {
+          "Ref": "MyApiProdStage"
+        }
+      }
+    }, 
+    "MyApiDeploymentfb330328f1": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "MyApi"
         }, 
-        "Description": "RestApi deployment id: 22e6f8d8130f68b2813a6e31d74b0ecccbf7820d"
-      }
-    }, 
-    "Distribution": {
-      "Type": "AWS::CloudFront::Distribution", 
-      "Properties": {
-        "DistributionConfig": {
-          "Origins": [
-            {
-              "DomainName": {
-                "Ref": "DomainName"
-              }, 
-              "Id": {
-                "Ref": "DomainName"
-              }, 
-              "CustomOriginConfig": {
-                "OriginProtocolPolicy": "https-only", 
-                "HTTPPort": 80, 
-                "HTTPSPort": 443
-              }
-            }
-          ], 
-          "PriceClass": "PriceClass_100", 
-          "Enabled": true, 
-          "DefaultCacheBehavior": {
-            "Compress": true, 
-            "TargetOriginId": {
-              "Ref": "DomainName"
-            }, 
-            "ViewerProtocolPolicy": "redirect-to-https", 
-            "ForwardedValues": {
-              "QueryString": false
-            }, 
-            "SmoothStreaming": false, 
-            "AllowedMethods": [
-              "HEAD", 
-              "DELETE", 
-              "POST", 
-              "GET", 
-              "OPTIONS", 
-              "PUT", 
-              "PATCH"
-            ]
-          }, 
-          "ViewerCertificate": {
-            "SslSupportMethod": "sni-only", 
-            "AcmCertificateArn": {
-              "Ref": "ACMCertificateArn"
-            }
-          }, 
-          "HttpVersion": "http2"
-        }
+        "Description": "RestApi deployment id: fb330328f152e4bb4b7d68e8b976b009e0558035"
       }
     }, 
     "MyApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment22e6f8d813"
+          "Ref": "MyApiDeploymentfb330328f1"
         }, 
         "RestApiId": {
           "Ref": "MyApi"

--- a/tests/translator/output/aws-us-gov/api_with_basic_custom_domain.json
+++ b/tests/translator/output/aws-us-gov/api_with_basic_custom_domain.json
@@ -53,16 +53,16 @@
         }
       }
     }, 
-    "MyApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+    "ApiGatewayDomainName23cdccdf9c": {
+      "Type": "AWS::ApiGateway::DomainName", 
       "Properties": {
-        "DeploymentId": {
-          "Ref": "MyApiDeploymentf3135fd1a7"
+        "CertificateArn": "my-api-cert-arn", 
+        "EndpointConfiguration": {
+          "Types": [
+            "EDGE"
+          ]
         }, 
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "StageName": "Prod"
+        "DomainName": "api-example.com"
       }
     }, 
     "MyFunctionImplicitGetPermissionProd": {
@@ -90,12 +90,22 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyAnotherApiDeployment836d746e1a"
+          "Ref": "MyAnotherApiDeploymenteb8302ec1b"
         }, 
         "RestApiId": {
           "Ref": "MyAnotherApi"
         }, 
         "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment790a4e6aa6": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 790a4e6aa6ad06f44702e52a66e5fec0cd96be99", 
+        "StageName": "Stage"
       }
     }, 
     "MyFunctionFetchPermissionProd": {
@@ -155,10 +165,10 @@
         }
       }
     }, 
-    "MyApifetchBasePathMapping": {
+    "MyApigetBasePathMapping": {
       "Type": "AWS::ApiGateway::BasePathMapping", 
       "Properties": {
-        "BasePath": "fetch", 
+        "BasePath": "get", 
         "DomainName": "api-example.com", 
         "RestApiId": {
           "Ref": "MyApi"
@@ -192,132 +202,13 @@
         }
       }
     }, 
-    "MyApigetBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
-      "Properties": {
-        "BasePath": "get", 
-        "DomainName": "api-example.com", 
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
-      }
-    }, 
-    "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
-      "Properties": {
-        "Body": {
-          "info": {
-            "version": "1.0", 
-            "title": {
-              "Ref": "AWS::StackName"
-            }
-          }, 
-          "paths": {
-            "/implicit": {
-              "post": {
-                "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
-                  "uri": {
-                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
-                  }
-                }, 
-                "responses": {}
-              }
-            }
-          }, 
-          "swagger": "2.0"
-        }, 
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL"
-          ]
-        }, 
-        "Parameters": {
-          "endpointConfigurationTypes": "REGIONAL"
-        }
-      }
-    }, 
-    "MyAnotherApiBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
-      "Properties": {
-        "DomainName": "another-example.com", 
-        "RestApiId": {
-          "Ref": "MyAnotherApi"
-        }, 
-        "Stage": {
-          "Ref": "MyAnotherApiProdStage"
-        }
-      }
-    }, 
-    "ApiGatewayDomainNameeab65c1531": {
-      "Type": "AWS::ApiGateway::DomainName", 
-      "Properties": {
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL"
-          ]
-        }, 
-        "RegionalCertificateArn": "another-api-arn", 
-        "DomainName": "another-example.com"
-      }
-    }, 
-    "ServerlessRestApiDeployment850347783d": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: 850347783d64d7c9e7f9528c3e117f7b29ef8bd9", 
-        "StageName": "Stage"
-      }
-    }, 
-    "MyApiDeploymentf3135fd1a7": {
+    "MyApiDeploymentdf7be0d48e": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "MyApi"
         }, 
-        "Description": "RestApi deployment id: f3135fd1a745bd03eb49425618a88b1a2ca1c06e"
-      }
-    }, 
-    "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
-      "Properties": {
-        "DeploymentId": {
-          "Ref": "ServerlessRestApiDeployment850347783d"
-        }, 
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "StageName": "Prod"
-      }
-    }, 
-    "ServerlessRestApiBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
-      "Properties": {
-        "DomainName": "another-example.com", 
-        "RestApiId": {
-          "Ref": "ServerlessRestApi"
-        }, 
-        "Stage": {
-          "Ref": "ServerlessRestApiProdStage"
-        }
-      }
-    }, 
-    "ApiGatewayDomainName23cdccdf9c": {
-      "Type": "AWS::ApiGateway::DomainName", 
-      "Properties": {
-        "CertificateArn": "my-api-cert-arn", 
-        "EndpointConfiguration": {
-          "Types": [
-            "EDGE"
-          ]
-        }, 
-        "DomainName": "api-example.com"
+        "Description": "RestApi deployment id: df7be0d48edfc5455fdd83e8eec35cf2e9956dc5"
       }
     }, 
     "MyApi": {
@@ -368,13 +259,122 @@
         }
       }
     }, 
-    "MyAnotherApiDeployment836d746e1a": {
+    "MyAnotherApiBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Properties": {
+        "DomainName": "another-example.com", 
+        "RestApiId": {
+          "Ref": "MyAnotherApi"
+        }, 
+        "Stage": {
+          "Ref": "MyAnotherApiProdStage"
+        }
+      }
+    }, 
+    "ApiGatewayDomainNameeab65c1531": {
+      "Type": "AWS::ApiGateway::DomainName", 
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "RegionalCertificateArn": "another-api-arn", 
+        "DomainName": "another-example.com"
+      }
+    }, 
+    "MyApifetchBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Properties": {
+        "BasePath": "fetch", 
+        "DomainName": "api-example.com", 
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "Stage": {
+          "Ref": "MyApiProdStage"
+        }
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment790a4e6aa6"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "MyAnotherApiDeploymenteb8302ec1b": {
       "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
         "RestApiId": {
           "Ref": "MyAnotherApi"
         }, 
-        "Description": "RestApi deployment id: 836d746e1af20f1dcc2c03b81a12a53828bf22e4"
+        "Description": "RestApi deployment id: eb8302ec1bd45ce6bb547e74633c4bbb3e503d4a"
+      }
+    }, 
+    "MyApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "MyApiDeploymentdf7be0d48e"
+        }, 
+        "RestApiId": {
+          "Ref": "MyApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping", 
+      "Properties": {
+        "DomainName": "another-example.com", 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Stage": {
+          "Ref": "ServerlessRestApiProdStage"
+        }
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/implicit": {
+              "post": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        }, 
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "REGIONAL"
+        }
       }
     }, 
     "MyFunctionApiPermissionProd": {

--- a/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/api_with_basic_custom_domain_intrinsics.json
@@ -63,16 +63,6 @@
       }, 
       "Condition": "C1"
     }, 
-    "MyApiDeployment49388946f5": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "MyApi"
-        }, 
-        "Description": "RestApi deployment id: 49388946f5e0e030c3139bb3f1b984fba94bbc84"
-      }, 
-      "Condition": "C1"
-    }, 
     "ServerlessRestApiProdStage": {
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
@@ -154,18 +144,13 @@
       }, 
       "Condition": "C1"
     }, 
-    "ApiGatewayDomainName9c93aac102": {
-      "Type": "AWS::ApiGateway::DomainName", 
+    "MyApiDeploymentc2e138c194": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
-        "EndpointConfiguration": {
-          "Types": [
-            "REGIONAL"
-          ]
+        "RestApiId": {
+          "Ref": "MyApi"
         }, 
-        "RegionalCertificateArn": "another-api-arn", 
-        "DomainName": {
-          "Fn::Sub": "example-us-gov-west-1.com"
-        }
+        "Description": "RestApi deployment id: c2e138c1943ffe20492a6a242e7537c4cd3c35f9"
       }, 
       "Condition": "C1"
     }, 
@@ -234,12 +219,27 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeployment49388946f5"
+          "Ref": "MyApiDeploymentc2e138c194"
         }, 
         "RestApiId": {
           "Ref": "MyApi"
         }, 
         "StageName": "Prod"
+      }, 
+      "Condition": "C1"
+    }, 
+    "ApiGatewayDomainName9c93aac102": {
+      "Type": "AWS::ApiGateway::DomainName", 
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "REGIONAL"
+          ]
+        }, 
+        "RegionalCertificateArn": "another-api-arn", 
+        "DomainName": {
+          "Fn::Sub": "example-us-gov-west-1.com"
+        }
       }, 
       "Condition": "C1"
     }, 

--- a/tests/translator/output/aws-us-gov/api_with_custom_domain_route53.json
+++ b/tests/translator/output/aws-us-gov/api_with_custom_domain_route53.json
@@ -53,29 +53,13 @@
         }
       }
     }, 
-    "ApiGatewayDomainName0caaf24ab1": {
-      "Type": "AWS::ApiGateway::DomainName", 
+    "MyApiDeployment1deeaff693": {
+      "Type": "AWS::ApiGateway::Deployment", 
       "Properties": {
-        "CertificateArn": "cert-arn-in-us-east-1", 
-        "EndpointConfiguration": {
-          "Types": [
-            "EDGE"
-          ]
-        }, 
-        "DomainName": "example.com"
-      }
-    }, 
-    "MyApifetchBasePathMapping": {
-      "Type": "AWS::ApiGateway::BasePathMapping", 
-      "Properties": {
-        "BasePath": "fetch", 
-        "DomainName": "example.com", 
         "RestApiId": {
           "Ref": "MyApi"
         }, 
-        "Stage": {
-          "Ref": "MyApiProdStage"
-        }
+        "Description": "RestApi deployment id: 1deeaff6933b892391de7a35e4cf92e79a47aea9"
       }
     }, 
     "RecordSetGroupbd00d962a4": {
@@ -88,8 +72,8 @@
               "HostedZoneId": "Z2FDTNDATAQYW2", 
               "DNSName": {
                 "Fn::GetAtt": [
-                  "Distribution", 
-                  "DomainName"
+                  "ApiGatewayDomainName0caaf24ab1", 
+                  "DistributionDomainName"
                 ]
               }
             }, 
@@ -101,8 +85,8 @@
               "HostedZoneId": "Z2FDTNDATAQYW2", 
               "DNSName": {
                 "Fn::GetAtt": [
-                  "Distribution", 
-                  "DomainName"
+                  "ApiGatewayDomainName0caaf24ab1", 
+                  "DistributionDomainName"
                 ]
               }
             }, 
@@ -112,63 +96,16 @@
         ]
       }
     }, 
-    "MyApiDeploymentf3b0901355": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    "MyApioneBasePathMapping": {
+      "Type": "AWS::ApiGateway::BasePathMapping", 
       "Properties": {
+        "BasePath": "one", 
+        "DomainName": "example.com", 
         "RestApiId": {
           "Ref": "MyApi"
         }, 
-        "Description": "RestApi deployment id: f3b0901355f3d895ddaa0964df0aef6171c1d400"
-      }
-    }, 
-    "Distribution": {
-      "Type": "AWS::CloudFront::Distribution", 
-      "Properties": {
-        "DistributionConfig": {
-          "Origins": [
-            {
-              "DomainName": {
-                "Ref": "DomainName"
-              }, 
-              "Id": {
-                "Ref": "DomainName"
-              }, 
-              "CustomOriginConfig": {
-                "OriginProtocolPolicy": "https-only", 
-                "HTTPPort": 80, 
-                "HTTPSPort": 443
-              }
-            }
-          ], 
-          "PriceClass": "PriceClass_100", 
-          "Enabled": true, 
-          "DefaultCacheBehavior": {
-            "Compress": true, 
-            "TargetOriginId": {
-              "Ref": "DomainName"
-            }, 
-            "ViewerProtocolPolicy": "redirect-to-https", 
-            "ForwardedValues": {
-              "QueryString": false
-            }, 
-            "SmoothStreaming": false, 
-            "AllowedMethods": [
-              "HEAD", 
-              "DELETE", 
-              "POST", 
-              "GET", 
-              "OPTIONS", 
-              "PUT", 
-              "PATCH"
-            ]
-          }, 
-          "ViewerCertificate": {
-            "SslSupportMethod": "sni-only", 
-            "AcmCertificateArn": {
-              "Ref": "ACMCertificateArn"
-            }
-          }, 
-          "HttpVersion": "http2"
+        "Stage": {
+          "Ref": "MyApiProdStage"
         }
       }
     }, 
@@ -176,7 +113,7 @@
       "Type": "AWS::ApiGateway::Stage", 
       "Properties": {
         "DeploymentId": {
-          "Ref": "MyApiDeploymentf3b0901355"
+          "Ref": "MyApiDeployment1deeaff693"
         }, 
         "RestApiId": {
           "Ref": "MyApi"
@@ -206,6 +143,18 @@
             }
           ]
         }
+      }
+    }, 
+    "ApiGatewayDomainName0caaf24ab1": {
+      "Type": "AWS::ApiGateway::DomainName", 
+      "Properties": {
+        "CertificateArn": "cert-arn-in-us-east-1", 
+        "EndpointConfiguration": {
+          "Types": [
+            "EDGE"
+          ]
+        }, 
+        "DomainName": "example.com"
       }
     }, 
     "MyApi": {

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -1015,5 +1015,5 @@ Domain:
   Route53: # optional | Default behavior is to treat as None - does not create Route53 resources | Enable these settings to create Route53 Recordsets
     HostedZoneId: String # REQUIRED | Must be a hostedzoneid value of a [`AWS::Route53::HostedZone`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-route53-hostedzone.html) resource
     EvaluateTargetHealth: Boolean # optional | default value is false
-    DistributionDomainName: String # REQUIRED IF the EndpointConfiguration is EDGE | Domain name of a [cloudfront distribution](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-distribution.html) is required to create Route53 recordsets 
+    DistributionDomainName: String # OPTIONAL if the EndpointConfiguration is EDGE | Default points to Api Gateway Distribution | Domain name of a [cloudfront distribution](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-cloudfront-distribution.html) 
 ```


### PR DESCRIPTION
*Issue #, if available:*
Found an issue where we don't support using the distribution supported by apigateway for custom domains.
*Description of changes:*

*Description of how you validated changes:*
validated end to end
*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
