### PR TITLE
fix: Transform Cognito Events to a Permission with `SourceArn`

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -3,7 +3,7 @@ import re
 from six import string_types
 from samtranslator.model import ResourceMacro, PropertyType
 from samtranslator.model.types import is_type, list_of, dict_of, one_of, is_str
-from samtranslator.model.intrinsics import ref, fnSub, make_shorthand, make_conditional
+from samtranslator.model.intrinsics import ref, fnGetAtt, fnSub, make_shorthand, make_conditional
 from samtranslator.model.tags.resource_tagging import get_tag_list
 
 from samtranslator.model.s3 import S3Bucket
@@ -838,9 +838,10 @@ class Cognito(PushEventSource):
         userpool_id = kwargs['userpool_id']
 
         resources = []
+        source_arn = fnGetAtt(userpool_id, 'Arn')
         resources.append(
             self._construct_permission(
-                function, event_source_token=self.UserPool, prefix=function.logical_id + "Cognito"))
+                function, source_arn=source_arn, prefix=function.logical_id + "Cognito"))
 
         self._inject_lambda_config(function, userpool)
         resources.append(CognitoUserPool.from_dict(userpool_id, userpool))

--- a/tests/translator/output/aws-cn/cognito_userpool_with_event.json
+++ b/tests/translator/output/aws-cn/cognito_userpool_with_event.json
@@ -85,8 +85,11 @@
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
         },
-        "EventSourceToken": {
-          "Ref": "UserPool"
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "UserPool",
+            "Arn"
+          ]
         },
         "Principal": "cognito-idp.amazonaws.com"
       }

--- a/tests/translator/output/aws-us-gov/cognito_userpool_with_event.json
+++ b/tests/translator/output/aws-us-gov/cognito_userpool_with_event.json
@@ -85,8 +85,11 @@
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
         },
-        "EventSourceToken": {
-          "Ref": "UserPool"
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "UserPool",
+            "Arn"
+          ]
         },
         "Principal": "cognito-idp.amazonaws.com"
       }

--- a/tests/translator/output/cognito_userpool_with_event.json
+++ b/tests/translator/output/cognito_userpool_with_event.json
@@ -85,8 +85,11 @@
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
         },
-        "EventSourceToken": {
-          "Ref": "UserPool"
+        "SourceArn": {
+          "Fn::GetAtt": [
+            "UserPool",
+            "Arn"
+          ]
         },
         "Principal": "cognito-idp.amazonaws.com"
       }


### PR DESCRIPTION
*Issue #, if available:* Fixes #1253.

*Description of changes:*

When the `AWS::Lambda::Permission` resource was created for a Cognito event, it used the `EventSourceToken` property. This caused authentication (or, in my case, _pre_-authentication) events to fail to execute "due to error `AccessDeniedException`". This PR changes that to the `SourceArn` property.

*Description of how you validated changes:*

I deployed a transformed template of one of my applications and attempted to authenticate. I succeeded. 🎉

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] ~Update documentation~
- [x] Verify transformed template deploys and application functions as expected
- [x] ~Add/update example to `examples/2016-10-31`~


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
