### PR TITLE
fix property naming in the cognito event docs

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -780,7 +780,7 @@ NOTE: To specify a Cognito UserPool as an event source for a Lambda function, bo
 ```yaml
 Type: Cognito
 Properties:
-  Bucket: Ref: MyUserPool
+  UserPool: Ref: MyUserPool
   Trigger: PreSignUp
 ```
 


### PR DESCRIPTION
*Description of changes:*
- just fixed a small typo :)

*Description of how you validated changes:*
- you can see the correct property name in the line above

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
