### PR TITLE
1391: update black instructions in dev guide

### DIFF
--- a/DEVELOPMENT_GUIDE.rst
+++ b/DEVELOPMENT_GUIDE.rst
@@ -33,7 +33,7 @@ Setup Python locally using `pyenv`_
 We format our code using [Black](https://github.com/python/black) and verify the source code is black compliant
 in Appveyor during PRs. You can find installation instructions on [Black's docs](https://black.readthedocs.io/en/stable/installation_and_usage.html).
 
-After installing, you can run our formatting through our Makefile by `make black-format` or integrating Black directly in your favorite IDE (instructions
+After installing, you can check your formatting through our Makefile by running `make black-check`. To automatically update your code to match our formatting, please run `make black`. You can also integrate Black directly in your favorite IDE (instructions
 can be found [here](https://black.readthedocs.io/en/stable/editor_integration.html))
 
 Pre-commit


### PR DESCRIPTION
This PR address #1391.

Updated the dev guide to have proper formatting command instructions.

*Checklist:*

- [ ] `make pr` passes
    - Fails for 5 files that are currently wrong in the `develop` branch. Can update if needed.
- [X] Update documentation


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
