### PR TITLE
Fix a typo in the comment that describes an example json for the lambda function

### DIFF
--- a/examples/apps/step-functions-send-to-sns/lambda_function.py
+++ b/examples/apps/step-functions-send-to-sns/lambda_function.py
@@ -17,7 +17,7 @@ def send_to_sns(message, context):
     #   {
     #       "topic": "arn:aws:sns:REGION:123456789012:MySNSTopic",
     #       "subject": "This is the subject of the message.",
-    #       "message": "This is the body of the message."
+    #       "body": "This is the body of the message."
     #   }
 
     sns = boto3.client('sns')


### PR DESCRIPTION
Fix a typo in the comment that describes an example json for the lambda function

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ X] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
