### PR TITLE
fix: throw error when method authorizer is present and api auth is no…

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -621,12 +621,13 @@ class Api(PushEventSource):
                             'because it wasn\'t defined in the API\'s Authorizers.'.format(
                                 authorizer=method_authorizer, method=self.Method, path=self.Path))
 
-                    if method_authorizer == 'NONE' and not api_auth.get('DefaultAuthorizer'):
-                        raise InvalidEventException(
-                            self.relative_id,
-                            'Unable to set Authorizer on API method [{method}] for path [{path}] because \'NONE\' '
-                            'is only a valid value when a DefaultAuthorizer on the API is specified.'.format(
-                                method=self.Method, path=self.Path))
+                    if method_authorizer == 'NONE':
+                        if not api_auth or not api_auth.get('DefaultAuthorizer'):
+                            raise InvalidEventException(
+                                self.relative_id,
+                                'Unable to set Authorizer on API method [{method}] for path [{path}] because \'NONE\' '
+                                'is only a valid value when a DefaultAuthorizer on the API is specified.'.format(
+                                    method=self.Method, path=self.Path))
 
             apikey_required_setting = self.Auth.get('ApiKeyRequired')
             apikey_required_setting_is_false = apikey_required_setting is not None and not apikey_required_setting

--- a/tests/translator/input/error_function_with_method_auth_and_no_api_auth.yaml
+++ b/tests/translator/input/error_function_with_method_auth_and_no_api_auth.yaml
@@ -1,0 +1,15 @@
+Resources:
+  HelloWorldFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: index.handler
+      Runtime: python3.7
+      Events:
+        HttpGetUserGroupIdUserId:
+          Type: Api
+          Properties:
+            Path: '/users/{groupId}/{userId}'
+            Method: GET
+            Auth:
+              Authorizer: "NONE"

--- a/tests/translator/output/error_function_with_method_auth_and_no_api_auth.json
+++ b/tests/translator/output/error_function_with_method_auth_and_no_api_auth.json
@@ -1,0 +1,4 @@
+{
+  "errors": [{"errorMessage": "Resource with id [HelloWorldFunction] is invalid. Event with id [HttpGetUserGroupIdUserId] is invalid. Unable to set Authorizer on API method [get] for path [/users/{groupId}/{userId}] because 'NONE' is only a valid value when a DefaultAuthorizer on the API is specified."}],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [HelloWorldFunction] is invalid. Event with id [HttpGetUserGroupIdUserId] is invalid. Unable to set Authorizer on API method [get] for path [/users/{groupId}/{userId}] because 'NONE' is only a valid value when a DefaultAuthorizer on the API is specified."
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -549,7 +549,8 @@ class TestTranslatorEndToEnd(TestCase):
     'error_api_with_invalid_open_api_version_type',
     'error_api_with_custom_domains_invalid',
     'error_api_with_custom_domains_route53_invalid',
-    'error_api_event_import_vaule_reference'
+    'error_api_event_import_vaule_reference',
+    'error_function_with_method_auth_and_no_api_auth'
 ])
 @patch('boto3.session.Session.region_name', 'ap-southeast-1')
 @patch('samtranslator.plugins.application.serverless_app_plugin.ServerlessAppPlugin._sar_service_call', mock_sar_service_call)


### PR DESCRIPTION
…t defined

*Issue #, if available:*
#1240 

*Description of changes:*
added a check to see if api auth section is defined

*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
