### PR TITLE
feat: add support for VPCEndpointIds in EndpointConfiguration

### DIFF
--- a/examples/2016-10-31/api_endpointconfiguration/template.yaml
+++ b/examples/2016-10-31/api_endpointconfiguration/template.yaml
@@ -1,0 +1,19 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Description: Example demonstrating API EndpointConfiguration
+
+Parameters:
+  VpcEndpointId:
+    Type: String
+
+Resources:
+  MyApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      EndpointConfiguration:
+        Types:
+          - PRIVATE
+        VPCEndpointIds:
+          - !Ref VpcEndpointId

--- a/examples/2016-10-31/api_endpointconfiguration/template.yaml
+++ b/examples/2016-10-31/api_endpointconfiguration/template.yaml
@@ -4,6 +4,9 @@ Transform: AWS::Serverless-2016-10-31
 Description: Example demonstrating API EndpointConfiguration
 
 Parameters:
+  EndpointConfigType:
+    Type: String
+    Default: PRIVATE
   VpcEndpointId:
     Type: String
 
@@ -14,6 +17,6 @@ Resources:
       StageName: Prod
       EndpointConfiguration:
         Types:
-          - PRIVATE
+          - !Ref EndpointConfigType
         VPCEndpointIds:
           - !Ref VpcEndpointId

--- a/examples/2016-10-31/api_endpointconfiguration/template.yaml
+++ b/examples/2016-10-31/api_endpointconfiguration/template.yaml
@@ -16,7 +16,7 @@ Resources:
     Properties:
       StageName: Prod
       EndpointConfiguration:
-        Types:
+        Type:
           - !Ref EndpointConfigType
         VPCEndpointIds:
           - !Ref VpcEndpointId

--- a/examples/2016-10-31/api_endpointconfiguration/template.yaml
+++ b/examples/2016-10-31/api_endpointconfiguration/template.yaml
@@ -16,7 +16,6 @@ Resources:
     Properties:
       StageName: Prod
       EndpointConfiguration:
-        Type:
-          - !Ref EndpointConfigType
+        Type: !Ref EndpointConfigType
         VPCEndpointIds:
           - !Ref VpcEndpointId

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -927,8 +927,11 @@ class ApiGenerator(object):
         :param string/dict value: Value to be set
         """
         if isinstance(value, dict):
-            rest_api.EndpointConfiguration = {"Types": [value.get("Types", value)]}
             rest_api.Parameters = {"endpointConfigurationTypes": value.get("Types", value)}
+            if isinstance(value.get("Types"), list):
+                rest_api.EndpointConfiguration = {"Types": value.get("Types", value)}
+            else:
+                rest_api.EndpointConfiguration = {"Types": [value.get("Types", value)]}
             if "VPCEndpointIds" in value.keys():
                 rest_api.EndpointConfiguration["VpcEndpointIds"] = value.get("VPCEndpointIds")
         else:

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -293,7 +293,8 @@ class ApiGenerator(object):
         elif endpoint not in ["EDGE", "REGIONAL", "PRIVATE"]:
             raise InvalidResourceException(
                 self.logical_id,
-                "EndpointConfiguration for Custom Domains must be" " one of {}.".format(["EDGE", "REGIONAL", "PRIVATE"]),
+                "EndpointConfiguration for Custom Domains must be"
+                " one of {}.".format(["EDGE", "REGIONAL", "PRIVATE"]),
             )
 
         if endpoint == "REGIONAL":
@@ -933,4 +934,3 @@ class ApiGenerator(object):
         else:
             rest_api.EndpointConfiguration = {"Types": [value]}
             rest_api.Parameters = {"endpointConfigurationTypes": value}
-

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -290,10 +290,10 @@ class ApiGenerator(object):
         if endpoint is None:
             endpoint = "REGIONAL"
             self.domain["EndpointConfiguration"] = "REGIONAL"
-        elif endpoint not in ["EDGE", "REGIONAL"]:
+        elif endpoint not in ["EDGE", "REGIONAL", "PRIVATE"]:
             raise InvalidResourceException(
                 self.logical_id,
-                "EndpointConfiguration for Custom Domains must be" " one of {}.".format(["EDGE", "REGIONAL"]),
+                "EndpointConfiguration for Custom Domains must be" " one of {}.".format(["EDGE", "REGIONAL", "PRIVATE"]),
             )
 
         if endpoint == "REGIONAL":
@@ -925,6 +925,12 @@ class ApiGenerator(object):
         :param rest_api: RestApi resource
         :param string/dict value: Value to be set
         """
+        if isinstance(value, dict):
+            rest_api.EndpointConfiguration = {"Types": [value.get("Types", value)]}
+            rest_api.Parameters = {"endpointConfigurationTypes": value.get("Types", value)}
+            if "VPCEndpointIds" in value.keys():
+                rest_api.EndpointConfiguration["VpcEndpointIds"] = value.get("VPCEndpointIds")
+        else:
+            rest_api.EndpointConfiguration = {"Types": [value]}
+            rest_api.Parameters = {"endpointConfigurationTypes": value}
 
-        rest_api.EndpointConfiguration = {"Types": [value]}
-        rest_api.Parameters = {"endpointConfigurationTypes": value}

--- a/samtranslator/model/api/api_generator.py
+++ b/samtranslator/model/api/api_generator.py
@@ -926,12 +926,9 @@ class ApiGenerator(object):
         :param rest_api: RestApi resource
         :param string/dict value: Value to be set
         """
-        if isinstance(value, dict):
-            rest_api.Parameters = {"endpointConfigurationTypes": value.get("Types", value)}
-            if isinstance(value.get("Types"), list):
-                rest_api.EndpointConfiguration = {"Types": value.get("Types", value)}
-            else:
-                rest_api.EndpointConfiguration = {"Types": [value.get("Types", value)]}
+        if isinstance(value, dict) and value.get("Type"):
+            rest_api.Parameters = {"endpointConfigurationTypes": value.get("Type")}
+            rest_api.EndpointConfiguration = {"Types": [value.get("Type")]}
             if "VPCEndpointIds" in value.keys():
                 rest_api.EndpointConfiguration["VpcEndpointIds"] = value.get("VPCEndpointIds")
         else:

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -763,7 +763,7 @@ class SamApi(SamResourceMacro):
         "CacheClusterEnabled": PropertyType(False, is_type(bool)),
         "CacheClusterSize": PropertyType(False, is_str()),
         "Variables": PropertyType(False, is_type(dict)),
-        "EndpointConfiguration": PropertyType(False, is_str()),
+        "EndpointConfiguration": PropertyType(False, one_of(is_str(), is_type(dict))),
         "MethodSettings": PropertyType(False, is_type(list)),
         "BinaryMediaTypes": PropertyType(False, is_type(list)),
         "MinimumCompressionSize": PropertyType(False, is_type(int)),

--- a/tests/translator/input/api_endpoint_configuration_with_vpcendpoint.yaml
+++ b/tests/translator/input/api_endpoint_configuration_with_vpcendpoint.yaml
@@ -8,10 +8,9 @@ Globals:
   Api:
     # Overriding this property for Implicit API
     EndpointConfiguration:
-      Types:
-        - "Ref": "EndpointConfigType"
+      Type: { "Ref" : "EndpointConfigType" }
       VPCEndpointIds:
-        - "Ref": "VpcEndpointId"
+        - { "Ref": "VpcEndpointId" }
 Resources:
   ImplicitApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/input/api_endpoint_configuration_with_vpcendpoint.yaml
+++ b/tests/translator/input/api_endpoint_configuration_with_vpcendpoint.yaml
@@ -1,0 +1,34 @@
+Parameters:
+  EndpointConfig:
+    Type: String
+
+Globals:
+  Api:
+    # Overriding this property for Implicit API
+    EndpointConfiguration:
+      Types:
+        - PRIVATE
+      VPCEndpointIds:
+        - VPCEndpoint1
+        - VPCEndpoint2
+
+Resources:
+  ImplicitApiFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      CodeUri: s3://sam-demo-bucket/member_portal.zip
+      Handler: index.gethtml
+      Runtime: nodejs12.x
+      Events:
+        GetHtml:
+          Type: Api
+          Properties:
+            Path: /
+            Method: get
+
+  ExplicitApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: Prod
+      DefinitionUri: s3://sam-demo-bucket/webpage_swagger.json
+      EndpointConfiguration: SomeValue

--- a/tests/translator/input/api_endpoint_configuration_with_vpcendpoint.yaml
+++ b/tests/translator/input/api_endpoint_configuration_with_vpcendpoint.yaml
@@ -1,5 +1,7 @@
 Parameters:
-  EndpointConfig:
+  EndpointConfigType:
+    Type: String
+  VpcEndpointId:
     Type: String
 
 Globals:
@@ -7,11 +9,9 @@ Globals:
     # Overriding this property for Implicit API
     EndpointConfiguration:
       Types:
-        - PRIVATE
+        - "Ref": "EndpointConfigType"
       VPCEndpointIds:
-        - VPCEndpoint1
-        - VPCEndpoint2
-
+        - "Ref": "VpcEndpointId"
 Resources:
   ImplicitApiFunction:
     Type: AWS::Serverless::Function

--- a/tests/translator/output/actual
+++ b/tests/translator/output/actual
@@ -6,51 +6,42 @@
     "EndpointConfigType": {
       "Type": "String"
     }
-  }, 
+  },
   "Resources": {
     "ImplicitApiFunction": {
-      "Type": "AWS::Lambda::Function", 
+      "Type": "AWS::Lambda::Function",
       "Properties": {
-        "Handler": "index.gethtml", 
+        "Handler": "index.gethtml",
         "Code": {
-          "S3Bucket": "sam-demo-bucket", 
+          "S3Bucket": "sam-demo-bucket",
           "S3Key": "member_portal.zip"
-        }, 
+        },
         "Role": {
           "Fn::GetAtt": [
-            "ImplicitApiFunctionRole", 
+            "ImplicitApiFunctionRole",
             "Arn"
           ]
-        }, 
+        },
         "Runtime": "nodejs12.x",
-        "Tags": [
-          {
-            "Value": "SAM", 
-            "Key": "lambda:createdBy"
-          }
-        ]
-      }
-    }, 
-    "ImplicitApiFunctionRole": {
-      "Type": "AWS::IAM::Role", 
-      "Properties": {
-        "ManagedPolicyArns": [
-          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
-        ],
         "Tags": [
           {
             "Value": "SAM",
             "Key": "lambda:createdBy"
           }
-        ],
+        ]
+      }
+    },
+    "ImplicitApiFunctionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
         "AssumeRolePolicyDocument": {
-          "Version": "2012-10-17", 
+          "Version": "2012-10-17",
           "Statement": [
             {
               "Action": [
                 "sts:AssumeRole"
-              ], 
-              "Effect": "Allow", 
+              ],
+              "Effect": "Allow",
               "Principal": {
                 "Service": [
                   "lambda.amazonaws.com"
@@ -58,20 +49,39 @@
               }
             }
           ]
-        }
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    },
+    "ExplicitApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment",
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        },
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289",
+        "StageName": "Stage"
       }
     },
     "ImplicitApiFunctionGetHtmlPermissionProd": {
-      "Type": "AWS::Lambda::Permission", 
+      "Type": "AWS::Lambda::Permission",
       "Properties": {
-        "Action": "lambda:InvokeFunction", 
-        "Principal": "apigateway.amazonaws.com", 
+        "Action": "lambda:InvokeFunction",
+        "Principal": "apigateway.amazonaws.com",
         "FunctionName": {
           "Ref": "ImplicitApiFunction"
-        }, 
+        },
         "SourceArn": {
           "Fn::Sub": [
-            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/",
             {
               "__Stage__": "*",
               "__ApiId__": {
@@ -81,92 +91,82 @@
           ]
         }
       }
-    }, 
+    },
     "ExplicitApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "EndpointConfiguration": {
           "Types": [
             "SomeValue"
           ]
-        }, 
+        },
         "BodyS3Location": {
-          "Bucket": "sam-demo-bucket", 
+          "Bucket": "sam-demo-bucket",
           "Key": "webpage_swagger.json"
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": "SomeValue"
         }
       }
-    }, 
+    },
     "ExplicitApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
           "Ref": "ExplicitApiDeploymentf117c932f7"
-        }, 
+        },
         "RestApiId": {
           "Ref": "ExplicitApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
+    },
     "ServerlessRestApiProdStage": {
-      "Type": "AWS::ApiGateway::Stage", 
+      "Type": "AWS::ApiGateway::Stage",
       "Properties": {
         "DeploymentId": {
-          "Ref": "ServerlessRestApiDeploymentcb4fb12558"
-        }, 
+          "Ref": "ServerlessRestApiDeployment62b96c1a61"
+        },
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
+        },
         "StageName": "Prod"
       }
-    }, 
-    "ServerlessRestApiDeploymentcb4fb12558": {
-      "Type": "AWS::ApiGateway::Deployment", 
+    },
+    "ServerlessRestApiDeployment62b96c1a61": {
+      "Type": "AWS::ApiGateway::Deployment",
       "Properties": {
         "RestApiId": {
           "Ref": "ServerlessRestApi"
-        }, 
-        "Description": "RestApi deployment id: cb4fb1255811b7b6a25dd35f23ee7ad133003b89", 
+        },
+        "Description": "RestApi deployment id: 62b96c1a611878eefb13e8ef66dbc71b9ba3dd19",
         "StageName": "Stage"
       }
-    }, 
-    "ExplicitApiDeploymentf117c932f7": {
-      "Type": "AWS::ApiGateway::Deployment", 
-      "Properties": {
-        "RestApiId": {
-          "Ref": "ExplicitApi"
-        }, 
-        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
-        "StageName": "Stage"
-      }
-    }, 
+    },
     "ServerlessRestApi": {
-      "Type": "AWS::ApiGateway::RestApi", 
+      "Type": "AWS::ApiGateway::RestApi",
       "Properties": {
         "Body": {
           "info": {
-            "version": "1.0", 
+            "version": "1.0",
             "title": {
               "Ref": "AWS::StackName"
             }
-          }, 
+          },
           "paths": {
             "/": {
               "get": {
                 "x-amazon-apigateway-integration": {
-                  "httpMethod": "POST", 
-                  "type": "aws_proxy", 
+                  "httpMethod": "POST",
+                  "type": "aws_proxy",
                   "uri": {
-                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
                   }
-                }, 
+                },
                 "responses": {}
               }
             }
-          }, 
+          },
           "swagger": "2.0"
         },
         "EndpointConfiguration": {

--- a/tests/translator/output/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/api_endpoint_configuration_with_vpcendpoint.json
@@ -1,0 +1,188 @@
+{
+  "Parameters": {
+    "EndpointConfig": {
+      "Type": "String"
+    }
+  }, 
+  "Resources": {
+    "ImplicitApiFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "ImplicitApiFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ImplicitApiFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "ExplicitApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
+        "StageName": "Stage"
+      }
+    },
+    "ImplicitApiFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:InvokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "ImplicitApiFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "ExplicitApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "SomeValue"
+          ]
+        }, 
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket", 
+          "Key": "webpage_swagger.json"
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "SomeValue"
+        }
+      }
+    }, 
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeploymentf117c932f7"
+        }, 
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment62b96c1a61"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment62b96c1a61": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 62b96c1a611878eefb13e8ef66dbc71b9ba3dd19", 
+        "StageName": "Stage"
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        }, 
+        "EndpointConfiguration": {
+          "VpcEndpointIds": [
+            "VPCEndpoint1",
+            "VPCEndpoint2"
+          ],
+          "Types": [
+            [
+              "PRIVATE"
+            ]
+          ]
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": [
+            "PRIVATE"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/api_endpoint_configuration_with_vpcendpoint.json
@@ -182,11 +182,9 @@
           ]
         },
         "Parameters": {
-          "endpointConfigurationTypes": [
-            {
-              "Ref": "EndpointConfigType"
-            }
-          ]
+          "endpointConfigurationTypes": {
+            "Ref": "EndpointConfigType"
+          }
         }
       }
     }

--- a/tests/translator/output/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/api_endpoint_configuration_with_vpcendpoint.json
@@ -1,6 +1,9 @@
 {
   "Parameters": {
-    "EndpointConfig": {
+    "VpcEndpointId": {
+      "Type": "String"
+    },
+    "EndpointConfigType": {
       "Type": "String"
     }
   }, 
@@ -165,21 +168,24 @@
             }
           }, 
           "swagger": "2.0"
-        }, 
+        },
         "EndpointConfiguration": {
           "VpcEndpointIds": [
-            "VPCEndpoint1",
-            "VPCEndpoint2"
+            {
+              "Ref": "VpcEndpointId"
+            }
           ],
           "Types": [
-            [
-              "PRIVATE"
-            ]
+            {
+              "Ref": "EndpointConfigType"
+            }
           ]
-        }, 
+        },
         "Parameters": {
           "endpointConfigurationTypes": [
-            "PRIVATE"
+            {
+              "Ref": "EndpointConfigType"
+            }
           ]
         }
       }

--- a/tests/translator/output/aws-cn/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/aws-cn/api_endpoint_configuration_with_vpcendpoint.json
@@ -182,11 +182,9 @@
           ]
         },
         "Parameters": {
-          "endpointConfigurationTypes": [
-            {
-              "Ref": "EndpointConfigType"
-            }
-          ]
+          "endpointConfigurationTypes": {
+            "Ref": "EndpointConfigType"
+          }
         }
       }
     }

--- a/tests/translator/output/aws-cn/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/aws-cn/api_endpoint_configuration_with_vpcendpoint.json
@@ -1,0 +1,188 @@
+{
+  "Parameters": {
+    "EndpointConfig": {
+      "Type": "String"
+    }
+  }, 
+  "Resources": {
+    "ImplicitApiFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "ImplicitApiFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ImplicitApiFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ImplicitApiFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:InvokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "ImplicitApiFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-cn:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "ExplicitApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "SomeValue"
+          ]
+        }, 
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket", 
+          "Key": "webpage_swagger.json"
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "SomeValue"
+        }
+      }
+    }, 
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeploymentf117c932f7"
+        }, 
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeploymentcb4fb12558"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeploymentcb4fb12558": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: cb4fb1255811b7b6a25dd35f23ee7ad133003b89", 
+        "StageName": "Stage"
+      }
+    }, 
+    "ExplicitApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
+        "StageName": "Stage"
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-cn:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "VpcEndpointIds": [
+            "VPCEndpoint1",
+            "VPCEndpoint2"
+          ],
+          "Types": [
+            [
+              "PRIVATE"
+            ]
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": [
+            "PRIVATE"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/aws-us-gov/api_endpoint_configuration_with_vpcendpoint.json
@@ -182,11 +182,9 @@
           ]
         },
         "Parameters": {
-          "endpointConfigurationTypes": [
-            {
-              "Ref": "EndpointConfigType"
-            }
-          ]
+          "endpointConfigurationTypes": {
+            "Ref": "EndpointConfigType"
+          }
         }
       }
     }

--- a/tests/translator/output/aws-us-gov/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/aws-us-gov/api_endpoint_configuration_with_vpcendpoint.json
@@ -1,6 +1,9 @@
 {
   "Parameters": {
-    "EndpointConfig": {
+    "VpcEndpointId": {
+      "Type": "String"
+    },
+    "EndpointConfigType": {
       "Type": "String"
     }
   }, 
@@ -168,18 +171,21 @@
         },
         "EndpointConfiguration": {
           "VpcEndpointIds": [
-            "VPCEndpoint1",
-            "VPCEndpoint2"
+            {
+              "Ref": "VpcEndpointId"
+            }
           ],
           "Types": [
-            [
-              "PRIVATE"
-            ]
+            {
+              "Ref": "EndpointConfigType"
+            }
           ]
         },
         "Parameters": {
           "endpointConfigurationTypes": [
-            "PRIVATE"
+            {
+              "Ref": "EndpointConfigType"
+            }
           ]
         }
       }

--- a/tests/translator/output/aws-us-gov/api_endpoint_configuration_with_vpcendpoint.json
+++ b/tests/translator/output/aws-us-gov/api_endpoint_configuration_with_vpcendpoint.json
@@ -1,0 +1,188 @@
+{
+  "Parameters": {
+    "EndpointConfig": {
+      "Type": "String"
+    }
+  }, 
+  "Resources": {
+    "ImplicitApiFunction": {
+      "Type": "AWS::Lambda::Function", 
+      "Properties": {
+        "Handler": "index.gethtml", 
+        "Code": {
+          "S3Bucket": "sam-demo-bucket", 
+          "S3Key": "member_portal.zip"
+        }, 
+        "Role": {
+          "Fn::GetAtt": [
+            "ImplicitApiFunctionRole", 
+            "Arn"
+          ]
+        }, 
+        "Runtime": "nodejs12.x",
+        "Tags": [
+          {
+            "Value": "SAM", 
+            "Key": "lambda:createdBy"
+          }
+        ]
+      }
+    }, 
+    "ImplicitApiFunctionRole": {
+      "Type": "AWS::IAM::Role", 
+      "Properties": {
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+        ],
+        "Tags": [
+          {
+            "Value": "SAM",
+            "Key": "lambda:createdBy"
+          }
+        ],
+        "AssumeRolePolicyDocument": {
+          "Version": "2012-10-17", 
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ], 
+              "Effect": "Allow", 
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ImplicitApiFunctionGetHtmlPermissionProd": {
+      "Type": "AWS::Lambda::Permission", 
+      "Properties": {
+        "Action": "lambda:InvokeFunction", 
+        "Principal": "apigateway.amazonaws.com", 
+        "FunctionName": {
+          "Ref": "ImplicitApiFunction"
+        }, 
+        "SourceArn": {
+          "Fn::Sub": [
+            "arn:aws-us-gov:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/", 
+            {
+              "__Stage__": "*",
+              "__ApiId__": {
+                "Ref": "ServerlessRestApi"
+              }
+            }
+          ]
+        }
+      }
+    }, 
+    "ExplicitApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "EndpointConfiguration": {
+          "Types": [
+            "SomeValue"
+          ]
+        }, 
+        "BodyS3Location": {
+          "Bucket": "sam-demo-bucket", 
+          "Key": "webpage_swagger.json"
+        }, 
+        "Parameters": {
+          "endpointConfigurationTypes": "SomeValue"
+        }
+      }
+    }, 
+    "ExplicitApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ExplicitApiDeploymentf117c932f7"
+        }, 
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApiDeployment5b2cb4ba8f": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "Description": "RestApi deployment id: 5b2cb4ba8fce8a9445b1914c6c6fbeef81a9075a", 
+        "StageName": "Stage"
+      }
+    }, 
+    "ExplicitApiDeploymentf117c932f7": {
+      "Type": "AWS::ApiGateway::Deployment", 
+      "Properties": {
+        "RestApiId": {
+          "Ref": "ExplicitApi"
+        }, 
+        "Description": "RestApi deployment id: f117c932f75cfa87d23dfed64e9430d0081ef289", 
+        "StageName": "Stage"
+      }
+    }, 
+    "ServerlessRestApiProdStage": {
+      "Type": "AWS::ApiGateway::Stage", 
+      "Properties": {
+        "DeploymentId": {
+          "Ref": "ServerlessRestApiDeployment5b2cb4ba8f"
+        }, 
+        "RestApiId": {
+          "Ref": "ServerlessRestApi"
+        }, 
+        "StageName": "Prod"
+      }
+    }, 
+    "ServerlessRestApi": {
+      "Type": "AWS::ApiGateway::RestApi", 
+      "Properties": {
+        "Body": {
+          "info": {
+            "version": "1.0", 
+            "title": {
+              "Ref": "AWS::StackName"
+            }
+          }, 
+          "paths": {
+            "/": {
+              "get": {
+                "x-amazon-apigateway-integration": {
+                  "httpMethod": "POST", 
+                  "type": "aws_proxy", 
+                  "uri": {
+                    "Fn::Sub": "arn:aws-us-gov:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ImplicitApiFunction.Arn}/invocations"
+                  }
+                }, 
+                "responses": {}
+              }
+            }
+          }, 
+          "swagger": "2.0"
+        },
+        "EndpointConfiguration": {
+          "VpcEndpointIds": [
+            "VPCEndpoint1",
+            "VPCEndpoint2"
+          ],
+          "Types": [
+            [
+              "PRIVATE"
+            ]
+          ]
+        },
+        "Parameters": {
+          "endpointConfigurationTypes": [
+            "PRIVATE"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/error_api_with_custom_domains_invalid.json
+++ b/tests/translator/output/error_api_with_custom_domains_invalid.json
@@ -1,8 +1,8 @@
 {
   "errors": [
     {
-      "errorMessage": "Resource with id [MyApi] is invalid. EndpointConfiguration for Custom Domains must be one of ['EDGE', 'REGIONAL']. Resource with id [ServerlessRestApi] is invalid. Custom Domains only works if both DomainName and CertificateArn are provided."
+      "errorMessage": "Resource with id [MyApi] is invalid. EndpointConfiguration for Custom Domains must be one of ['EDGE', 'REGIONAL', 'PRIVATE']. Resource with id [ServerlessRestApi] is invalid. Custom Domains only works if both DomainName and CertificateArn are provided."
     }
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [MyApi] is invalid. EndpointConfiguration for Custom Domains must be one of ['EDGE', 'REGIONAL']. Resource with id [ServerlessRestApi] is invalid. Custom Domains only works if both DomainName and CertificateArn are provided."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 2. Resource with id [MyApi] is invalid. EndpointConfiguration for Custom Domains must be one of ['EDGE', 'REGIONAL', 'PRIVATE']. Resource with id [ServerlessRestApi] is invalid. Custom Domains only works if both DomainName and CertificateArn are provided."
 }

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -162,6 +162,7 @@ class TestTranslatorEndToEnd(TestCase):
                 "implicit_api",
                 "explicit_api",
                 "api_endpoint_configuration",
+                "api_endpoint_configuration_with_vpcendpoint",
                 "api_with_auth_all_maximum",
                 "api_with_auth_all_minimum",
                 "api_with_auth_no_default",

--- a/tests/translator/validator/test_validator.py
+++ b/tests/translator/validator/test_validator.py
@@ -22,6 +22,7 @@ INPUT_FOLDER = os.path.join(BASE_PATH, os.pardir, "input")
         "implicit_api",
         "explicit_api",
         "api_endpoint_configuration",
+        "api_endpoint_configuration_with_vpcendpoint",
         "api_with_method_settings",
         "api_with_binary_media_types",
         "api_with_minimum_compression_size",
@@ -80,6 +81,7 @@ def test_validate_template_success(testcase):
     # These templates are failing validation, will fix schema one at a time
     excluded = [
         "api_endpoint_configuration",
+        "api_endpoint_configuration_with_vpcendpoint",
         "api_with_binary_media_types",
         "api_with_minimum_compression_size",
         "api_with_cors",

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -233,7 +233,7 @@ CacheClusterSize | `string` | The stage's cache cluster size.
 Variables | Map of `string` to `string` | A map (string to string map) that defines the stage variables, where the variable name is the key and the variable value is the value. Variable names are limited to alphanumeric characters. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&amp;=,-]+`.
 MethodSettings | List of [CloudFormation MethodSettings property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-stage-methodsetting.html) | Configures all settings for API stage including Logging, Metrics, CacheTTL, Throttling. This value is passed through to CloudFormation. So any values supported by CloudFormation ``MethodSettings`` property can be used here.
 Tags | Map of `string` to `string` | A map (string to string) that specifies the tags to be added to this API Stage. Keys and values are limited to alphanumeric characters.
-EndpointConfiguration | `string` | Specify the type of endpoint for API endpoint. Value is either `REGIONAL`, `EDGE`, or `PRIVATE`.
+EndpointConfiguration | `string` or [API EndpointConfiguration Object](#api-endpointconfiguration-object) | Specify the type of endpoint for API endpoint. Specify the type as `REGIONAL`, `EDGE`, or `PRIVATE` or specify a dictionary with additional [API EndpointConfiguration Object](#api-endpointconfiguration-object).
 BinaryMediaTypes | List of `string` |  List of MIME types that your API could return. Use this to enable binary support for APIs. Use `~1` instead of `/` in the mime types (See examples in [template.yaml](../examples/2016-10-31/implicit_api_settings/template.yaml)).
 MinimumCompressionSize | `int` | Allow compression of response bodies based on client's Accept-Encoding header. Compression is triggered when response body size is greater than or equal to your configured threshold. The maximum body size threshold is 10 MB (10,485,760 Bytes). The following compression types are supported: gzip, deflate, and identity.
 Cors | `string` or [Cors Configuration](#cors-configuration) | Enable CORS for all your APIs. Specify the domain to allow as a string or specify a dictionary with additional [Cors Configuration](#cors-configuration). NOTE: Cors requires SAM to modify your OpenAPI definition. Hence it works only inline OpenAPI defined with `DefinitionBody`.
@@ -949,6 +949,7 @@ Properties:
 - [Application Location Object](#application-id-object)
 - [DeadLetterQueue Object](#deadletterqueue-object)
 - [Cors Configuration](#cors-configuration)
+- [API EndpointConfiguration Object](#api-endpointconfiguration-object)
 - [API Auth Object](#api-auth-object)
 - [Function Auth Object](#function-auth-object)
 - [Function Request Model Object](#function-request-model-object)
@@ -1042,6 +1043,15 @@ Cors:
 ```
 
 > NOTE: API Gateway requires literal values to be a quoted string, so don't forget the additional quotes in the  `Allow___` values. ie. "'www.example.com'" is correct whereas "www.example.com" is wrong.
+
+#### API EndpointConfiguration Object
+
+```yaml
+EndpointConfiguration:
+  Types:
+    - PRIVATE # OPTIONAL | Default value is REGIONAL. Accepted values are EDGE, REGIONAL, PRIVATE
+  VPCEndpointIds: [<list of vpc endpoint ids>] # REQUIRED if Type includes PRIVATE
+```
 
 #### API Auth Object
 

--- a/versions/2016-10-31.md
+++ b/versions/2016-10-31.md
@@ -233,7 +233,7 @@ CacheClusterSize | `string` | The stage's cache cluster size.
 Variables | Map of `string` to `string` | A map (string to string map) that defines the stage variables, where the variable name is the key and the variable value is the value. Variable names are limited to alphanumeric characters. Values must match the following regular expression: `[A-Za-z0-9._~:/?#&amp;=,-]+`.
 MethodSettings | List of [CloudFormation MethodSettings property](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-properties-apitgateway-stage-methodsetting.html) | Configures all settings for API stage including Logging, Metrics, CacheTTL, Throttling. This value is passed through to CloudFormation. So any values supported by CloudFormation ``MethodSettings`` property can be used here.
 Tags | Map of `string` to `string` | A map (string to string) that specifies the tags to be added to this API Stage. Keys and values are limited to alphanumeric characters.
-EndpointConfiguration | `string` or [API EndpointConfiguration Object](#api-endpointconfiguration-object) | Specify the type of endpoint for API endpoint. Specify the type as `REGIONAL`, `EDGE`, or `PRIVATE` or specify a dictionary with additional [API EndpointConfiguration Object](#api-endpointconfiguration-object).
+EndpointConfiguration | `string` or [API EndpointConfiguration Object](#api-endpointconfiguration-object) | Specify the type of endpoint for API endpoint. Specify the type as `REGIONAL` or `EDGE`. To use a `PRIVATE` endpoint, specify a dictionary with additional [API EndpointConfiguration Object](#api-endpointconfiguration-object). (See examples in [template.yaml](../examples/2016-10-31/api_endpointconfiguration/template.yaml))
 BinaryMediaTypes | List of `string` |  List of MIME types that your API could return. Use this to enable binary support for APIs. Use `~1` instead of `/` in the mime types (See examples in [template.yaml](../examples/2016-10-31/implicit_api_settings/template.yaml)).
 MinimumCompressionSize | `int` | Allow compression of response bodies based on client's Accept-Encoding header. Compression is triggered when response body size is greater than or equal to your configured threshold. The maximum body size threshold is 10 MB (10,485,760 Bytes). The following compression types are supported: gzip, deflate, and identity.
 Cors | `string` or [Cors Configuration](#cors-configuration) | Enable CORS for all your APIs. Specify the domain to allow as a string or specify a dictionary with additional [Cors Configuration](#cors-configuration). NOTE: Cors requires SAM to modify your OpenAPI definition. Hence it works only inline OpenAPI defined with `DefinitionBody`.
@@ -1048,9 +1048,8 @@ Cors:
 
 ```yaml
 EndpointConfiguration:
-  Types:
-    - PRIVATE # OPTIONAL | Default value is REGIONAL. Accepted values are EDGE, REGIONAL, PRIVATE
-  VPCEndpointIds: [<list of vpc endpoint ids>] # REQUIRED if Type includes PRIVATE
+  Type: PRIVATE # OPTIONAL | Default value is REGIONAL. Accepted values are EDGE, REGIONAL, PRIVATE
+  VPCEndpointIds: [<list of vpc endpoint ids>] # REQUIRED if Type is PRIVATE
 ```
 
 #### API Auth Object


### PR DESCRIPTION
*Issue #1327
*Description of changes:*
Adds support for configuring a PRIVATE  RestApi Endpoint
*Description of how you validated changes:*
added unit tests with expected input and output
*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [x] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
