### PR TITLE
docs: remove comment stating FIFO SQS Queues aren't supported

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -580,7 +580,7 @@ Enabled | `boolean` | Indicates whether Lambda begins polling the event source.
 ```yaml
 Type: SQS
 Properties:
-  Queue: arn:aws:sqs:us-west-2:012345678901:my-queue # NOTE: FIFO SQS Queues are not yet supported
+  Queue: arn:aws:sqs:us-west-2:012345678901:my-queue
   BatchSize: 10
   Enabled: false
 ```


### PR DESCRIPTION
*Description of changes:*

Remove comment stating FIFO SQS Queues aren't supported

*Description of how you validated changes:*

https://aws.amazon.com/blogs/compute/new-for-aws-lambda-sqs-fifo-as-an-event-source/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
