### PR TITLE
docs: document support for HTTP API Access Log Settings

### DIFF
--- a/tests/translator/input/http_api_explicit_stage.yaml
+++ b/tests/translator/input/http_api_explicit_stage.yaml
@@ -14,3 +14,6 @@ Resources:
     Type: AWS::Serverless::HttpApi
     Properties:
       StageName: Prod
+      AccessLogSettings:
+        DestinationArn: arn:aws:logs:us-east-1:123456789012:log-group:LogGroupName
+        Format: $context.requestId

--- a/tests/translator/output/aws-cn/http_api_explicit_stage.json
+++ b/tests/translator/output/aws-cn/http_api_explicit_stage.json
@@ -51,7 +51,11 @@
           "Ref": "MyApi"
         }, 
         "AutoDeploy": true, 
-        "StageName": "Prod"
+        "StageName": "Prod",
+        "AccessLogSettings": {
+          "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:LogGroupName",
+          "Format": "$context.requestId"
+        }
       }
     }, 
     "HttpApiFunctionRole": {

--- a/tests/translator/output/aws-us-gov/http_api_explicit_stage.json
+++ b/tests/translator/output/aws-us-gov/http_api_explicit_stage.json
@@ -51,7 +51,11 @@
           "Ref": "MyApi"
         }, 
         "AutoDeploy": true, 
-        "StageName": "Prod"
+        "StageName": "Prod",
+        "AccessLogSettings": {
+          "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:LogGroupName",
+          "Format": "$context.requestId"
+        }
       }
     }, 
     "HttpApiFunctionRole": {

--- a/tests/translator/output/http_api_explicit_stage.json
+++ b/tests/translator/output/http_api_explicit_stage.json
@@ -51,7 +51,11 @@
           "Ref": "MyApi"
         }, 
         "AutoDeploy": true, 
-        "StageName": "Prod"
+        "StageName": "Prod",
+        "AccessLogSettings": {
+          "DestinationArn": "arn:aws:logs:us-east-1:123456789012:log-group:LogGroupName",
+          "Format": "$context.requestId"
+        }
       }
     }, 
     "HttpApiFunctionRole": {

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -278,6 +278,7 @@ StageName | `string` | The name of the API stage. If a name is not given, SAM wi
 DefinitionUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | S3 URI or location to the Swagger document describing the API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration. **Note** Intrinsic functions are not supported in external OpenApi files, instead use DefinitionBody to define OpenApi definition.
 DefinitionBody | `JSON or YAML Object` | OpenApi specification that describes your API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration.
 Auth | [HTTP API Auth Object](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-httpapi-httpapiauth.html) | Configure authorization to control access to your API Gateway API.
+AccessLogSettings | [AccessLogSettings](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apigatewayv2-stage-accesslogsettings.html) | Settings for logging access in a stage.
 
 ##### Return values
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Document support for AccessLogSettings for Http Api and add tests.

*Description of how you validated changes:*
`make pr`

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
