### PR TITLE
Fixed a code fence that abruptly ends the API Auth object code sample

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -949,7 +949,6 @@ Auth:
     IpRangeBlacklist: [<list of ip ranges>]
     SourceVpcWhitelist: [<list of vpc/vpce endpoint ids>]
     SourceVpcBlacklist: [<list of vpc/vpce endpoint ids>]
-```
 
   # For AWS_IAM:
   # DefaultAuthorizer: AWS_IAM


### PR DESCRIPTION
*Description of changes:*
Fixed a typo in which a code fence interrupts the API Auth object code sample, which makes it very hard to read

*Description of how you validated changes:*
I opened the document and viewed the changes, i.e., the code sample is no longer interrupted

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
