### PR TITLE
fix: use isinstance check instead of type (#1411)

### DIFF
--- a/samtranslator/translator/translator.py
+++ b/samtranslator/translator/translator.py
@@ -51,7 +51,7 @@ class Translator:
                     # adds to the function_names dict with key as the api_name and value as the function_name
                     if item.get("Type") == "Api" and item.get("Properties") and item.get("Properties").get("RestApiId"):
                         rest_api = item.get("Properties").get("RestApiId")
-                        if type(rest_api) == dict or isinstance(rest_api, dict):
+                        if isinstance(rest_api, dict):
                             api_name = item.get("Properties").get("RestApiId").get("Ref")
                         else:
                             api_name = item.get("Properties").get("RestApiId")


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws-cloudformation/cfn-python-lint/issues/1325

*Description of changes:*
Do a correct type check, which will fix a recent SAM bug in cfn-lint

*Description of how you validated changes:*
`make pr`

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
