### PR TITLE
fix: handle explicit null in nested app SemanticVersion

### DIFF
--- a/samtranslator/plugins/application/serverless_app_plugin.py
+++ b/samtranslator/plugins/application/serverless_app_plugin.py
@@ -135,7 +135,8 @@ class ServerlessAppPlugin(BasePlugin):
                 isinstance(app.properties[self.LOCATION_KEY], dict) and
                 self.APPLICATION_ID_KEY in app.properties[self.LOCATION_KEY] and
                 app.properties[self.LOCATION_KEY][self.APPLICATION_ID_KEY] is not None and
-                self.SEMANTIC_VERSION_KEY in app.properties[self.LOCATION_KEY])
+                self.SEMANTIC_VERSION_KEY in app.properties[self.LOCATION_KEY] and
+                app.properties[self.LOCATION_KEY][self.SEMANTIC_VERSION_KEY] is not None)
 
     def _handle_get_application_request(self, app_id, semver, key, logical_id):
         """

--- a/tests/plugins/application/test_serverless_app_plugin.py
+++ b/tests/plugins/application/test_serverless_app_plugin.py
@@ -156,7 +156,7 @@ class TestServerlessAppPlugin_on_before_transform_template_translate(TestCase):
     def test_process_invalid_applications(self, SamTemplateMock):
         self.plugin = ServerlessAppPlugin(sar_client=boto3.client('serverlessrepo', region_name='us-east-1'))
         template_dict = {"a": "b"}
-        app_resources = [("id1", ApplicationResource(app_id = '')), ("id2", ApplicationResource(app_id=None))]
+        app_resources = [("id1", ApplicationResource(app_id = '')), ("id2", ApplicationResource(app_id=None)), ("id3", ApplicationResource(app_id='id3', semver=None))]
 
         sam_template = Mock()
         SamTemplateMock.return_value = sam_template
@@ -177,7 +177,7 @@ class TestServerlessAppPlugin_on_before_transform_template_translate(TestCase):
     def test_process_invalid_applications_validate(self, SamTemplateMock):
         self.plugin = ServerlessAppPlugin(validate_only=True)
         template_dict = {"a": "b"}
-        app_resources = [("id1", ApplicationResource(app_id = '')), ("id2", ApplicationResource(app_id=None))]
+        app_resources = [("id1", ApplicationResource(app_id = '')), ("id2", ApplicationResource(app_id=None)), ("id3", ApplicationResource(app_id='id3', semver=None))]
 
         sam_template = Mock()
         SamTemplateMock.return_value = sam_template


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If `AWS::Serverless::Application` has a `Location` property with `ApplicationId` and `SemanticVersion`, but `SemanticVersion` is passed an explicit `null` value, SAM will throw an uncaught error. This fix adds a check for this case so SAM returns a validation error as expected.

*Description of how you validated changes:*

`make pr` passes. Also manually verified using sam-translate.py and this sample template:

```yaml
AWSTemplateFormatVersion: "2010-09-09"
Transform: "AWS::Serverless-2016-10-31"

Resources:
  NestedApp:
    Type: AWS::Serverless::Application
    Properties:
      Location:
        ApplicationId: foo
        SemanticVersion: null
```

Without the fix:

```sh
% ./bin/sam-translate.py --template-file foo.yaml
ERROR:samtranslator.plugins:Plugin 'ServerlessAppPlugin' raised an exception: Parameter validation failed:
Invalid type for parameter SemanticVersion, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
Traceback (most recent call last):
  File "/Users/jahood/Documents/workspace/serverless-application-model/bin/../samtranslator/plugins/__init__.py", line 132, in act
    getattr(plugin, method_name)(*args, **kwargs)
  File "/Users/jahood/Documents/workspace/serverless-application-model/bin/../samtranslator/plugins/application/serverless_app_plugin.py", line 108, in on_before_transform_template
    service_call(app_id, semver, key, logical_id)
  File "/Users/jahood/Documents/workspace/serverless-application-model/bin/../samtranslator/plugins/application/serverless_app_plugin.py", line 177, in _handle_create_cfn_template_request
    response = self._sar_service_call(create_cfn_template, logical_id, app_id, semver)
  File "/Users/jahood/Documents/workspace/serverless-application-model/bin/../samtranslator/plugins/application/serverless_app_plugin.py", line 330, in _sar_service_call
    response = service_call_lambda(*args)
  File "/Users/jahood/Documents/workspace/serverless-application-model/bin/../samtranslator/plugins/application/serverless_app_plugin.py", line 175, in <lambda>
    SemanticVersion=self._sanitize_sar_str_param(semver)
  File "/Users/jahood/.pyenv/versions/samtranslator27/lib/python2.7/site-packages/botocore/client.py", line 357, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/Users/jahood/.pyenv/versions/samtranslator27/lib/python2.7/site-packages/botocore/client.py", line 634, in _make_api_call
    api_params, operation_model, context=request_context)
  File "/Users/jahood/.pyenv/versions/samtranslator27/lib/python2.7/site-packages/botocore/client.py", line 682, in _convert_to_request_dict
    api_params, operation_model)
  File "/Users/jahood/.pyenv/versions/samtranslator27/lib/python2.7/site-packages/botocore/validate.py", line 297, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
ParamValidationError: Parameter validation failed:
Invalid type for parameter SemanticVersion, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
Traceback (most recent call last):
  File "./bin/sam-translate.py", line 141, in <module>
    transform_template(input_file_path, output_file_path)
  File "./bin/sam-translate.py", line 98, in transform_template
    sam_template, {}, ManagedPolicyLoader(iam_client))
  File "/Users/jahood/Documents/workspace/serverless-application-model/bin/../samtranslator/translator/transform.py", line 16, in transform
    return translator.translate(input_fragment, parameter_values=parameter_values)
  File "/Users/jahood/Documents/workspace/serverless-application-model/bin/../samtranslator/translator/translator.py", line 59, in translate
    sam_plugins=sam_plugins
  File "/Users/jahood/Documents/workspace/serverless-application-model/bin/../samtranslator/parser/parser.py", line 13, in parse
    sam_plugins.act(LifeCycleEvents.before_transform_template, sam_template)
  File "/Users/jahood/Documents/workspace/serverless-application-model/bin/../samtranslator/plugins/__init__.py", line 138, in act
    raise ex
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter SemanticVersion, value: None, type: <type 'NoneType'>, valid types: <type 'basestring'>
```

With the fix:

```sh
% ./bin/sam-translate.py --template-file foo.yaml
ERROR:__main__:Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [NestedApp] is invalid. Property 'SemanticVersion' cannot be blank.
ERROR:__main__:["Resource with id [NestedApp] is invalid. Property 'SemanticVersion' cannot be blank."]
```

*Checklist:*

- [ x ] Write/update tests
- [ x ] `make pr` passes
- [ n/a ] Update documentation
- [ n/a ] Verify transformed template deploys and application functions as expected
- [ n/a ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
