### PR TITLE
Added EventBridgePutEventsPolicy template

### DIFF
--- a/examples/2016-10-31/policy_templates/all_policy_templates.yaml
+++ b/examples/2016-10-31/policy_templates/all_policy_templates.yaml
@@ -107,3 +107,6 @@ Resources:
         - TextractDetectAnalyzePolicy: {}
 
         - TextractGetResultPolicy: {}
+
+        - EventBridgePutEventsPolicy:
+            EventBusName: name

--- a/samtranslator/policy_templates_data/policy_templates.json
+++ b/samtranslator/policy_templates_data/policy_templates.json
@@ -1904,6 +1904,32 @@
           }
         ]
       }
+    },
+    "EventBridgePutEventsPolicy": {
+      "Description": "Gives permissions to send events to EventBridge",
+      "Parameters": {
+        "EventBusName": {
+          "Description": "Name of the EventBridge EventBus"
+        }
+      },
+      "Definition": {
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "events:PutEvents",
+            "Resource": {
+              "Fn::Sub": [
+                "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}",
+                {
+                  "eventBusName": {
+                    "Ref": "EventBusName"
+                  }
+                }
+              ]
+            }
+          }
+        ]
+      }
     }
   }
 }

--- a/tests/translator/input/all_policy_templates.yaml
+++ b/tests/translator/input/all_policy_templates.yaml
@@ -159,3 +159,6 @@ Resources:
 
         - AthenaQueryPolicy:
             WorkGroupName: name
+
+        - EventBridgePutEventsPolicy:
+            EventBusName: name

--- a/tests/translator/output/all_policy_templates.json
+++ b/tests/translator/output/all_policy_templates.json
@@ -1485,6 +1485,25 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy55",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "events:PutEvents",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}",
+                      {
+                        "eventBusName": "name"
+                      }
+                    ]
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [

--- a/tests/translator/output/aws-cn/all_policy_templates.json
+++ b/tests/translator/output/aws-cn/all_policy_templates.json
@@ -1485,6 +1485,25 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy55",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "events:PutEvents",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}",
+                      {
+                        "eventBusName": "name"
+                      }
+                    ]
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [

--- a/tests/translator/output/aws-us-gov/all_policy_templates.json
+++ b/tests/translator/output/aws-us-gov/all_policy_templates.json
@@ -1485,6 +1485,25 @@
                 }
               ]
             }
+          },
+          {
+            "PolicyName": "KitchenSinkFunctionRolePolicy55",
+            "PolicyDocument": {
+              "Statement": [
+                {
+                  "Action": "events:PutEvents",
+                  "Resource": {
+                    "Fn::Sub": [
+                      "arn:${AWS::Partition}:events:${AWS::Region}:${AWS::AccountId}:event-bus/${eventBusName}",
+                      {
+                        "eventBusName": "name"
+                      }
+                    ]
+                  },
+                  "Effect": "Allow"
+                }
+              ]
+            }
           }
         ], 
         "Tags": [


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds a dedicated template policy for EventBridge granting the permissions to publish events to EventBus either custom ones or partner events.

*Description of how you validated changes:* Unit tests for transformed had been added to validate that the additional policy had been output.

*Checklist:*

- [X] Write/update tests
- [X] `make pr` passes
- [ ] Update documentation
- [X] Verify transformed template deploys and application functions as expected
- [X] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
