### PR TITLE
explicit UpdateReplacePolicy

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -43,7 +43,7 @@ class Resource(object):
     property_types = None
     _keywords = ["logical_id", "relative_id", "depends_on", "resource_attributes"]
 
-    _supported_resource_attributes = ["DeletionPolicy", "UpdatePolicy", "Condition"]
+    _supported_resource_attributes = ["DeletionPolicy", "UpdateReplacePolicy", "UpdatePolicy", "Condition"]
 
     # Runtime attributes that can be qureied resource. They are CloudFormation attributes like ARN, Name etc that
     # will be resolvable at runtime. This map will be implemented by sub-classes to express list of attributes they

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -677,6 +677,7 @@ class SamFunction(SamResourceMacro):
         if attributes is None:
             attributes = {}
         attributes["DeletionPolicy"] = "Retain"
+        attributes["UpdateReplacePolicy"] = "Delete"
 
         lambda_version = LambdaVersion(logical_id=logical_id, attributes=attributes)
         lambda_version.FunctionName = function.get_runtime_attr("name")
@@ -1104,6 +1105,7 @@ class SamLayerVersion(SamResourceMacro):
         if attributes is None:
             attributes = {}
         attributes["DeletionPolicy"] = retention_policy_value
+        attributes["UpdateReplacePolicy"] = "Delete"
 
         old_logical_id = self.logical_id
         new_logical_id = logical_id_generator.LogicalIdGenerator(old_logical_id, self.to_dict()).gen()

--- a/tests/translator/output/aws-cn/basic_layer.json
+++ b/tests/translator/output/aws-cn/basic_layer.json
@@ -10,6 +10,7 @@
   "Resources": {
     "LayerWithCondition7c655e10ea": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -22,6 +23,7 @@
     }, 
     "MinimalLayer0c7f96cce7": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -33,6 +35,7 @@
     }, 
     "CompleteLayer5d71a60e81": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -50,6 +53,7 @@
     }, 
     "LayerWithContentUriObjectbdbf1b82ac": {
       "DeletionPolicy": "Delete", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-cn/function_event_conditions.json
+++ b/tests/translator/output/aws-cn/function_event_conditions.json
@@ -316,6 +316,7 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Condition": "MyCondition",
       "Properties": {

--- a/tests/translator/output/aws-cn/function_with_alias.json
+++ b/tests/translator/output/aws-cn/function_with_alias.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "Description": "sam-testing",

--- a/tests/translator/output/aws-cn/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/aws-cn/function_with_alias_and_event_sources.json
@@ -358,6 +358,7 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_alias_intrinsics.json
+++ b/tests/translator/output/aws-cn/function_with_alias_intrinsics.json
@@ -8,6 +8,7 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_custom_codedeploy_deployment_preference.json
@@ -59,6 +59,7 @@
     }, 
     "CustomWithFindInMapVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -204,6 +205,7 @@
     }, 
     "CustomWithConditionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -242,6 +244,7 @@
     }, 
     "CustomWithCondition2Version640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -303,6 +306,7 @@
     }, 
     "NormalWithRefVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -429,6 +433,7 @@
     }, 
     "CustomWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -591,6 +596,7 @@
     }, 
     "NormalWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -813,6 +819,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -140,6 +140,7 @@
     }, 
     "HelloWorldFunctionVersionfb53d5c2e6": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_and_custom_role.json
@@ -102,6 +102,7 @@
     }, 
     "FunctionWithRoleVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -209,6 +210,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_no_service_role.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_no_service_role.json
@@ -86,6 +86,7 @@
     }, 
     "OtherFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -186,6 +187,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference.json
@@ -146,6 +146,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_all_parameters.json
@@ -205,6 +205,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_from_parameters.json
@@ -219,6 +219,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations.json
@@ -188,6 +188,7 @@
     }, 
     "MinimalFunctionWithMinimalDeploymentPreferenceVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -303,6 +304,7 @@
     }, 
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -376,6 +378,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_disabled_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_disabled_deployment_preference.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_event_dest_basic.json
+++ b/tests/translator/output/aws-cn/function_with_event_dest_basic.json
@@ -138,6 +138,7 @@
     }, 
     "MyTestFunctionVersiondaf9da458d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_layers.json
+++ b/tests/translator/output/aws-cn/function_with_layers.json
@@ -28,6 +28,7 @@
     }, 
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-cn/function_with_many_layers.json
+++ b/tests/translator/output/aws-cn/function_with_many_layers.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-cn/function_with_resource_refs.json
+++ b/tests/translator/output/aws-cn/function_with_resource_refs.json
@@ -159,6 +159,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/globals_for_function.json
+++ b/tests/translator/output/aws-cn/globals_for_function.json
@@ -223,6 +223,7 @@
     }, 
     "FunctionWithOverridesVersion096ed3b52b": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -232,6 +233,7 @@
     }, 
     "MinimalFunctionVersion0a06fc8fb1": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/layers_all_properties.json
+++ b/tests/translator/output/aws-cn/layers_all_properties.json
@@ -66,6 +66,7 @@
     }, 
     "MyLayerd04062b365": {
       "DeletionPolicy": "Delete", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -77,6 +78,7 @@
     }, 
     "MyLayerWithANamefda8c9ec8c": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-cn/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-cn/layers_with_intrinsics.json
@@ -15,6 +15,7 @@
   "Resources": {
     "LayerWithNameIntrinsiccf8baed8b9": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -26,6 +27,7 @@
     },
     "LayerWithRefNameIntrinsicRegion186db7e435": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -37,6 +39,7 @@
     },
     "LayerWithSubNameIntrinsicRegionfbc3f9f13d": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -50,6 +53,7 @@
     },
     "LayerWithRuntimesIntrinsic1a006faa85": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -64,6 +68,7 @@
     },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -77,6 +82,7 @@
     "LayerWithSubNameIntrinsic6e9b477102": {
       "Type": "AWS::Lambda::LayerVersion",
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Properties": {
         "Content": {
           "S3Bucket": "sam-demo-bucket",

--- a/tests/translator/output/aws-us-gov/basic_layer.json
+++ b/tests/translator/output/aws-us-gov/basic_layer.json
@@ -10,6 +10,7 @@
   "Resources": {
     "LayerWithCondition7c655e10ea": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -22,6 +23,7 @@
     }, 
     "MinimalLayer0c7f96cce7": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -33,6 +35,7 @@
     }, 
     "CompleteLayer5d71a60e81": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -50,6 +53,7 @@
     }, 
     "LayerWithContentUriObjectbdbf1b82ac": {
       "DeletionPolicy": "Delete", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-us-gov/function_event_conditions.json
+++ b/tests/translator/output/aws-us-gov/function_event_conditions.json
@@ -316,6 +316,7 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Condition": "MyCondition",
       "Properties": {

--- a/tests/translator/output/aws-us-gov/function_with_alias.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "Description": "sam-testing",

--- a/tests/translator/output/aws-us-gov/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_and_event_sources.json
@@ -368,6 +368,7 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_alias_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_intrinsics.json
@@ -8,6 +8,7 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_custom_codedeploy_deployment_preference.json
@@ -59,6 +59,7 @@
     }, 
     "CustomWithFindInMapVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -204,6 +205,7 @@
     }, 
     "CustomWithConditionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -242,6 +244,7 @@
     }, 
     "CustomWithCondition2Version640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -303,6 +306,7 @@
     }, 
     "NormalWithRefVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -429,6 +433,7 @@
     }, 
     "CustomWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -591,6 +596,7 @@
     }, 
     "NormalWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -813,6 +819,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -140,6 +140,7 @@
     }, 
     "HelloWorldFunctionVersionfb53d5c2e6": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_and_custom_role.json
@@ -102,6 +102,7 @@
     }, 
     "FunctionWithRoleVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -209,6 +210,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_no_service_role.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_no_service_role.json
@@ -86,6 +86,7 @@
     }, 
     "OtherFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -186,6 +187,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
@@ -146,6 +146,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_all_parameters.json
@@ -205,6 +205,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_from_parameters.json
@@ -219,6 +219,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations.json
@@ -188,6 +188,7 @@
     }, 
     "MinimalFunctionWithMinimalDeploymentPreferenceVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -303,6 +304,7 @@
     }, 
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -376,6 +378,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_disabled_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_disabled_deployment_preference.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_event_dest_basic.json
+++ b/tests/translator/output/aws-us-gov/function_with_event_dest_basic.json
@@ -138,6 +138,7 @@
     }, 
     "MyTestFunctionVersiondaf9da458d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_layers.json
+++ b/tests/translator/output/aws-us-gov/function_with_layers.json
@@ -28,6 +28,7 @@
     }, 
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-us-gov/function_with_many_layers.json
+++ b/tests/translator/output/aws-us-gov/function_with_many_layers.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-us-gov/function_with_resource_refs.json
+++ b/tests/translator/output/aws-us-gov/function_with_resource_refs.json
@@ -159,6 +159,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/globals_for_function.json
+++ b/tests/translator/output/aws-us-gov/globals_for_function.json
@@ -223,6 +223,7 @@
     }, 
     "FunctionWithOverridesVersion096ed3b52b": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -232,6 +233,7 @@
     }, 
     "MinimalFunctionVersion0a06fc8fb1": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/layers_all_properties.json
+++ b/tests/translator/output/aws-us-gov/layers_all_properties.json
@@ -66,6 +66,7 @@
     }, 
     "MyLayerd04062b365": {
       "DeletionPolicy": "Delete", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -77,6 +78,7 @@
     }, 
     "MyLayerWithANamefda8c9ec8c": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
@@ -15,6 +15,7 @@
   "Resources": {
     "LayerWithNameIntrinsiccf8baed8b9": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -26,6 +27,7 @@
     },
     "LayerWithRefNameIntrinsicRegionad31c93c8b": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -37,6 +39,7 @@
     },
     "LayerWithSubNameIntrinsicRegion5b2c74d55e": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -50,6 +53,7 @@
     },
     "LayerWithRuntimesIntrinsic1a006faa85": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -64,6 +68,7 @@
     },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -77,6 +82,7 @@
     "LayerWithSubNameIntrinsic6e9b477102": {
       "Type": "AWS::Lambda::LayerVersion",
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Properties": {
         "Content": {
           "S3Bucket": "sam-demo-bucket",

--- a/tests/translator/output/basic_layer.json
+++ b/tests/translator/output/basic_layer.json
@@ -10,6 +10,7 @@
   "Resources": {
     "LayerWithCondition7c655e10ea": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -22,6 +23,7 @@
     }, 
     "MinimalLayer0c7f96cce7": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -33,6 +35,7 @@
     }, 
     "CompleteLayer5d71a60e81": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -50,6 +53,7 @@
     }, 
     "LayerWithContentUriObjectbdbf1b82ac": {
       "DeletionPolicy": "Delete", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/function_event_conditions.json
+++ b/tests/translator/output/function_event_conditions.json
@@ -316,6 +316,7 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Condition": "MyCondition",
       "Properties": {

--- a/tests/translator/output/function_with_alias.json
+++ b/tests/translator/output/function_with_alias.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "Description": "sam-testing",

--- a/tests/translator/output/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/function_with_alias_and_code_sha256.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MinimalFunctionVersion6b86b273ff": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "Description": "sam-testing",

--- a/tests/translator/output/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/function_with_alias_and_event_sources.json
@@ -360,6 +360,7 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_alias_intrinsics.json
+++ b/tests/translator/output/function_with_alias_intrinsics.json
@@ -8,6 +8,7 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/function_with_custom_codedeploy_deployment_preference.json
@@ -59,6 +59,7 @@
     }, 
     "CustomWithFindInMapVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -204,6 +205,7 @@
     }, 
     "CustomWithConditionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -242,6 +244,7 @@
     }, 
     "CustomWithCondition2Version640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -303,6 +306,7 @@
     }, 
     "NormalWithRefVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -429,6 +433,7 @@
     }, 
     "CustomWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -591,6 +596,7 @@
     }, 
     "NormalWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -813,6 +819,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -140,6 +140,7 @@
     }, 
     "HelloWorldFunctionVersionfb53d5c2e6": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/function_with_deployment_and_custom_role.json
@@ -102,6 +102,7 @@
     }, 
     "FunctionWithRoleVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -209,6 +210,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_no_service_role.json
+++ b/tests/translator/output/function_with_deployment_no_service_role.json
@@ -86,6 +86,7 @@
     }, 
     "OtherFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -186,6 +187,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_preference.json
+++ b/tests/translator/output/function_with_deployment_preference.json
@@ -146,6 +146,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/function_with_deployment_preference_all_parameters.json
@@ -205,6 +205,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/function_with_deployment_preference_from_parameters.json
@@ -219,6 +219,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/function_with_deployment_preference_multiple_combinations.json
@@ -188,6 +188,7 @@
     }, 
     "MinimalFunctionWithMinimalDeploymentPreferenceVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -303,6 +304,7 @@
     }, 
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -376,6 +378,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_disabled_deployment_preference.json
+++ b/tests/translator/output/function_with_disabled_deployment_preference.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_event_dest_basic.json
+++ b/tests/translator/output/function_with_event_dest_basic.json
@@ -138,6 +138,7 @@
     }, 
     "MyTestFunctionVersiondaf9da458d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_layers.json
+++ b/tests/translator/output/function_with_layers.json
@@ -28,6 +28,7 @@
     }, 
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/function_with_many_layers.json
+++ b/tests/translator/output/function_with_many_layers.json
@@ -2,6 +2,7 @@
   "Resources": {
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/function_with_resource_refs.json
+++ b/tests/translator/output/function_with_resource_refs.json
@@ -159,6 +159,7 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/globals_for_function.json
+++ b/tests/translator/output/globals_for_function.json
@@ -223,6 +223,7 @@
     }, 
     "FunctionWithOverridesVersion096ed3b52b": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -232,6 +233,7 @@
     }, 
     "MinimalFunctionVersion0a06fc8fb1": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/layers_all_properties.json
+++ b/tests/translator/output/layers_all_properties.json
@@ -66,6 +66,7 @@
     }, 
     "MyLayerd04062b365": {
       "DeletionPolicy": "Delete", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -77,6 +78,7 @@
     }, 
     "MyLayerWithANamefda8c9ec8c": {
       "DeletionPolicy": "Retain", 
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/layers_with_intrinsics.json
+++ b/tests/translator/output/layers_with_intrinsics.json
@@ -15,6 +15,7 @@
   "Resources": {
     "LayerWithNameIntrinsiccf8baed8b9": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -26,6 +27,7 @@
     },
     "LayerWithRefNameIntrinsicRegion32bf7198a5": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -37,6 +39,7 @@
     },
     "LayerWithSubNameIntrinsicRegiond71326de24": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -50,6 +53,7 @@
     },
     "LayerWithRuntimesIntrinsic1a006faa85": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -64,6 +68,7 @@
     },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -77,6 +82,7 @@
     "LayerWithSubNameIntrinsic6e9b477102": {
       "Type": "AWS::Lambda::LayerVersion",
       "DeletionPolicy": "Retain",
+      "UpdateReplacePolicy": "Delete",
       "Properties": {
         "Content": {
           "S3Bucket": "sam-demo-bucket",


### PR DESCRIPTION
fixes https://github.com/aws-cloudformation/cfn-python-lint/issues/1265

*Description of changes:* [`UpdateReplacePolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html) currently defaults to `Delete` anyway, so this change should be a no-op explicitly acknowledging the current default [`UpdateReplacePolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html) value by making it explicit. I'd encourage following up and re-evaluating what [`UpdateReplacePolicy`](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-updatereplacepolicy.html) value really makes sense here, as [CloudFormation Linter rules](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/docs/rules.md) [I3011](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/rules/resources/UpdateReplacePolicyDeletionPolicyOnStatefulResourceTypes.py) and [W3011](https://github.com/aws-cloudformation/cfn-python-lint/blob/master/src/cfnlint/rules/resources/BothUpdateReplacePolicyDeletionPolicyNeeded.py) are really just meant to encourage explicit policies because the default values can lead to disastrous surprises

---

63 AssertionErrors to fix 😳

```shell
serverless-application-model $ gsed -i -r 's/(DeletionPolicy.*)/\1\n      "UpdateReplacePolicy": "Delete",/' tests/translator/output/**/*.json
```

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
