### PR TITLE
feat(policy-templates): add Textract policies

### DIFF
--- a/examples/2016-10-31/policy_templates/all_policy_templates.yaml
+++ b/examples/2016-10-31/policy_templates/all_policy_templates.yaml
@@ -101,3 +101,9 @@ Resources:
 
         - CodeCommitReadPolicy:
             RepositoryName: name
+
+        - TextractPolicy: {}
+
+        - TextractDetectAnalyzePolicy: {}
+
+        - TextractGetResultPolicy: {}

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1849,6 +1849,61 @@
           }
         ]
       }
+    },
+    "TextractPolicy": {
+      "Description": "Gives full access to Textract",
+      "Parameters": {
+
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "textract:*"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
+    },
+    "TextractDetectAnalyzePolicy": {
+      "Description": "Gives access to detect and analyze documents with Textract",
+      "Parameters": {
+
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "textract:DetectDocumentText",
+              "textract:StartDocumentTextDetection",
+              "textract:StartDocumentAnalysis",
+              "textract:AnalyzeDocument"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
+    },
+    "TextractGetResultPolicy": {
+      "Description": "Gives access to get detected and analyzed documents from Textract",
+      "Parameters": {
+
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": [
+              "textract:GetDocumentTextDetection",
+              "textract:GetDocumentAnalysis"
+            ],
+            "Resource": "*"
+          }
+        ]
+      }
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adding a policy `TextractPolicy` that grants full access to Textract. It grants the following permissions:

- textract:*

Adding a policy `TextractDetectAnalyzePolicy` that grants detect and analyze access to Textract. It grants the following permissions:

- textract:DetectDocumentText
- textract:StartDocumentTextDetection
- textract:StartDocumentAnalysis
- textract:AnalyzeDocument

Adding a policy `TextractDetectAnalyzePolicy` that grants get result access to Textract. It grants the following permissions:

- textract:GetDocumentTextDetection
- textract:GetDocumentAnalysis

*Description of how you validated changes:*

I ran make pr.

*Checklist:*

- [X] Write/update tests
- [X] `make pr` passes
- [X] Update documentation
- [X] Verify transformed template deploys and application functions as expected
- [X] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
