### PR TITLE
fix: unhashable type: 'dict_node' when referencing RestApiId by Ref in Lambda event mapping on redeploy check

### DIFF
--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -1,6 +1,5 @@
 import copy
 from samtranslator.model import ResourceTypeResolver, sam_resources
-from collections import OrderedDict
 from samtranslator.translator.verify_logical_id import verify_unique_logical_id
 from samtranslator.model.preferences.deployment_preference_collection import DeploymentPreferenceCollection
 from samtranslator.model.exceptions import (
@@ -52,7 +51,7 @@ class Translator:
                     # adds to the function_names dict with key as the api_name and value as the function_name
                     if item.get("Type") == "Api" and item.get("Properties") and item.get("Properties").get("RestApiId"):
                         rest_api = item.get("Properties").get("RestApiId")
-                        if type(rest_api) == dict or isinstance(rest_api, OrderedDict):
+                        if type(rest_api) == dict or isinstance(rest_api, dict):
                             api_name = item.get("Properties").get("RestApiId").get("Ref")
                         else:
                             api_name = item.get("Properties").get("RestApiId")


### PR DESCRIPTION
This handles the error of when referencing an API via Ref so that the dictionary check actually occurs. This makes the type checks equivalent and isn't as restrictive as the OrderedDict class. Helps for when things like cfn-lint pass in templates which is where I noticed the bug after updating to the latest version.

*Issue #, if available:*

*Description of changes:*

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
