### PR TITLE
Upgrade deprecated runtime nodejs6.10

### DIFF
--- a/examples/2016-10-31/alexa_skill/template.yaml
+++ b/examples/2016-10-31/alexa_skill/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: s3://<bucket>/alexa_skill.zip
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Events:
         AlexaSkillEvent:
           Type: AlexaSkill

--- a/examples/2016-10-31/api_backend/template.yaml
+++ b/examples/2016-10-31/api_backend/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.get
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Policies:
         - DynamoDBReadPolicy:
@@ -25,7 +25,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.put
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Policies:
         - DynamoDBCrudPolicy:
@@ -44,7 +44,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.delete
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Policies:
         - DynamoDBCrudPolicy:

--- a/examples/2016-10-31/api_gateway_responses/template.yaml
+++ b/examples/2016-10-31/api_gateway_responses/template.yaml
@@ -18,7 +18,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.get
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       InlineCode: module.exports = async () => throw new Error('Check out the response headers!')
       Events:
         GetResource:

--- a/examples/2016-10-31/api_request_model/template.yaml
+++ b/examples/2016-10-31/api_request_model/template.yaml
@@ -25,7 +25,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Events:
         GetApi:

--- a/examples/2016-10-31/api_swagger_cors/template.yaml
+++ b/examples/2016-10-31/api_swagger_cors/template.yaml
@@ -25,7 +25,7 @@ Resources:
       # Replace <bucket> with your bucket name
       CodeUri: s3://<bucket>/api_swagger_cors.zip
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Events:
         ProxyApiRoot:
           Type: Api

--- a/examples/2016-10-31/cloudwatch-logs/template.yaml
+++ b/examples/2016-10-31/cloudwatch-logs/template.yaml
@@ -7,7 +7,7 @@ Resources:
     Properties:
       CodeUri: ./index.js
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Events:
         LogsProcessor:
           Type: CloudWatchLogs

--- a/examples/2016-10-31/hello_world/template.yaml
+++ b/examples/2016-10-31/hello_world/template.yaml
@@ -7,5 +7,5 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: src/

--- a/examples/2016-10-31/implicit_api_settings/template.yaml
+++ b/examples/2016-10-31/implicit_api_settings/template.yaml
@@ -42,7 +42,7 @@ Resources:
       # Replace <bucket> with your bucket name
       CodeUri: src/
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       Events:
         ProxyApiRoot:
           Type: Api

--- a/examples/2016-10-31/inline_swagger/template.yaml
+++ b/examples/2016-10-31/inline_swagger/template.yaml
@@ -28,7 +28,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Events:
         GetApi:

--- a/examples/2016-10-31/lambda_edge/template.yaml
+++ b/examples/2016-10-31/lambda_edge/template.yaml
@@ -60,7 +60,7 @@ Resources:
         Properties:
           CodeUri: src/
           Role: !GetAtt LambdaEdgeFunctionRole.Arn
-          Runtime: nodejs6.10
+          Runtime: nodejs10.x
           Handler: index.handler
           Timeout: 5
           # More info at https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst

--- a/examples/2016-10-31/s3_processor/template.yaml
+++ b/examples/2016-10-31/s3_processor/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Policies: AmazonS3ReadOnlyAccess
       Events:

--- a/examples/2016-10-31/schedule/template.yaml
+++ b/examples/2016-10-31/schedule/template.yaml
@@ -6,7 +6,7 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs6.10
+      Runtime: nodejs10.x
       CodeUri: src/
       Events:
         Timer:


### PR DESCRIPTION
CloudFormation templates in serverless-application-model have been found to include a [deprecated Lambda function runtime](https://docs.aws.amazon.com/lambda/latest/dg/runtime-support-policy.html) (nodejs6.10). The affected templates have been updated to a supported runtime (nodejs10.x).

Please note, **this pull request has been generated by a bot**; please check the base branch and files changed before merging.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.