### PR TITLE
revert: "fix: update policy used for xray tracing (#1405)"

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -431,7 +431,7 @@ class SamFunction(SamResourceMacro):
 
         managed_policy_arns = [ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaBasicExecutionRole")]
         if self.Tracing:
-            managed_policy_arns.append(ArnGenerator.generate_aws_managed_policy_arn("AWSXRayDaemonWriteAccess"))
+            managed_policy_arns.append(ArnGenerator.generate_aws_managed_policy_arn("AWSXrayWriteOnlyAccess"))
         if self.VpcConfig:
             managed_policy_arns.append(
                 ArnGenerator.generate_aws_managed_policy_arn("service-role/AWSLambdaVPCAccessExecutionRole")

--- a/tests/translator/output/aws-cn/basic_function.json
+++ b/tests/translator/output/aws-cn/basic_function.json
@@ -303,7 +303,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-cn:iam::aws:policy/AWSXRayDaemonWriteAccess"
+          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess"
         ],
         "Tags": [
           {
@@ -334,7 +334,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-cn:iam::aws:policy/AWSXRayDaemonWriteAccess"
+          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess"
         ],
         "Tags": [
           {

--- a/tests/translator/output/aws-cn/globals_for_function.json
+++ b/tests/translator/output/aws-cn/globals_for_function.json
@@ -5,7 +5,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-cn:iam::aws:policy/AWSXRayDaemonWriteAccess",
+          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess",
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ],
         "Tags": [
@@ -107,7 +107,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole",
-          "arn:aws-cn:iam::aws:policy/AWSXRayDaemonWriteAccess",
+          "arn:aws-cn:iam::aws:policy/AWSXrayWriteOnlyAccess",
           "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ],
         "Tags": [

--- a/tests/translator/output/aws-us-gov/basic_function.json
+++ b/tests/translator/output/aws-us-gov/basic_function.json
@@ -303,7 +303,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXRayDaemonWriteAccess"
+          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess"
         ],
         "Tags": [
           {
@@ -334,7 +334,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXRayDaemonWriteAccess"
+          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess"
         ],
         "Tags": [
           {

--- a/tests/translator/output/aws-us-gov/globals_for_function.json
+++ b/tests/translator/output/aws-us-gov/globals_for_function.json
@@ -5,7 +5,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXRayDaemonWriteAccess",
+          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess",
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/OverridePermissionsBoundary",
@@ -107,7 +107,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws-us-gov:iam::aws:policy/AWSXRayDaemonWriteAccess",
+          "arn:aws-us-gov:iam::aws:policy/AWSXrayWriteOnlyAccess",
           "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",

--- a/tests/translator/output/basic_function.json
+++ b/tests/translator/output/basic_function.json
@@ -303,7 +303,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
         ],
         "Tags": [
           {
@@ -334,7 +334,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess"
+          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess"
         ],
         "Tags": [
           {

--- a/tests/translator/output/globals_for_function.json
+++ b/tests/translator/output/globals_for_function.json
@@ -5,7 +5,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess",
+          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess",
           "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/OverridePermissionsBoundary",
@@ -107,7 +107,7 @@
       "Properties": {
         "ManagedPolicyArns": [
           "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
-          "arn:aws:iam::aws:policy/AWSXRayDaemonWriteAccess",
+          "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess",
           "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
         ], 
         "PermissionsBoundary": "arn:aws:1234:iam:boundary/CustomerCreatedPermissionsBoundary",


### PR DESCRIPTION
This reverts commit 2d5d7a0cd76b02a80fea3c0d8c99867036189abe.

*Issue #, if available:*
N/A

*Description of changes:*
Reverts the XRay policy update. This update caused some customers deployments to break due to tightly controlled permissions regarding specific managed policies. While the permissions in these policies are the exact same, the names are different and caused some failures.

*Description of how you validated changes:*
`make pr`

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
