### PR TITLE
Fix Template Specification API Auth Object section

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -1032,10 +1032,7 @@ Cors:
 
 #### API Auth Object
 
-Configure Auth on APIs. 
-
-**Authorizers:**
-Define Lambda and Cognito `Authorizers` and specify a `DefaultAuthorizer`. If you use IAM permission, only specify `AWS_IAM` to a `DefaultAuthorizer`. For more information, see the documentation on [Lambda Authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html) and [Amazon Cognito User Pool Authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html) and [IAM Permissions](https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html).
+Configure Auth on APIs.
 
 ```yaml
 Auth:
@@ -1057,8 +1054,14 @@ Auth:
   # For AWS_IAM:
   # DefaultAuthorizer: AWS_IAM
   # InvokeRole: NONE # CALLER_CREDENTIALS by default unless overridden
+    Authorizers: [<list of authorizers, see below >]
+```
+
+**Authorizers:**
+Define Lambda and Cognito `Authorizers` and specify a `DefaultAuthorizer`. If you use IAM permission, only specify `AWS_IAM` to a `DefaultAuthorizer`. For more information, see the documentation on [Lambda Authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-use-lambda-authorizer.html) and [Amazon Cognito User Pool Authorizers](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-integrate-with-cognito.html) and [IAM Permissions](https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html).
   
- ```yaml
+```yaml
+Auth:
   Authorizers:
     MyCognitoAuth:
       UserPoolArn: !GetAtt MyCognitoUserPool.Arn # Can also accept an array


### PR DESCRIPTION
The YAML with `authorizers` example was malformed.

*Issue #, if available:* #1378

*Description of changes:* 

I splitted the example YAML in the _API Auth Object_ section between the main _Auth:_ section and the _Authorizers:_ subsection.

*Description of how you validated changes:*

Manually checked it with a markdown viewer

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`

_All above are irrelevant_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
