### PR TITLE
fix: destination config link

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -510,7 +510,7 @@ MaximumBatchingWindowInSeconds | `integer` | The maximum amount of time to gathe
 MaximumRetryAttempts | `integer` | The number of times to retry a record before it is bypassed. If an `OnFailure` destination is set, metadata describing the records will be sent to the destination. If no destination is set, the records will be bypassed
 BisectBatchOnFunctionError | `boolean` | A boolean flag which determines whether a failed batch will be split in two after a failed invoke.
 MaximumRecordAgeInSeconds | `integer` | The maximum age of a record that will be invoked by Lambda. If an `OnFailure` destination is set, metadata describing the records will be sent to the destination. If no destination is set, the records will be bypassed
-DestinationConfig | [DestinationConfig Object](destination-config-object) | Expired record metadata/retries and exhausted metadata is sent to this destination after they have passed the defined limits.
+DestinationConfig | [DestinationConfig Object](#destination-config-object) | Expired record metadata/retries and exhausted metadata is sent to this destination after they have passed the defined limits.
 ParallelizationFactor | `integer` | Allocates multiple virtual shards, increasing the Lambda invokes by the given factor and speeding up the stream processing.
 
 **NOTE:** `SQSSendMessagePolicy` or `SNSPublishMessagePolicy` needs to be added in `Policies` for publishing messages to the `SQS` or `SNS` resource mentioned in `OnFailure` property


### PR DESCRIPTION
*Issue #, if available:*
#1268 
The link is broken  for DynamoDb and is working for Kinesis

*Description of changes:*
fixed the link for DestinationConfig Object for DynamoDB

*Description of how you validated changes:*

*Checklist:*

- [x] `make pr` passes
- [x] Update documentation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
