### PR TITLE
Allow kinesis:DescribeStreamSummary for KinesisCrudPolicy and KinesisReadStreamPolicy

### DIFF
--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -651,6 +651,7 @@
             "Effect": "Allow",
             "Action": [
               "kinesis:DescribeStream",
+              "kinesis:DescribeStreamSummary",
               "kinesis:GetRecords",
               "kinesis:GetShardIterator"
             ],
@@ -748,6 +749,7 @@
               "kinesis:DecreaseStreamRetentionPeriod",
               "kinesis:DeleteStream",
               "kinesis:DescribeStream",
+              "kinesis:DescribeStreamSummary",
               "kinesis:GetShardIterator",
               "kinesis:IncreaseStreamRetentionPeriod",
               "kinesis:ListTagsForStream",

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -501,6 +501,7 @@
                 {
                   "Action": [
                     "kinesis:DescribeStream",
+                    "kinesis:DescribeStreamSummary",
                     "kinesis:GetRecords",
                     "kinesis:GetShardIterator"
                   ],
@@ -577,6 +578,7 @@
                     "kinesis:DecreaseStreamRetentionPeriod",
                     "kinesis:DeleteStream",
                     "kinesis:DescribeStream",
+                    "kinesis:DescribeStreamSummary",
                     "kinesis:GetShardIterator",
                     "kinesis:IncreaseStreamRetentionPeriod",
                     "kinesis:ListTagsForStream",

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -500,6 +500,7 @@
                 {
                   "Action": [
                     "kinesis:DescribeStream",
+                    "kinesis:DescribeStreamSummary",
                     "kinesis:GetRecords",
                     "kinesis:GetShardIterator"
                   ],
@@ -576,6 +577,7 @@
                     "kinesis:DecreaseStreamRetentionPeriod",
                     "kinesis:DeleteStream",
                     "kinesis:DescribeStream",
+                    "kinesis:DescribeStreamSummary",
                     "kinesis:GetShardIterator",
                     "kinesis:IncreaseStreamRetentionPeriod",
                     "kinesis:ListTagsForStream",

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -500,6 +500,7 @@
                 {
                   "Action": [
                     "kinesis:DescribeStream",
+                    "kinesis:DescribeStreamSummary",
                     "kinesis:GetRecords",
                     "kinesis:GetShardIterator"
                   ],
@@ -576,6 +577,7 @@
                     "kinesis:DecreaseStreamRetentionPeriod",
                     "kinesis:DeleteStream",
                     "kinesis:DescribeStream",
+                    "kinesis:DescribeStreamSummary",
                     "kinesis:GetShardIterator",
                     "kinesis:IncreaseStreamRetentionPeriod",
                     "kinesis:ListTagsForStream",


### PR DESCRIPTION
Resolves issue #1251

Added kinesis:DescribeStreamSummary action to KinesisCrudPolicy and KinesisReadStreamPolicy

Validated via unit test.

*Checklist:*

- [X] Write/update tests
- [X] `make pr` passes
- [ ] Update documentation
- [X] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
