### PR TITLE
feat: add Tags support to Http Api

### DIFF
--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -11,6 +11,7 @@ from samtranslator.model.tags.resource_tagging import get_tag_list
 AuthProperties = namedtuple("_AuthProperties", ["Authorizers", "DefaultAuthorizer"])
 AuthProperties.__new__.__defaults__ = (None, None)
 DefaultStageName = "$default"
+HttpApiTagName = "httpapi:createdBy"
 
 
 class HttpApiGenerator(object):
@@ -70,6 +71,7 @@ class HttpApiGenerator(object):
             )
 
         self._add_auth()
+        self._add_tags()
 
         if self.definition_uri:
             http_api.BodyS3Location = self._construct_body_s3_dict()
@@ -83,9 +85,6 @@ class HttpApiGenerator(object):
                 "add a 'HttpApi' event to an 'AWS::Serverless::Function'",
             )
 
-        if self.tags is not None:
-            http_api.Tags = get_tag_list(self.tags)
-
         return http_api
 
     def _add_auth(self):
@@ -97,7 +96,7 @@ class HttpApiGenerator(object):
 
         if self.auth and not self.definition_body:
             raise InvalidResourceException(
-                self.logical_id, "Auth works only with inline Swagger specified in " "'DefinitionBody' property"
+                self.logical_id, "Auth works only with inline OpenApi specified in the 'DefinitionBody' property."
             )
 
         # Make sure keys in the dict are recognized
@@ -107,7 +106,7 @@ class HttpApiGenerator(object):
         if not OpenApiEditor.is_valid(self.definition_body):
             raise InvalidResourceException(
                 self.logical_id,
-                "Unable to add Auth configuration because " "'DefinitionBody' does not contain a valid Swagger",
+                "Unable to add Auth configuration because 'DefinitionBody' does not contain a valid OpenApi definition.",
             )
         open_api_editor = OpenApiEditor(self.definition_body)
         auth_properties = AuthProperties(**self.auth)
@@ -118,6 +117,25 @@ class HttpApiGenerator(object):
         self._set_default_authorizer(
             open_api_editor, authorizers, auth_properties.DefaultAuthorizer, auth_properties.Authorizers
         )
+        self.definition_body = open_api_editor.openapi
+
+    def _add_tags(self):
+        if self.tags and not self.definition_body:
+            raise InvalidResourceException(
+                self.logical_id, "Tags works only with inline OpenApi specified in the 'DefinitionBody' property."
+            )
+
+        if not self.definition_body:
+            return
+
+        if not self.tags:
+            self.tags = {}
+        self.tags[HttpApiTagName] = "SAM"
+
+        open_api_editor = OpenApiEditor(self.definition_body)
+
+        # authorizers is guaranteed to return a value or raise an exception
+        open_api_editor.add_tags(self.tags)
         self.definition_body = open_api_editor.openapi
 
     def _set_default_authorizer(self, open_api_editor, authorizers, default_authorizer, api_authorizers):
@@ -134,7 +152,9 @@ class HttpApiGenerator(object):
         if not authorizers.get(default_authorizer):
             raise InvalidResourceException(
                 self.logical_id,
-                "Unable to set DefaultAuthorizer because '" + default_authorizer + "' was not defined in 'Authorizers'",
+                "Unable to set DefaultAuthorizer because '"
+                + default_authorizer
+                + "' was not defined in 'Authorizers'.",
             )
 
         for path in open_api_editor.iter_on_path():
@@ -151,7 +171,7 @@ class HttpApiGenerator(object):
         authorizers = {}
 
         if not isinstance(authorizers_config, dict):
-            raise InvalidResourceException(self.logical_id, "Authorizers must be a dictionary")
+            raise InvalidResourceException(self.logical_id, "Authorizers must be a dictionary.")
 
         for authorizer_name, authorizer in authorizers_config.items():
             if not isinstance(authorizer, dict):
@@ -179,7 +199,7 @@ class HttpApiGenerator(object):
             if not self.definition_uri.get("Bucket", None) or not self.definition_uri.get("Key", None):
                 # DefinitionUri is a dictionary but does not contain Bucket or Key property
                 raise InvalidResourceException(
-                    self.logical_id, "'DefinitionUri' requires Bucket and Key properties to be specified"
+                    self.logical_id, "'DefinitionUri' requires Bucket and Key properties to be specified."
                 )
             s3_pointer = self.definition_uri
 
@@ -225,9 +245,6 @@ class HttpApiGenerator(object):
         stage.StageVariables = self.stage_variables
         stage.AccessLogSettings = self.access_log_settings
         stage.AutoDeploy = True
-
-        if self.tags is not None:
-            stage.Tags = get_tag_list(self.tags)
 
         return stage
 

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -131,6 +131,14 @@ class HttpApiGenerator(object):
         if not self.definition_body:
             return
 
+        if self.tags and not OpenApiEditor.is_valid(self.definition_body):
+            raise InvalidResourceException(
+                self.logical_id,
+                "Unable to add `Tags` because 'DefinitionBody' does not contain a valid OpenApi definition.",
+            )
+        elif not OpenApiEditor.is_valid(self.definition_body):
+            return
+
         if not self.tags:
             self.tags = {}
         self.tags[HttpApiTagName] = "SAM"

--- a/samtranslator/model/api/http_api_generator.py
+++ b/samtranslator/model/api/http_api_generator.py
@@ -120,6 +120,9 @@ class HttpApiGenerator(object):
         self.definition_body = open_api_editor.openapi
 
     def _add_tags(self):
+        """
+        Adds tags to the Http Api, including a default SAM tag.
+        """
         if self.tags and not self.definition_body:
             raise InvalidResourceException(
                 self.logical_id, "Tags works only with inline OpenApi specified in the 'DefinitionBody' property."

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -354,7 +354,7 @@ class OpenApiEditor(object):
         """
         for name, value in tags.items():
             # find an existing tag with this name if it exists
-            existing_tag = next(existing_tag for existing_tag in self.tags if existing_tag.get("name") == name)
+            existing_tag = next((existing_tag for existing_tag in self.tags if existing_tag.get("name") == name), None)
             if existing_tag:
                 # overwrite tag value for an existing tag
                 existing_tag[self._X_APIGW_TAG_VALUE] = value

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -347,6 +347,11 @@ class OpenApiEditor(object):
                 method_definition["security"] = security
 
     def add_tags(self, tags):
+        """
+        Adds tags to the OpenApi definition using an ApiGateway extension for tag values.
+
+        :param dict tags: dictionary of tagName:tagValue pairs.
+        """
         for name, value in tags.items():
             # find an existing tag with this name if it exists
             existing_tag = next(existing_tag for existing_tag in self.tags if existing_tag.get("name") == name)

--- a/samtranslator/open_api/open_api.py
+++ b/samtranslator/open_api/open_api.py
@@ -27,8 +27,8 @@ class OpenApiEditor(object):
         Initialize the class with a swagger dictionary. This class creates a copy of the Swagger and performs all
         modifications on this copy.
 
-        :param dict doc: Swagger document as a dictionary
-        :raises ValueError: If the input Swagger document does not meet the basic Swagger requirements.
+        :param dict doc: OpenApi document as a dictionary
+        :raises ValueError: If the input OpenApi document does not meet the basic OpenApi requirements.
         """
         if not OpenApiEditor.is_valid(doc):
             raise ValueError(

--- a/tests/translator/input/error_http_api_tags.yaml
+++ b/tests/translator/input/error_http_api_tags.yaml
@@ -1,0 +1,8 @@
+Resources:
+  Api:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      DefinitionBody:
+        invalid: def_body
+      Tags:
+        Tag: value

--- a/tests/translator/input/error_http_api_tags_def_uri.yaml
+++ b/tests/translator/input/error_http_api_tags_def_uri.yaml
@@ -1,0 +1,7 @@
+Resources:
+  Api:
+    Type: AWS::Serverless::HttpApi
+    Properties:
+      DefinitionUri: s3://bucket/key
+      Tags:
+        Tag: value

--- a/tests/translator/input/http_api_def_uri.yaml
+++ b/tests/translator/input/http_api_def_uri.yaml
@@ -3,8 +3,6 @@ Resources:
     Type: AWS::Serverless::HttpApi
     Properties:
       DefinitionUri: s3://bucket/key
-      Tags:
-        Tag: value
       StageName: !Join ["", ["Stage", "Name"]]
 
   MyApi2:
@@ -14,8 +12,6 @@ Resources:
         Bucket: bucket
         Key: key
         Version: version
-      Tags:
-        Tag: value
 
   Function:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/http_api_existing_openapi_conditions.yaml
+++ b/tests/translator/input/http_api_existing_openapi_conditions.yaml
@@ -35,6 +35,9 @@ Resources:
   MyApi:
     Type: AWS::Serverless::HttpApi
     Properties:
+      Tags:
+        Tag1: value1
+        Tag2: value2
       Auth:
         Authorizers:
           OAuth2:

--- a/tests/translator/input/http_api_existing_openapi_conditions.yaml
+++ b/tests/translator/input/http_api_existing_openapi_conditions.yaml
@@ -109,6 +109,9 @@ Resources:
                 - scope4
               responses: {}
         openapi: 3.0.1
+        tags:
+          - name: Tag1
+            description: this tag exists, but doesn't have an amazon extension value
         components:
           securitySchemes:
             oauth2Auth:

--- a/tests/translator/output/aws-cn/explicit_http_api.json
+++ b/tests/translator/output/aws-cn/explicit_http_api.json
@@ -74,6 +74,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {
@@ -177,6 +183,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {

--- a/tests/translator/output/aws-cn/explicit_http_api_minimum.json
+++ b/tests/translator/output/aws-cn/explicit_http_api_minimum.json
@@ -54,6 +54,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {}, 
           "openapi": "3.0.1"
         }
@@ -99,6 +105,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {

--- a/tests/translator/output/aws-cn/http_api_def_uri.json
+++ b/tests/translator/output/aws-cn/http_api_def_uri.json
@@ -57,13 +57,7 @@
               "Name"
             ]
           ]
-        }, 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        }
       }
     }, 
     "FunctionRole": {
@@ -103,13 +97,7 @@
           "Ref": "MyApi2"
         }, 
         "AutoDeploy": true, 
-        "StageName": "$default", 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        "StageName": "$default"
       }
     }, 
     "MyApi2": {
@@ -119,13 +107,7 @@
           "Version": "version", 
           "Bucket": "bucket", 
           "Key": "key"
-        }, 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        }
       }
     }, 
     "FunctionApi2Permission": {
@@ -155,13 +137,7 @@
         "BodyS3Location": {
           "Bucket": "bucket", 
           "Key": "key"
-        }, 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        }
       }
     }
   }

--- a/tests/translator/output/aws-cn/http_api_existing_openapi.json
+++ b/tests/translator/output/aws-cn/http_api_existing_openapi.json
@@ -95,6 +95,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/basic": {
               "post": {

--- a/tests/translator/output/aws-cn/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/aws-cn/http_api_existing_openapi_conditions.json
@@ -105,6 +105,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/basic": {
               "post": {
@@ -270,6 +276,10 @@
           }, 
           "openapi": "3.0.1", 
           "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            },
             {
               "name": "Tag1", 
               "x-amazon-apigateway-tag-value": "value1"

--- a/tests/translator/output/aws-cn/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/aws-cn/http_api_existing_openapi_conditions.json
@@ -268,7 +268,17 @@
               }
             }
           }, 
-          "openapi": "3.0.1"
+          "openapi": "3.0.1", 
+          "tags": [
+            {
+              "name": "Tag1", 
+              "x-amazon-apigateway-tag-value": "value1"
+            }, 
+            {
+              "name": "Tag2", 
+              "x-amazon-apigateway-tag-value": "value2"
+            }
+          ]
         }
       }
     }

--- a/tests/translator/output/aws-cn/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/aws-cn/http_api_existing_openapi_conditions.json
@@ -282,7 +282,8 @@
             },
             {
               "name": "Tag1", 
-              "x-amazon-apigateway-tag-value": "value1"
+              "x-amazon-apigateway-tag-value": "value1",
+              "description": "this tag exists, but doesn't have an amazon extension value"
             }, 
             {
               "name": "Tag2", 

--- a/tests/translator/output/aws-cn/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/aws-cn/http_api_existing_openapi_conditions.json
@@ -104,13 +104,7 @@
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
-          "tags": [
-            {
-              "name": "httpapi:createdBy", 
-              "x-amazon-apigateway-tag-value": "SAM"
-            }
-          ], 
+          },
           "paths": {
             "/basic": {
               "post": {

--- a/tests/translator/output/aws-cn/http_api_explicit_stage.json
+++ b/tests/translator/output/aws-cn/http_api_explicit_stage.json
@@ -110,7 +110,13 @@
               }
             }
           }, 
-          "openapi": "3.0.1"
+          "openapi": "3.0.1", 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ]
         }
       }
     }

--- a/tests/translator/output/aws-cn/implicit_http_api.json
+++ b/tests/translator/output/aws-cn/implicit_http_api.json
@@ -82,6 +82,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/basic2": {
               "post": {

--- a/tests/translator/output/aws-cn/implicit_http_api_auth_and_simple_case.json
+++ b/tests/translator/output/aws-cn/implicit_http_api_auth_and_simple_case.json
@@ -95,6 +95,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/scope3": {
               "post": {

--- a/tests/translator/output/aws-cn/implicit_http_api_with_many_conditions.json
+++ b/tests/translator/output/aws-cn/implicit_http_api_with_many_conditions.json
@@ -199,6 +199,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/hello/again": {
               "Fn::If": [

--- a/tests/translator/output/aws-us-gov/explicit_http_api.json
+++ b/tests/translator/output/aws-us-gov/explicit_http_api.json
@@ -74,6 +74,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {
@@ -177,6 +183,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {

--- a/tests/translator/output/aws-us-gov/explicit_http_api_minimum.json
+++ b/tests/translator/output/aws-us-gov/explicit_http_api_minimum.json
@@ -54,6 +54,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {}, 
           "openapi": "3.0.1"
         }
@@ -99,6 +105,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {

--- a/tests/translator/output/aws-us-gov/http_api_def_uri.json
+++ b/tests/translator/output/aws-us-gov/http_api_def_uri.json
@@ -57,13 +57,7 @@
               "Name"
             ]
           ]
-        }, 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        }
       }
     }, 
     "FunctionRole": {
@@ -103,13 +97,7 @@
           "Ref": "MyApi2"
         }, 
         "AutoDeploy": true, 
-        "StageName": "$default", 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        "StageName": "$default"
       }
     }, 
     "MyApi2": {
@@ -119,13 +107,7 @@
           "Version": "version", 
           "Bucket": "bucket", 
           "Key": "key"
-        }, 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        }
       }
     }, 
     "FunctionApi2Permission": {
@@ -155,13 +137,7 @@
         "BodyS3Location": {
           "Bucket": "bucket", 
           "Key": "key"
-        }, 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        }
       }
     }
   }

--- a/tests/translator/output/aws-us-gov/http_api_existing_openapi.json
+++ b/tests/translator/output/aws-us-gov/http_api_existing_openapi.json
@@ -95,6 +95,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/basic": {
               "post": {

--- a/tests/translator/output/aws-us-gov/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/aws-us-gov/http_api_existing_openapi_conditions.json
@@ -276,7 +276,8 @@
             },
             {
               "name": "Tag1", 
-              "x-amazon-apigateway-tag-value": "value1"
+              "x-amazon-apigateway-tag-value": "value1",
+              "description": "this tag exists, but doesn't have an amazon extension value"
             }, 
             {
               "name": "Tag2", 

--- a/tests/translator/output/aws-us-gov/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/aws-us-gov/http_api_existing_openapi_conditions.json
@@ -268,7 +268,17 @@
               }
             }
           }, 
-          "openapi": "3.0.1"
+          "openapi": "3.0.1", 
+          "tags": [
+            {
+              "name": "Tag1", 
+              "x-amazon-apigateway-tag-value": "value1"
+            }, 
+            {
+              "name": "Tag2", 
+              "x-amazon-apigateway-tag-value": "value2"
+            }
+          ]
         }
       }
     }

--- a/tests/translator/output/aws-us-gov/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/aws-us-gov/http_api_existing_openapi_conditions.json
@@ -271,6 +271,10 @@
           "openapi": "3.0.1", 
           "tags": [
             {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            },
+            {
               "name": "Tag1", 
               "x-amazon-apigateway-tag-value": "value1"
             }, 

--- a/tests/translator/output/aws-us-gov/http_api_explicit_stage.json
+++ b/tests/translator/output/aws-us-gov/http_api_explicit_stage.json
@@ -94,6 +94,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {

--- a/tests/translator/output/aws-us-gov/implicit_http_api.json
+++ b/tests/translator/output/aws-us-gov/implicit_http_api.json
@@ -82,6 +82,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/basic2": {
               "post": {

--- a/tests/translator/output/aws-us-gov/implicit_http_api_auth_and_simple_case.json
+++ b/tests/translator/output/aws-us-gov/implicit_http_api_auth_and_simple_case.json
@@ -95,6 +95,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/scope3": {
               "post": {

--- a/tests/translator/output/aws-us-gov/implicit_http_api_with_many_conditions.json
+++ b/tests/translator/output/aws-us-gov/implicit_http_api_with_many_conditions.json
@@ -199,6 +199,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/hello/again": {
               "Fn::If": [

--- a/tests/translator/output/error_http_api_tags.json
+++ b/tests/translator/output/error_http_api_tags.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [Api] is invalid. Unable to add `Tags` because 'DefinitionBody' does not contain a valid OpenApi definition."
+    }
+  ],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Api] is invalid. Unable to add `Tags` because 'DefinitionBody' does not contain a valid OpenApi definition."
+}

--- a/tests/translator/output/error_http_api_tags_def_uri.json
+++ b/tests/translator/output/error_http_api_tags_def_uri.json
@@ -1,0 +1,8 @@
+{
+  "errors": [
+    {
+      "errorMessage": "Resource with id [Api] is invalid. Tags works only with inline OpenApi specified in the 'DefinitionBody' property."
+    }
+  ],
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 1. Resource with id [Api] is invalid. Tags works only with inline OpenApi specified in the 'DefinitionBody' property."
+}

--- a/tests/translator/output/explicit_http_api.json
+++ b/tests/translator/output/explicit_http_api.json
@@ -74,6 +74,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {
@@ -177,6 +183,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {

--- a/tests/translator/output/explicit_http_api_minimum.json
+++ b/tests/translator/output/explicit_http_api_minimum.json
@@ -54,6 +54,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {}, 
           "openapi": "3.0.1"
         }
@@ -99,6 +105,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {

--- a/tests/translator/output/http_api_def_uri.json
+++ b/tests/translator/output/http_api_def_uri.json
@@ -57,13 +57,7 @@
               "Name"
             ]
           ]
-        }, 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        }
       }
     }, 
     "FunctionRole": {
@@ -103,13 +97,7 @@
           "Ref": "MyApi2"
         }, 
         "AutoDeploy": true, 
-        "StageName": "$default", 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        "StageName": "$default"
       }
     }, 
     "MyApi2": {
@@ -119,13 +107,7 @@
           "Version": "version", 
           "Bucket": "bucket", 
           "Key": "key"
-        }, 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        }
       }
     }, 
     "FunctionApi2Permission": {
@@ -155,13 +137,7 @@
         "BodyS3Location": {
           "Bucket": "bucket", 
           "Key": "key"
-        }, 
-        "Tags": [
-          {
-            "Value": "value", 
-            "Key": "Tag"
-          }
-        ]
+        }
       }
     }
   }

--- a/tests/translator/output/http_api_existing_openapi.json
+++ b/tests/translator/output/http_api_existing_openapi.json
@@ -95,6 +95,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/basic": {
               "post": {

--- a/tests/translator/output/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/http_api_existing_openapi_conditions.json
@@ -276,7 +276,8 @@
             },
             {
               "name": "Tag1", 
-              "x-amazon-apigateway-tag-value": "value1"
+              "x-amazon-apigateway-tag-value": "value1",
+              "description": "this tag exists, but doesn't have an amazon extension value"
             }, 
             {
               "name": "Tag2", 

--- a/tests/translator/output/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/http_api_existing_openapi_conditions.json
@@ -268,7 +268,17 @@
               }
             }
           }, 
-          "openapi": "3.0.1"
+          "openapi": "3.0.1", 
+          "tags": [
+            {
+              "name": "Tag1", 
+              "x-amazon-apigateway-tag-value": "value1"
+            }, 
+            {
+              "name": "Tag2", 
+              "x-amazon-apigateway-tag-value": "value2"
+            }
+          ]
         }
       }
     }

--- a/tests/translator/output/http_api_existing_openapi_conditions.json
+++ b/tests/translator/output/http_api_existing_openapi_conditions.json
@@ -104,7 +104,7 @@
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/basic": {
               "post": {
@@ -270,6 +270,10 @@
           }, 
           "openapi": "3.0.1", 
           "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            },
             {
               "name": "Tag1", 
               "x-amazon-apigateway-tag-value": "value1"

--- a/tests/translator/output/http_api_explicit_stage.json
+++ b/tests/translator/output/http_api_explicit_stage.json
@@ -94,6 +94,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "$default": {
               "x-amazon-apigateway-any-method": {

--- a/tests/translator/output/implicit_http_api.json
+++ b/tests/translator/output/implicit_http_api.json
@@ -82,6 +82,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/basic2": {
               "post": {

--- a/tests/translator/output/implicit_http_api_auth_and_simple_case.json
+++ b/tests/translator/output/implicit_http_api_auth_and_simple_case.json
@@ -95,6 +95,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/scope3": {
               "post": {

--- a/tests/translator/output/implicit_http_api_with_many_conditions.json
+++ b/tests/translator/output/implicit_http_api_with_many_conditions.json
@@ -199,6 +199,12 @@
               "Ref": "AWS::StackName"
             }
           }, 
+          "tags": [
+            {
+              "name": "httpapi:createdBy", 
+              "x-amazon-apigateway-tag-value": "SAM"
+            }
+          ], 
           "paths": {
             "/hello/again": {
               "Fn::If": [

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -602,6 +602,8 @@ class TestTranslatorEndToEnd(TestCase):
         "error_http_api_event_invalid_api",
         "error_http_api_invalid_auth",
         "error_http_api_invalid_openapi",
+        "error_http_api_tags",
+        "error_http_api_tags_def_uri",
         "error_implicit_http_api_method",
         "error_implicit_http_api_path",
         "error_http_api_event_multiple_same_path",

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -278,6 +278,7 @@ StageName | `string` | The name of the API stage. If a name is not given, SAM wi
 DefinitionUri | `string` <span>&#124;</span> [S3 Location Object](#s3-location-object) | S3 URI or location to the Swagger document describing the API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration. **Note** Intrinsic functions are not supported in external OpenApi files, instead use DefinitionBody to define OpenApi definition.
 DefinitionBody | `JSON or YAML Object` | OpenApi specification that describes your API. If neither `DefinitionUri` nor `DefinitionBody` are specified, SAM will generate a `DefinitionBody` for you based on your template configuration.
 Auth | [HTTP API Auth Object](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-httpapi-httpapiauth.html) | Configure authorization to control access to your API Gateway API.
+Tags | Map of `string` to `string` | A map (string to string) that specifies the [tags](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-resource-tags.html) to be added to this HTTP API. When the stack is created, SAM will automatically add the following tag: `lambda:createdBy: SAM`.
 
 ##### Return values
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Add tags support to Serverless::HttpApi resources
*Description of how you validated changes:*
Deployed templates to CFN to verify tags work, show up in console.
*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
