### PR TITLE
Update policy_templates.rst

### DIFF
--- a/docs/policy_templates.rst
+++ b/docs/policy_templates.rst
@@ -1,7 +1,7 @@
 Policy Templates
 ================
 
-When you define a Serverless Function, SAM automatically creates the IAM Role required to run the function. Let's say
+When you define a Serverless Function, SAM doesn't automatically creates the IAM Role required to run the function. Let's say
 your function needs to access couple of DynamoDB tables, you need to give your function explicit permissions to access
 the tables. You can do this by adding AWS Managed Policies to Serverless Function resource definition in your SAM 
 template.


### PR DESCRIPTION
The first sentence says that "SAM automatically creates the IAM Role required to run the function." But then the next sentence seems to negate that when it reads, "you need to give your function explicit permissions..." So, shouldn't the first sentence say "SAM does NOT automatically create the IAM Role" because you have to explicitly give it to your function?

*Issue #, if available:*

*Description of changes:* Documentation wording needs updating.

*Description of how you validated changes:* n/a

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
