### PR TITLE
Switch Definition to Model

### DIFF
--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -217,7 +217,7 @@ Layers:
 
 Creates a collection of Amazon API Gateway resources and methods that can be invoked through HTTPS endpoints.
 
-An `AWS::Serverless::Api` resource need not be explicitly added to a AWS Serverless Application Definition template. A resource of this type is implicitly created from the union of [Api](#api) events defined on `AWS::Serverless::Function` resources defined in the template that do not refer to an `AWS::Serverless::Api` resource. An `AWS::Serverless::Api` resource should be used to define and document the API using [OpenAPI](https://github.com/OAI/OpenAPI-Specification), which provides more ability to configure the underlying Amazon API Gateway resources.
+An `AWS::Serverless::Api` resource need not be explicitly added to a AWS Serverless Application Model template. A resource of this type is implicitly created from the union of [Api](#api) events defined on `AWS::Serverless::Function` resources defined in the template that do not refer to an `AWS::Serverless::Api` resource. An `AWS::Serverless::Api` resource should be used to define and document the API using [OpenAPI](https://github.com/OAI/OpenAPI-Specification), which provides more ability to configure the underlying Amazon API Gateway resources.
 
 ##### Properties
 
@@ -266,7 +266,7 @@ SAM will generate an API Gateway Stage and API Gateway Deployment for every `AWS
 
 Creates a collection of Amazon API Gateway resources and methods that can be invoked through HTTPS endpoints.
 
-An `AWS::Serverless::HttpApi` resource need not be explicitly added to a AWS Serverless Application Definition template. A resource of this type is implicitly created from the union of [HttpApi](#httpapi) events defined on `AWS::Serverless::Function` resources defined in the template that do not refer to an `AWS::Serverless::HttpApi` resource. An `AWS::Serverless::HttpApi` resource should be used to define and document the API using OpenApi 3.0, which provides more ability to configure the underlying Amazon API Gateway resources.
+An `AWS::Serverless::HttpApi` resource need not be explicitly added to a AWS Serverless Application Model template. A resource of this type is implicitly created from the union of [HttpApi](#httpapi) events defined on `AWS::Serverless::Function` resources defined in the template that do not refer to an `AWS::Serverless::HttpApi` resource. An `AWS::Serverless::HttpApi` resource should be used to define and document the API using OpenApi 3.0, which provides more ability to configure the underlying Amazon API Gateway resources.
 
 For complete documentation about this new feature and examples, see the [HTTP API SAM Documentation](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-resource-httpapi.html)
 


### PR DESCRIPTION
*Issue #, if available:*
The term "AWS Serverless Application Definition template" is not one I have seen anywhere else in this doc nor on any other doc, but "AWS Serverless Application Model template" is found. I'm assuming this is a prior naming convention that should be updated to prevent confusion.

*Description of changes:*
Changing two instances of the word "Definition" to "Model"

*Description of how you validated changes:*
n/a

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
