### PR TITLE
feat: add TimeoutInMillis to HttpApi events

### DIFF
--- a/samtranslator/model/eventsources/push.py
+++ b/samtranslator/model/eventsources/push.py
@@ -935,6 +935,7 @@ class HttpApi(PushEventSource):
         "ApiId": PropertyType(False, is_str()),
         "Stage": PropertyType(False, is_str()),
         "Auth": PropertyType(False, is_type(dict)),
+        "TimeoutInMillis": PropertyType(False, is_type(int)),
     }
 
     def resources_to_link(self, resources):
@@ -1064,6 +1065,8 @@ class HttpApi(PushEventSource):
         editor.add_lambda_integration(self.Path, self.Method, uri, self.Auth, api.get("Auth"), condition=condition)
         if self.Auth:
             self._add_auth_to_openapi_integration(api, editor)
+        if self.TimeoutInMillis:
+            editor.add_timeout_to_method(api=api, path=self.Path, method_name=self.Method, timeout=self.TimeoutInMillis)
         api["DefinitionBody"] = editor.openapi
 
     def _add_auth_to_openapi_integration(self, api, editor):

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -236,6 +236,20 @@ class OpenApiEditor(object):
         for path, value in self.paths.items():
             yield path
 
+    def add_timeout_to_method(self, api, path, method_name, timeout):
+        """
+        Adds a timeout to this path/method.
+        
+        :param dict api: Reference to the related Api's properties as defined in the template.
+        :param string path: Path name
+        :param string method_name: Method name
+        :param int timeout: Timeout amount, in milliseconds
+        """
+        normalized_method_name = self._normalize_method_name(method_name)
+        for method_definition in self.get_method_contents(self.get_path(path)[normalized_method_name]):
+            if self.method_definition_has_integration(method_definition):
+                method_definition[self._X_APIGW_INTEGRATION]["timeoutInMillis"] = timeout
+
     def add_authorizers_security_definitions(self, authorizers):
         """
         Add Authorizer definitions to the securityDefinitions part of Swagger.

--- a/tests/translator/input/http_api_existing_openapi.yaml
+++ b/tests/translator/input/http_api_existing_openapi.yaml
@@ -1,3 +1,7 @@
+Parameters:
+  Timeout:
+    Default: 15000
+    Type: Number
 Resources:
   HttpApiFunction: 
     Type: AWS::Serverless::Function
@@ -13,10 +17,12 @@ Resources:
             Path: /basic
             Method: post
             ApiId: !Ref MyApi
+            TimeoutInMillis: 10000
         SimpleCase: # path exists, integration doesn't
           Type: HttpApi
           Properties:
             ApiId: !Ref MyApi
+            TimeoutInMillis: !Ref Timeout
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:

--- a/tests/translator/output/aws-cn/http_api_existing_openapi.json
+++ b/tests/translator/output/aws-cn/http_api_existing_openapi.json
@@ -1,4 +1,10 @@
 {
+  "Parameters": {
+    "Timeout": {
+      "Default": 15000,
+      "Type": "Number"
+    }
+  },
   "Resources": {
     "HttpApiFunctionSimpleCasePermission": {
       "Type": "AWS::Lambda::Permission", 
@@ -100,6 +106,7 @@
               "post": {
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "POST", 
+                  "timeoutInMillis": 10000,
                   "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DifferentFunction.Arn}/invocations"
@@ -151,6 +158,9 @@
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "POST", 
                   "type": "aws_proxy", 
+                  "timeoutInMillis": {
+                    "Ref": "Timeout"
+                  },
                   "uri": {
                     "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HttpApiFunction.Arn}/invocations"
                   }, 

--- a/tests/translator/output/aws-us-gov/http_api_existing_openapi.json
+++ b/tests/translator/output/aws-us-gov/http_api_existing_openapi.json
@@ -1,4 +1,10 @@
 {
+  "Parameters": {
+    "Timeout": {
+      "Default": 15000,
+      "Type": "Number"
+    }
+  },
   "Resources": {
     "HttpApiFunctionSimpleCasePermission": {
       "Type": "AWS::Lambda::Permission", 
@@ -100,6 +106,7 @@
               "post": {
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "POST", 
+                  "timeoutInMillis": 10000,
                   "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DifferentFunction.Arn}/invocations"
@@ -151,6 +158,9 @@
                 "x-amazon-apigateway-integration": {
                   "httpMethod": "POST", 
                   "type": "aws_proxy", 
+                  "timeoutInMillis": {
+                    "Ref": "Timeout"
+                  },
                   "uri": {
                     "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HttpApiFunction.Arn}/invocations"
                   }, 

--- a/tests/translator/output/http_api_existing_openapi.json
+++ b/tests/translator/output/http_api_existing_openapi.json
@@ -1,4 +1,10 @@
 {
+  "Parameters": {
+    "Timeout": {
+      "Default": 15000,
+      "Type": "Number"
+    }
+  },
   "Resources": {
     "HttpApiFunctionSimpleCasePermission": {
       "Type": "AWS::Lambda::Permission", 
@@ -99,7 +105,8 @@
             "/basic": {
               "post": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
+                  "httpMethod": "POST",
+                  "timeoutInMillis": 10000,
                   "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DifferentFunction.Arn}/invocations"
@@ -147,9 +154,12 @@
                     ]
                   }
                 ], 
-                "isDefaultRoute": true, 
+                "isDefaultRoute": true,
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
+                  "httpMethod": "POST",
+                  "timeoutInMillis": {
+                    "Ref": "Timeout"
+                  }, 
                   "type": "aws_proxy", 
                   "uri": {
                     "Fn::Sub": "arn:${AWS::Partition}:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${HttpApiFunction.Arn}/invocations"

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -651,6 +651,7 @@ Path | `string` | Uri path for which this function is invoked. MUST start with `
 Method | `string` | HTTP method for which this function is invoked.
 ApiId | `string` | Identifier of a HttpApi resource which MUST contain an operation with the given path and method. Typically, this is set to [reference](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference-ref.html) an `AWS::Serverless::HttpApi` resource defined in this template. If not defined, a default `AWS::Serverless::HttpApi` resource is created using a generated OpenApi document contains a union of all paths and methods defined by `HttpApi` events defined in this template that do not specify an ApiId.
 Auth | [Function Auth Object](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-function-httpapifunctionauth.html) | Auth configuration for this specific Api+Path+Method. Useful for overriding the API's `DefaultAuthorizer` setting auth config on an individual path when no `DefaultAuthorizer` is specified.
+TimeoutInMillis | `int` | Custom timeout between 50 and 29,000 milliseconds. The default value is 5,000 milliseconds, or 5 seconds for HTTP APIs.
 
 ##### Example: HttpApi event source object
 


### PR DESCRIPTION
*Issue #, if available:*
#1317 

*Description of changes:*
Allow setting `TimeoutInMillis` on HttpApi events.

*Description of how you validated changes:*
`make pr`

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
