### PR TITLE
Adding cloudwatch:describeAlarmHistory policy

### DIFF
--- a/examples/2016-10-31/policy_templates/all_policy_templates.yaml
+++ b/examples/2016-10-31/policy_templates/all_policy_templates.yaml
@@ -14,6 +14,8 @@ Resources:
         - LambdaInvokePolicy:
             FunctionName: name
 
+        - CloudWatchDescribeAlarmHistoryPolicy: {}
+
         - CloudWatchPutMetricPolicy: {}
 
         - EC2DescribePolicy: {}

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -62,6 +62,21 @@
         ]
       }
     },
+    "CloudWatchDescribeAlarmHistoryPolicy": {
+      "Description": "Gives permissions to describe CloudWatch alarm history",
+      "Parameters": {},
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "cloudwatch:DescribeAlarmHistory"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
+    },
     "CloudWatchPutMetricPolicy": {
       "Description": "Gives permissions to put metrics to CloudWatch",
       "Parameters": {

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -18,6 +18,8 @@ Resources:
         - LambdaInvokePolicy:
             FunctionName: name
 
+        - CloudWatchDescribeAlarmHistoryPolicy: {}
+
         - CloudWatchPutMetricPolicy: {}
 
         - EC2DescribePolicy: {}

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -83,7 +83,7 @@
               "Statement": [
                 {
                   "Action": [
-                    "cloudwatch:PutMetricData"
+                    "cloudwatch:DescribeAlarmHistory"
                   ],
                   "Resource": "*",
                   "Effect": "Allow"
@@ -93,6 +93,20 @@
           },
           {
             "PolicyName": "KitchenSinkFunctionRolePolicy3",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -107,7 +121,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy4",
+            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -147,7 +161,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy5",
+            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -182,7 +196,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy6",
+            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -203,7 +217,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy7",
+            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -225,7 +239,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy8",
+            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -260,7 +274,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy9",
+            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -299,7 +313,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy10",
+            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -315,7 +329,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy11",
+            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -331,7 +345,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy12",
+            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -355,7 +369,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy13",
+            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -379,7 +393,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy14",
+            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -401,7 +415,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy15",
+            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -422,7 +436,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy16",
+            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -443,7 +457,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy17",
+            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -460,7 +474,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy18",
+            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -485,7 +499,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy19",
+            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -518,7 +532,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy20",
+            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -542,7 +556,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy21",
+            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -567,7 +581,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy22",
+            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -600,7 +614,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy23",
+            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -619,7 +633,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy24",
+            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -657,7 +671,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy25",
+            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -710,7 +724,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy26",
+            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -725,7 +739,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy27",
+            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -749,7 +763,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy28",
+            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -770,7 +784,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy29",
+            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -791,7 +805,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy30",
+            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -808,7 +822,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy31",
+            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -823,7 +837,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy32",
+            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -838,7 +852,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy33",
+            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -876,7 +890,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy34",
+            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -917,7 +931,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy35",
+            "PolicyName": "KitchenSinkFunctionRolePolicy36",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -938,7 +952,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy36",
+            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -976,7 +990,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy37",
+            "PolicyName": "KitchenSinkFunctionRolePolicy38",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -990,7 +1004,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy38",
+            "PolicyName": "KitchenSinkFunctionRolePolicy39",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1013,7 +1027,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy39",
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1030,7 +1044,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy40",
+            "PolicyName": "KitchenSinkFunctionRolePolicy41",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1055,7 +1069,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy41",
+            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1070,7 +1084,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy42",
+            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [{
                 "Effect": "Allow",
@@ -1087,7 +1101,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy43",
+            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1101,7 +1115,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy44",
+            "PolicyName": "KitchenSinkFunctionRolePolicy45",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1122,7 +1136,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy45",
+            "PolicyName": "KitchenSinkFunctionRolePolicy46",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1148,7 +1162,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy46",
+            "PolicyName": "KitchenSinkFunctionRolePolicy47",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1167,7 +1181,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy47",
+            "PolicyName": "KitchenSinkFunctionRolePolicy48",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1188,7 +1202,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy48",
+            "PolicyName": "KitchenSinkFunctionRolePolicy49",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1218,7 +1232,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy49",
+            "PolicyName": "KitchenSinkFunctionRolePolicy50",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1239,7 +1253,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy50",
+            "PolicyName": "KitchenSinkFunctionRolePolicy51",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1321,7 +1335,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy51",
+            "PolicyName": "KitchenSinkFunctionRolePolicy52",
             "PolicyDocument": {
               "Statement": [
                 {

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -83,7 +83,7 @@
               "Statement": [
                 {
                   "Action": [
-                    "cloudwatch:PutMetricData"
+                    "cloudwatch:DescribeAlarmHistory"
                   ],
                   "Resource": "*",
                   "Effect": "Allow"
@@ -93,6 +93,20 @@
           },
           {
             "PolicyName": "KitchenSinkFunctionRolePolicy3",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -107,7 +121,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy4",
+            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -146,7 +160,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy5",
+            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -181,7 +195,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy6",
+            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -202,7 +216,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy7",
+            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -224,7 +238,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy8",
+            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -259,7 +273,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy9",
+            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -298,7 +312,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy10",
+            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -314,7 +328,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy11",
+            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -330,7 +344,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy12",
+            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -354,7 +368,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy13",
+            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -378,7 +392,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy14",
+            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -400,7 +414,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy15",
+            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -421,7 +435,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy16",
+            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -442,7 +456,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy17",
+            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -459,7 +473,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy18",
+            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -484,7 +498,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy19",
+            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -517,7 +531,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy20",
+            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -541,7 +555,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy21",
+            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -566,7 +580,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy22",
+            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -599,7 +613,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy23",
+            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -618,7 +632,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy24",
+            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -656,7 +670,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy25",
+            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -709,7 +723,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy26",
+            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -724,7 +738,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy27",
+            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -748,7 +762,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy28",
+            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -769,7 +783,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy29",
+            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -790,7 +804,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy30",
+            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -807,7 +821,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy31",
+            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -822,7 +836,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy32",
+            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -837,7 +851,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy33",
+            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -875,7 +889,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy34",
+            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -916,7 +930,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy35",
+            "PolicyName": "KitchenSinkFunctionRolePolicy36",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -937,7 +951,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy36",
+            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -975,7 +989,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy37",
+            "PolicyName": "KitchenSinkFunctionRolePolicy38",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -989,7 +1003,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy38",
+            "PolicyName": "KitchenSinkFunctionRolePolicy39",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1012,7 +1026,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy39",
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1029,7 +1043,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy40",
+            "PolicyName": "KitchenSinkFunctionRolePolicy41",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1054,7 +1068,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy41",
+            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1069,7 +1083,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy42",
+            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [{
                 "Effect": "Allow",
@@ -1086,7 +1100,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy43",
+            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1100,7 +1114,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy44",
+            "PolicyName": "KitchenSinkFunctionRolePolicy45",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1121,7 +1135,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy45",
+            "PolicyName": "KitchenSinkFunctionRolePolicy46",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1147,7 +1161,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy46",
+            "PolicyName": "KitchenSinkFunctionRolePolicy47",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1166,7 +1180,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy47",
+            "PolicyName": "KitchenSinkFunctionRolePolicy48",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1187,7 +1201,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy48",
+            "PolicyName": "KitchenSinkFunctionRolePolicy49",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1217,7 +1231,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy49",
+            "PolicyName": "KitchenSinkFunctionRolePolicy50",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1238,7 +1252,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy50",
+            "PolicyName": "KitchenSinkFunctionRolePolicy51",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1320,7 +1334,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy51",
+            "PolicyName": "KitchenSinkFunctionRolePolicy52",
             "PolicyDocument": {
               "Statement": [
                 {

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -83,7 +83,7 @@
               "Statement": [
                 {
                   "Action": [
-                    "cloudwatch:PutMetricData"
+                    "cloudwatch:DescribeAlarmHistory"
                   ],
                   "Resource": "*",
                   "Effect": "Allow"
@@ -93,6 +93,20 @@
           },
           {
             "PolicyName": "KitchenSinkFunctionRolePolicy3",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": [
+                    "cloudwatch:PutMetricData"
+                  ],
+                  "Resource": "*",
+                  "Effect": "Allow"
+                }
+              ]
+            }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy4",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -107,7 +121,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy4",
+            "PolicyName": "KitchenSinkFunctionRolePolicy5",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -146,7 +160,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy5",
+            "PolicyName": "KitchenSinkFunctionRolePolicy6",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -181,7 +195,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy6",
+            "PolicyName": "KitchenSinkFunctionRolePolicy7",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -202,7 +216,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy7",
+            "PolicyName": "KitchenSinkFunctionRolePolicy8",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -224,7 +238,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy8",
+            "PolicyName": "KitchenSinkFunctionRolePolicy9",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -259,7 +273,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy9",
+            "PolicyName": "KitchenSinkFunctionRolePolicy10",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -298,7 +312,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy10",
+            "PolicyName": "KitchenSinkFunctionRolePolicy11",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -314,7 +328,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy11",
+            "PolicyName": "KitchenSinkFunctionRolePolicy12",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -330,7 +344,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy12",
+            "PolicyName": "KitchenSinkFunctionRolePolicy13",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -354,7 +368,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy13",
+            "PolicyName": "KitchenSinkFunctionRolePolicy14",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -378,7 +392,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy14",
+            "PolicyName": "KitchenSinkFunctionRolePolicy15",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -400,7 +414,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy15",
+            "PolicyName": "KitchenSinkFunctionRolePolicy16",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -421,7 +435,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy16",
+            "PolicyName": "KitchenSinkFunctionRolePolicy17",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -442,7 +456,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy17",
+            "PolicyName": "KitchenSinkFunctionRolePolicy18",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -459,7 +473,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy18",
+            "PolicyName": "KitchenSinkFunctionRolePolicy19",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -484,7 +498,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy19",
+            "PolicyName": "KitchenSinkFunctionRolePolicy20",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -517,7 +531,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy20",
+            "PolicyName": "KitchenSinkFunctionRolePolicy21",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -541,7 +555,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy21",
+            "PolicyName": "KitchenSinkFunctionRolePolicy22",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -566,7 +580,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy22",
+            "PolicyName": "KitchenSinkFunctionRolePolicy23",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -599,7 +613,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy23",
+            "PolicyName": "KitchenSinkFunctionRolePolicy24",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -618,7 +632,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy24",
+            "PolicyName": "KitchenSinkFunctionRolePolicy25",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -656,7 +670,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy25",
+            "PolicyName": "KitchenSinkFunctionRolePolicy26",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -709,7 +723,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy26",
+            "PolicyName": "KitchenSinkFunctionRolePolicy27",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -724,7 +738,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy27",
+            "PolicyName": "KitchenSinkFunctionRolePolicy28",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -748,7 +762,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy28",
+            "PolicyName": "KitchenSinkFunctionRolePolicy29",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -769,7 +783,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy29",
+            "PolicyName": "KitchenSinkFunctionRolePolicy30",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -790,7 +804,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy30",
+            "PolicyName": "KitchenSinkFunctionRolePolicy31",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -807,7 +821,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy31",
+            "PolicyName": "KitchenSinkFunctionRolePolicy32",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -822,7 +836,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy32",
+            "PolicyName": "KitchenSinkFunctionRolePolicy33",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -837,7 +851,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy33",
+            "PolicyName": "KitchenSinkFunctionRolePolicy34",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -875,7 +889,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy34",
+            "PolicyName": "KitchenSinkFunctionRolePolicy35",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -916,7 +930,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy35",
+            "PolicyName": "KitchenSinkFunctionRolePolicy36",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -937,7 +951,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy36",
+            "PolicyName": "KitchenSinkFunctionRolePolicy37",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -975,7 +989,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy37",
+            "PolicyName": "KitchenSinkFunctionRolePolicy38",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -989,7 +1003,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy38",
+            "PolicyName": "KitchenSinkFunctionRolePolicy39",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1013,7 +1027,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy39",
+            "PolicyName": "KitchenSinkFunctionRolePolicy40",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1030,7 +1044,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy40",
+            "PolicyName": "KitchenSinkFunctionRolePolicy41",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1055,7 +1069,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy41",
+            "PolicyName": "KitchenSinkFunctionRolePolicy42",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1070,7 +1084,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy42",
+            "PolicyName": "KitchenSinkFunctionRolePolicy43",
             "PolicyDocument": {
               "Statement": [{
                 "Effect": "Allow",
@@ -1087,7 +1101,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy43",
+            "PolicyName": "KitchenSinkFunctionRolePolicy44",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1101,7 +1115,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy44",
+            "PolicyName": "KitchenSinkFunctionRolePolicy45",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1122,7 +1136,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy45",
+            "PolicyName": "KitchenSinkFunctionRolePolicy46",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1148,7 +1162,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy46",
+            "PolicyName": "KitchenSinkFunctionRolePolicy47",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1167,7 +1181,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy47",
+            "PolicyName": "KitchenSinkFunctionRolePolicy48",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1188,7 +1202,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy48",
+            "PolicyName": "KitchenSinkFunctionRolePolicy49",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1218,7 +1232,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy49",
+            "PolicyName": "KitchenSinkFunctionRolePolicy50",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1239,7 +1253,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy50",
+            "PolicyName": "KitchenSinkFunctionRolePolicy51",
             "PolicyDocument": {
               "Statement": [
                 {
@@ -1321,7 +1335,7 @@
             }
           },
           {
-            "PolicyName": "KitchenSinkFunctionRolePolicy51",
+            "PolicyName": "KitchenSinkFunctionRolePolicy52",
             "PolicyDocument": {
               "Statement": [
                 {


### PR DESCRIPTION
*Description of changes:*
Added describe cloudwatch alarm history to list of policy templates.

*Description of how you validated changes:*

- update tests
- `make pr` passes
- Update documentation
- Verify transformed template deploys and application functions as expected
- Add example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
