### PR TITLE
fix: remove type property after transformation

### DIFF
--- a/samtranslator/model/eventsources/pull.py
+++ b/samtranslator/model/eventsources/pull.py
@@ -85,6 +85,8 @@ class PullEventSource(ResourceMacro):
 
             # SAM attaches the policies for SQS or SNS only if 'Type' is given
             if destination_type:
+                # delete this field as its used internally for SAM to determine the policy
+                del self.DestinationConfig["OnFailure"]["Type"]
                 # the values 'SQS' and 'SNS' are allowed. No intrinsics are allowed
                 if destination_type not in ["SQS", "SNS"]:
                     raise InvalidEventException(self.logical_id, "The only valid values for 'Type' are 'SQS' and 'SNS'")
@@ -102,7 +104,6 @@ class PullEventSource(ResourceMacro):
                     destination_config_policy = IAMRolePolicies().sns_publish_role_policy(
                         sns_topic_arn, self.logical_id
                     )
-
             lambda_eventsourcemapping.DestinationConfig = self.DestinationConfig
 
         if "Condition" in function.resource_attributes:

--- a/tests/translator/output/aws-cn/function_with_event_source_mapping.json
+++ b/tests/translator/output/aws-cn/function_with_event_source_mapping.json
@@ -169,8 +169,7 @@
                 "MySqsQueue",
                 "Arn"
               ]
-            },
-            "Type": "SQS"
+            }
           }
         },
         "EventSourceArn": {
@@ -227,8 +226,7 @@
             "OnFailure": {
                 "Destination": {
                     "Ref": "MySnsTopic"
-                },
-                "Type": "SNS"
+                }
             }
         }
       }

--- a/tests/translator/output/aws-us-gov/function_with_event_source_mapping.json
+++ b/tests/translator/output/aws-us-gov/function_with_event_source_mapping.json
@@ -169,8 +169,7 @@
                 "MySqsQueue",
                 "Arn"
               ]
-            },
-            "Type": "SQS"
+            }
           }
         },
         "EventSourceArn": {
@@ -227,8 +226,7 @@
             "OnFailure": {
                 "Destination": {
                     "Ref": "MySnsTopic"
-                },
-                "Type": "SNS"
+                }
             }
         }
       }

--- a/tests/translator/output/function_with_event_source_mapping.json
+++ b/tests/translator/output/function_with_event_source_mapping.json
@@ -169,8 +169,7 @@
                 "MySqsQueue",
                 "Arn"
               ]
-            },
-            "Type": "SQS"
+            }
           }
         },
         "EventSourceArn": {
@@ -227,8 +226,7 @@
             "OnFailure": {
                 "Destination": {
                     "Ref": "MySnsTopic"
-                },
-                "Type": "SNS"
+                }
             }
         }
       }


### PR DESCRIPTION
*Issue #, if available:*
#1475 

*Description of changes:*
removed the `Type` property after transformation as its used by SAM internally to determine the type of the policy to add.

*Description of how you validated changes:*

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
