### PR TITLE
fix: make usageplan properties referable

### DIFF
--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -10,7 +10,14 @@ from .api.http_api_generator import HttpApiGenerator
 from .s3_utils.uri_parser import construct_s3_location_object
 from .tags.resource_tagging import get_tag_list
 from samtranslator.model import PropertyType, SamResourceMacro, ResourceTypeResolver
-from samtranslator.model.apigateway import ApiGatewayDeployment, ApiGatewayStage, ApiGatewayDomainName
+from samtranslator.model.apigateway import (
+    ApiGatewayDeployment,
+    ApiGatewayStage,
+    ApiGatewayDomainName,
+    ApiGatewayUsagePlan,
+    ApiGatewayUsagePlanKey,
+    ApiGatewayApiKey,
+)
 from samtranslator.model.apigatewayv2 import ApiGatewayV2Stage
 from samtranslator.model.cloudformation import NestedStack
 from samtranslator.model.dynamodb import DynamoDBTable
@@ -764,6 +771,9 @@ class SamApi(SamResourceMacro):
         "Stage": ApiGatewayStage.resource_type,
         "Deployment": ApiGatewayDeployment.resource_type,
         "DomainName": ApiGatewayDomainName.resource_type,
+        "UsagePlan": ApiGatewayUsagePlan.resource_type,
+        "UsagePlanKey": ApiGatewayUsagePlanKey.resource_type,
+        "ApiKey": ApiGatewayApiKey.resource_type,
     }
 
     def to_cloudformation(self, **kwargs):

--- a/tests/translator/input/api_with_usageplans.yaml
+++ b/tests/translator/input/api_with_usageplans.yaml
@@ -126,3 +126,15 @@ Outputs:
       Description: "API endpoint URL for Prod environment"
       Value:
         Fn::Sub: 'https://${MyApiThree}.execute-api.${AWS::Region}.amazonaws.com/Prod/'
+    UsagePlan:
+      Description: "Usage Plan physical Id"
+      Value:
+        !Ref MyApiTwo.UsagePlan
+    UsagePlanKey:
+      Description: "Usage Plan Key"
+      Value:
+        !Ref MyApiTwo.UsagePlanKey
+    ApiKey:
+      Description: "Api Key"
+      Value:
+        !Ref MyApiThree.ApiKey

--- a/tests/translator/output/api_with_usageplans.json
+++ b/tests/translator/output/api_with_usageplans.json
@@ -17,6 +17,24 @@
       "Value": {
         "Fn::Sub": "https://${MyApiOne}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
       }
+    },
+    "ApiKey": {
+      "Description": "Api Key",
+      "Value": {
+        "Ref": "ServerlessApiKey"
+      }
+    },
+    "UsagePlanKey": {
+      "Description": "Usage Plan Key",
+      "Value": {
+        "Ref": "MyApiTwoUsagePlanKey"
+      }
+    },
+    "UsagePlan": {
+      "Description": "Usage Plan physical Id",
+      "Value": {
+        "Ref": "MyApiTwoUsagePlan"
+      }
     }
   },
   "Resources": {

--- a/tests/translator/output/aws-cn/api_with_usageplans.json
+++ b/tests/translator/output/aws-cn/api_with_usageplans.json
@@ -17,6 +17,24 @@
       "Value": {
         "Fn::Sub": "https://${MyApiOne}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
       }
+    },
+    "ApiKey": {
+      "Description": "Api Key",
+      "Value": {
+        "Ref": "ServerlessApiKey"
+      }
+    },
+    "UsagePlanKey": {
+      "Description": "Usage Plan Key",
+      "Value": {
+        "Ref": "MyApiTwoUsagePlanKey"
+      }
+    },
+    "UsagePlan": {
+      "Description": "Usage Plan physical Id",
+      "Value": {
+        "Ref": "MyApiTwoUsagePlan"
+      }
     }
   },
   "Resources": {

--- a/tests/translator/output/aws-us-gov/api_with_usageplans.json
+++ b/tests/translator/output/aws-us-gov/api_with_usageplans.json
@@ -17,6 +17,24 @@
       "Value": {
         "Fn::Sub": "https://${MyApiOne}.execute-api.${AWS::Region}.amazonaws.com/Prod/"
       }
+    },
+    "ApiKey": {
+      "Description": "Api Key",
+      "Value": {
+        "Ref": "ServerlessApiKey"
+      }
+    },
+    "UsagePlanKey": {
+      "Description": "Usage Plan Key",
+      "Value": {
+        "Ref": "MyApiTwoUsagePlanKey"
+      }
+    },
+    "UsagePlan": {
+      "Description": "Usage Plan physical Id",
+      "Value": {
+        "Ref": "MyApiTwoUsagePlan"
+      }
     }
   },
   "Resources": {


### PR DESCRIPTION
*Issue #, if available:*
#1432 

*Description of changes:*
made usageplan resources a referable property to api

*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
