### PR TITLE
Amend provisioned concurrency examples and templates to work for false condition

### DIFF
--- a/examples/2016-10-31/lambda_edge/README.md
+++ b/examples/2016-10-31/lambda_edge/README.md
@@ -30,8 +30,10 @@ LambdaEdgeFunctionSample:
         Timeout: 5
         # More info at https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst
         AutoPublishAlias: live 
-        ProvisionedConcurrencyConfig:
-          ProvisionedConcurrentExecutions: !If [AliasProvisionedConcurrencyEnabled, !Ref ProvisionedConcurrency, !Ref 'AWS::NoValue']
+        ProvisionedConcurrencyConfig: !If
+            - AliasProvisionedConcurrencyEnabled
+            - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
+            - !Ref 'AWS::NoValue'
 ```
 
 We must also create a custom IAM Role which allows `lambda.amazonaws.com` and `edgelambda.amazonaws.com` services to assume the role and execute the function.

--- a/examples/2016-10-31/lambda_edge/template.yaml
+++ b/examples/2016-10-31/lambda_edge/template.yaml
@@ -12,7 +12,8 @@ Parameters:
       - true
       - false
     Default: true
-
+Conditions:
+  AliasProvisionedConcurrencyEnabled: !Equals [!Ref EnableAliasProvisionedConcurrency, true]
 Globals:
 
   Function:

--- a/examples/2016-10-31/lambda_edge/template.yaml
+++ b/examples/2016-10-31/lambda_edge/template.yaml
@@ -17,8 +17,10 @@ Conditions:
 Globals:
 
   Function:
-    ProvisionedConcurrencyConfig:
-      ProvisionedConcurrentExecutions: !If [AliasProvisionedConcurrencyEnabled, !Ref ProvisionedConcurrency, !Ref 'AWS::NoValue']
+    ProvisionedConcurrencyConfig: !If
+        - AliasProvisionedConcurrencyEnabled
+        - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
+        - !Ref 'AWS::NoValue'
 
 Resources:
 

--- a/tests/translator/input/error_function_with_no_alias_provisioned_concurrency.yaml
+++ b/tests/translator/input/error_function_with_no_alias_provisioned_concurrency.yaml
@@ -21,5 +21,7 @@ Resources:
       Runtime: python2.7
       DeploymentPreference:
         Type: Linear10PercentEvery3Minutes
-      ProvisionedConcurrencyConfig:
-        ProvisionedConcurrentExecutions: !If [AliasProvisionedConcurrencyEnabled, ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency, !Ref 'AWS::NoValue']
+      ProvisionedConcurrencyConfig: !If
+        - AliasProvisionedConcurrencyEnabled
+        - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
+        - !Ref 'AWS::NoValue'

--- a/tests/translator/input/function_with_deployment_preference.yaml
+++ b/tests/translator/input/function_with_deployment_preference.yaml
@@ -22,5 +22,7 @@ Resources:
       AutoPublishAlias: live
       DeploymentPreference:
         Type: Linear10PercentEvery3Minutes
-      ProvisionedConcurrencyConfig:
-        ProvisionedConcurrentExecutions: !If [AliasProvisionedConcurrencyEnabled, !Ref ProvisionedConcurrency, !Ref 'AWS::NoValue']
+      ProvisionedConcurrencyConfig: !If
+        - AliasProvisionedConcurrencyEnabled
+        - ProvisionedConcurrentExecutions: !Ref ProvisionedConcurrency
+        - !Ref 'AWS::NoValue'

--- a/tests/translator/output/aws-cn/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference.json
@@ -174,18 +174,18 @@
           ]
         }, 
         "ProvisionedConcurrencyConfig": {
-          "ProvisionedConcurrentExecutions": {
-            "Fn::If": [
-              "AliasProvisionedConcurrencyEnabled", 
-              {
+          "Fn::If": [
+            "AliasProvisionedConcurrencyEnabled",
+            {
+              "ProvisionedConcurrentExecutions": {
                 "Ref": "ProvisionedConcurrency"
-              }, 
-              {
-                "Ref": "AWS::NoValue"
               }
-            ]
-          }
-        }, 
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
         "FunctionName": {
           "Ref": "MinimalFunction"
         }

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
@@ -174,18 +174,18 @@
           ]
         }, 
         "ProvisionedConcurrencyConfig": {
-          "ProvisionedConcurrentExecutions": {
-            "Fn::If": [
-              "AliasProvisionedConcurrencyEnabled", 
-              {
+          "Fn::If": [
+            "AliasProvisionedConcurrencyEnabled",
+            {
+              "ProvisionedConcurrentExecutions": {
                 "Ref": "ProvisionedConcurrency"
-              }, 
-              {
-                "Ref": "AWS::NoValue"
               }
-            ]
-          }
-        }, 
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
         "FunctionName": {
           "Ref": "MinimalFunction"
         }

--- a/tests/translator/output/function_with_deployment_preference.json
+++ b/tests/translator/output/function_with_deployment_preference.json
@@ -174,18 +174,18 @@
           ]
         }, 
         "ProvisionedConcurrencyConfig": {
-          "ProvisionedConcurrentExecutions": {
-            "Fn::If": [
-              "AliasProvisionedConcurrencyEnabled", 
-              {
+          "Fn::If": [
+            "AliasProvisionedConcurrencyEnabled",
+            {
+              "ProvisionedConcurrentExecutions": {
                 "Ref": "ProvisionedConcurrency"
-              }, 
-              {
-                "Ref": "AWS::NoValue"
               }
-            ]
-          }
-        }, 
+            },
+            {
+              "Ref": "AWS::NoValue"
+            }
+          ]
+        },
         "FunctionName": {
           "Ref": "MinimalFunction"
         }


### PR DESCRIPTION
*Issue #, if available:*
None


*Description of changes:*
The current examples and templates for lambda provisioned concurrency works fine for a true valid condition, but if the condition in the example is false, it will fail with and error because the parent property ProvisionedConcurrencyConfig will still be present, but will have no child configuration settings.

*Description of how you validated changes:*
In the example templates, change the condition AliasProvisionedConcurrencyEnabled to false
Then when you try to deploy the template, cloudformation deploy will fail with the error:
```
Property ProvisionedConcurrentExecutions cannot be empty.
```

I also added a missing condition in the lambda_edge/template.yaml 

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
