### PR TITLE
Updating spec to include EventBusName for both CloudWatchEvent and EventBridgeRule, which are identical

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -721,6 +721,7 @@ The object describing an event source with type `EventBridgeRule`.
 Property Name | Type | Description
 ---|:---:|---
 Pattern | [Event Pattern Object](https://docs.aws.amazon.com/eventbridge/latest/userguide/eventbridge-and-event-patterns.html) | **Required.** Pattern describing which EventBridge events trigger the function. Only matching events trigger the function.
+EventBusName | `string` | The event bus to associate with this rule. If you omit this, the default event bus is used.
 Input | `string` | JSON-formatted string to pass to the function as the event body. This value overrides the matched event.
 InputPath | `string` | JSONPath describing the part of the event to pass to the function.
 


### PR DESCRIPTION
Documentation change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
