### PR TITLE
Introduce AutoPublishCodeSha256 to allow overriding the publish versi…

### DIFF
--- a/docs/cloudformation_compatibility.rst
+++ b/docs/cloudformation_compatibility.rst
@@ -62,6 +62,7 @@ DeadLetterQueue                    All
 DeploymentPreference               All
 Layers                             All
 AutoPublishAlias             Ref of a CloudFormation Parameter  Alias resources created by SAM uses a LocicalId <FunctionLogicalId+AliasName>. So SAM either needs a string for alias name, or a Ref to template Parameter that SAM can resolve into a string.
+AutoPublishCodeSha256              All
 ReservedConcurrentExecutions       All
 EventInvokeConfig                  All
 ============================ ================================== ========================

--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -62,7 +62,9 @@ This will:
 
 - Create an Alias with ``<alias-name>`` 
 - Create & publish a Lambda version with the latest code & configuration 
-  derived from the ``CodeUri`` property 
+  derived from the ``CodeUri`` property. Optionally it is possible to specify
+  property `AutoPublishCodeSha256` that will override the hash computed for
+  Lambda ``CodeUri`` property.
 - Point the Alias to the latest published version 
 - Point all event sources to the Alias & not to the function 
 - When the ``CodeUri`` property of ``AWS::Serverless::Function`` changes, 

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -70,6 +70,7 @@ class SamFunction(SamResourceMacro):
         "EventInvokeConfig": PropertyType(False, is_type(dict)),
         # Intrinsic functions in value of Alias property are not supported, yet
         "AutoPublishAlias": PropertyType(False, one_of(is_str())),
+        "AutoPublishCodeSha256": PropertyType(False, one_of(is_str())),
         "VersionDescription": PropertyType(False, is_str()),
         "ProvisionedConcurrencyConfig": PropertyType(False, is_type(dict)),
     }
@@ -132,7 +133,10 @@ class SamFunction(SamResourceMacro):
         alias_name = ""
         if self.AutoPublishAlias:
             alias_name = self._get_resolved_alias_name("AutoPublishAlias", self.AutoPublishAlias, intrinsics_resolver)
-            lambda_version = self._construct_version(lambda_function, intrinsics_resolver=intrinsics_resolver)
+            code_sha256 = self.AutoPublishCodeSha256
+            lambda_version = self._construct_version(
+                lambda_function, intrinsics_resolver=intrinsics_resolver, code_sha256=code_sha256
+            )
             lambda_alias = self._construct_alias(alias_name, lambda_function, lambda_version)
             resources.append(lambda_version)
             resources.append(lambda_alias)
@@ -596,7 +600,7 @@ class SamFunction(SamResourceMacro):
         else:
             raise InvalidResourceException(self.logical_id, "Either 'InlineCode' or 'CodeUri' must be set")
 
-    def _construct_version(self, function, intrinsics_resolver):
+    def _construct_version(self, function, intrinsics_resolver, code_sha256=None):
         """Constructs a Lambda Version resource that will be auto-published when CodeUri of the function changes.
         Old versions will not be deleted without a direct reference from the CloudFormation template.
 
@@ -604,6 +608,7 @@ class SamFunction(SamResourceMacro):
         :param model.intrinsics.resolver.IntrinsicsResolver intrinsics_resolver: Class that can help resolve
             references to parameters present in CodeUri. It is a common usecase to set S3Key of Code to be a
             template parameter. Need to resolve the values otherwise we will never detect a change in Code dict
+        :param str code_sha256: User predefined hash of the Lambda function code
         :return: Lambda function Version resource
         """
         code_dict = function.Code
@@ -635,7 +640,7 @@ class SamFunction(SamResourceMacro):
         # SHA Collisions: For purposes of triggering a new update, we are concerned about just the difference previous
         #                 and next hashes. The chances that two subsequent hashes collide is fairly low.
         prefix = "{id}Version".format(id=self.logical_id)
-        logical_id = logical_id_generator.LogicalIdGenerator(prefix, code_dict).gen()
+        logical_id = logical_id_generator.LogicalIdGenerator(prefix, code_dict, code_sha256).gen()
 
         attributes = self.get_passthrough_resource_attributes()
         if attributes is None:

--- a/samtranslator/translator/logical_id_generator.py
+++ b/samtranslator/translator/logical_id_generator.py
@@ -10,7 +10,7 @@ class LogicalIdGenerator(object):
     #       given by this class
     HASH_LENGTH = 10
 
-    def __init__(self, prefix, data_obj=None):
+    def __init__(self, prefix, data_obj=None, data_hash=None):
         """
         Generate logical IDs for resources that are stable, deterministic and platform independent
 
@@ -24,6 +24,7 @@ class LogicalIdGenerator(object):
 
         self._prefix = prefix
         self.data_str = data_str
+        self.data_hash = data_hash
 
     def gen(self):
         """
@@ -53,6 +54,9 @@ class LogicalIdGenerator(object):
         :return: Hash of data if it was present
         :rtype string
         """
+
+        if self.data_hash:
+            return self.data_hash[:length]
 
         data_hash = ""
         if not self.data_str:

--- a/tests/translator/input/function_with_alias_and_code_sha256.yaml
+++ b/tests/translator/input/function_with_alias_and_code_sha256.yaml
@@ -1,0 +1,11 @@
+Resources:
+  MinimalFunction:
+    Type: 'AWS::Serverless::Function'
+    Properties:
+      CodeUri: s3://sam-demo-bucket/hello.zip
+      Handler: hello.handler
+      Runtime: python2.7
+      AutoPublishAlias: live
+      AutoPublishCodeSha256: 6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b
+      VersionDescription: sam-testing
+

--- a/tests/translator/output/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/function_with_alias_and_code_sha256.json
@@ -1,0 +1,82 @@
+{
+  "Resources": {
+    "MinimalFunctionVersion6b86b273ff": {
+      "DeletionPolicy": "Retain", 
+      "Type": "AWS::Lambda::Version", 
+      "Properties": {
+        "Description": "sam-testing",
+        "FunctionName": {
+          "Ref": "MinimalFunction"
+        }
+      }
+    }, 
+    "MinimalFunctionAliaslive": {
+      "Type": "AWS::Lambda::Alias", 
+      "Properties": {
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "MinimalFunctionVersion6b86b273ff",
+            "Version"
+          ]
+        }, 
+        "FunctionName": {
+          "Ref": "MinimalFunction"
+        }, 
+        "Name": "live"
+      }
+    }, 
+    "MinimalFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "hello.zip"
+        }, 
+        "Handler": "hello.handler", 
+        "Role": {
+          "Fn::GetAtt": [
+            "MinimalFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "python2.7", 
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "MinimalFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/test_logical_id_generator.py
+++ b/tests/translator/test_logical_id_generator.py
@@ -44,6 +44,33 @@ class TestLogicalIdGenerator(TestCase):
 
         self.assertEqual(generator.gen(), generator.gen())
 
+    @patch.object(LogicalIdGenerator, "_stringify")
+    def test_gen_hash_data_override(self, stringify_mock):
+        data = {"foo": "bar"}
+        stringified_data = "stringified data"
+        hash_value = "6b86b273ff"
+        stringify_mock.return_value = stringified_data
+
+        generator = LogicalIdGenerator(self.prefix, data_obj=data, data_hash=hash_value)
+
+        expected = "{}{}".format(self.prefix, hash_value)
+        self.assertEqual(expected, generator.gen())
+        stringify_mock.assert_called_once_with(data)
+
+        self.assertEqual(generator.gen(), generator.gen())
+
+    @patch.object(LogicalIdGenerator, "_stringify")
+    def test_gen_hash_data_empty(self, stringify_mock):
+        data = {"foo": "bar"}
+        stringified_data = "stringified data"
+        hash_value = ""
+        stringify_mock.return_value = stringified_data
+
+        generator = LogicalIdGenerator(self.prefix, data_obj=data, data_hash=hash_value)
+
+        stringify_mock.assert_called_once_with(data)
+        self.assertEqual(generator.gen(), generator.gen())
+
     def test_gen_stability_with_copy(self):
         data = {"foo": "bar", "a": "b"}
         generator = LogicalIdGenerator(self.prefix, data_obj=data)


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/serverless-application-model/issues/1375

*Description of changes:* The change introduces additional attribute to AWS::Serverless::Function that allow to override the hash computed for the created Lambda version. To allow more fine grained control this change adds a `AutoPublishCodeSha256` attribute that will allow to associate it in the template.

Example:

```
Resources:
  MinimalFunction:
    Type: 'AWS::Serverless::Function'
    Properties:
      CodeUri: s3://sam-demo-bucket/hello.zip
      Handler: hello.handler
      Runtime: python2.7
      AutoPublishAlias: live
      AutoPublishCodeSha256: 6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b
      VersionDescription: sam-testing
```

*Description of how you validated changes:* Added unit tests to cover this feature.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
