### PR TITLE
Update inbound-ses-spam-filter to include Lambda ARN

### DIFF
--- a/examples/apps/inbound-ses-spam-filter/template.yaml
+++ b/examples/apps/inbound-ses-spam-filter/template.yaml
@@ -5,6 +5,10 @@ Description: >-
 Parameters: 
     IdentityNameParameter: 
       Type: String
+Outputs: 
+  InboundSESSpamFilterFunction: 
+    Description: "inboundsesspamfilter Lambda Function ARN"
+    Value: !GetAtt inboundsesspamfilter.Arn
 Resources:
   inboundsesspamfilter:
     Type: 'AWS::Serverless::Function'


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Currently, this filter is pretty useless to deploy as a nested stack. I cannot use the [published resource](https://serverlessrepo.aws.amazon.com/applications/arn:aws:serverlessrepo:us-east-1:077246666028:applications~inbound-ses-spam-filter) because I cannot tie the Function ARN to my SES ReceiptRuleAction. This change adds an output so that this template is useful for nested deployments.

*Description of how you validated changes:* No validation

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
