### PR TITLE
docs: add README pointing to example apps

### DIFF
--- a/examples/apps/README.md
+++ b/examples/apps/README.md
@@ -1,0 +1,1 @@
+All example applications have been moved to [aws-samples/serverless-app-examples](https://github.com/aws-samples/serverless-app-examples).


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
I accidentally deleted this change before it was merged. This adds a README to point to the new home of the example applications.

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
