### PR TITLE
fix: throw error for apikey false in api event when not defined in api

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -680,7 +680,7 @@ class Api(PushEventSource):
 
             apikey_required_setting = self.Auth.get("ApiKeyRequired")
             apikey_required_setting_is_false = apikey_required_setting is not None and not apikey_required_setting
-            if apikey_required_setting_is_false and not api_auth.get("ApiKeyRequired"):
+            if apikey_required_setting_is_false and (not api_auth or not api_auth.get("ApiKeyRequired")):
                 raise InvalidEventException(
                     self.relative_id,
                     "Unable to set ApiKeyRequired [False] on API method [{method}] for path [{path}] "

--- a/tests/translator/input/error_function_with_api_key_false.yaml
+++ b/tests/translator/input/error_function_with_api_key_false.yaml
@@ -1,0 +1,22 @@
+Resources:
+  MyApiWithoutAuth:
+    Type: "AWS::Serverless::Api"
+    Properties:
+      StageName: Prod
+      OpenApiVersion: '3.0.1'
+
+  MyFunctionWithApiKeyRequired:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://bucket/key
+      Handler: index.handler
+      Runtime: nodejs12.x
+      Events:
+        MyApiWithApiKeyRequired:
+          Type: Api
+          Properties:
+            RestApiId: !Ref MyApiWithoutAuth
+            Path: /ApiKeyRequiredTrue
+            Method: get
+            Auth:
+              ApiKeyRequired: false

--- a/tests/translator/output/error_function_with_api_key_false.json
+++ b/tests/translator/output/error_function_with_api_key_false.json
@@ -1,0 +1,8 @@
+ {
+  "errors": [
+    {
+      "errorMessage": "Resource with id [MyFunctionWithApiKeyRequired] is invalid. Event with id [MyApiWithApiKeyRequired] is invalid. Unable to set ApiKeyRequired [False] on API method [get] for path [/ApiKeyRequiredTrue] because the related API does not specify any ApiKeyRequired."
+    }
+  ],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [MyFunctionWithApiKeyRequired] is invalid. Event with id [MyApiWithApiKeyRequired] is invalid. Unable to set ApiKeyRequired [False] on API method [get] for path [/ApiKeyRequiredTrue] because the related API does not specify any ApiKeyRequired."
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -602,6 +602,7 @@ class TestTranslatorEndToEnd(TestCase):
         "error_http_api_event_multiple_same_path",
         "error_function_with_event_dest_invalid",
         "error_function_with_event_dest_type",
+        "error_function_with_api_key_false",
     ],
 )
 @patch("boto3.session.Session.region_name", "ap-southeast-1")


### PR DESCRIPTION
*Issue #, if available:*
#1328 

*Description of changes:*
added a check if api_auth exists

*Description of how you validated changes:*
added an error case
make pr

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
