### PR TITLE
Revert "feat: add explicit UpdateReplacePolicy (#1481)"

### DIFF
--- a/samtranslator/model/__init__.py
+++ b/samtranslator/model/__init__.py
@@ -43,7 +43,7 @@ class Resource(object):
     property_types = None
     _keywords = ["logical_id", "relative_id", "depends_on", "resource_attributes"]
 
-    _supported_resource_attributes = ["DeletionPolicy", "UpdateReplacePolicy", "UpdatePolicy", "Condition"]
+    _supported_resource_attributes = ["DeletionPolicy", "UpdatePolicy", "Condition"]
 
     # Runtime attributes that can be qureied resource. They are CloudFormation attributes like ARN, Name etc that
     # will be resolvable at runtime. This map will be implemented by sub-classes to express list of attributes they

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -679,7 +679,6 @@ class SamFunction(SamResourceMacro):
         if attributes is None:
             attributes = {}
         attributes["DeletionPolicy"] = "Retain"
-        attributes["UpdateReplacePolicy"] = "Delete"
 
         lambda_version = LambdaVersion(logical_id=logical_id, attributes=attributes)
         lambda_version.FunctionName = function.get_runtime_attr("name")
@@ -1109,7 +1108,6 @@ class SamLayerVersion(SamResourceMacro):
         if attributes is None:
             attributes = {}
         attributes["DeletionPolicy"] = retention_policy_value
-        attributes["UpdateReplacePolicy"] = "Delete"
 
         old_logical_id = self.logical_id
         new_logical_id = logical_id_generator.LogicalIdGenerator(old_logical_id, self.to_dict()).gen()

--- a/tests/translator/output/aws-cn/basic_layer.json
+++ b/tests/translator/output/aws-cn/basic_layer.json
@@ -10,7 +10,6 @@
   "Resources": {
     "LayerWithCondition7c655e10ea": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -23,7 +22,6 @@
     }, 
     "MinimalLayer0c7f96cce7": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -35,7 +33,6 @@
     }, 
     "CompleteLayer5d71a60e81": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -53,7 +50,6 @@
     }, 
     "LayerWithContentUriObjectbdbf1b82ac": {
       "DeletionPolicy": "Delete", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-cn/function_event_conditions.json
+++ b/tests/translator/output/aws-cn/function_event_conditions.json
@@ -316,7 +316,6 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Condition": "MyCondition",
       "Properties": {

--- a/tests/translator/output/aws-cn/function_with_alias.json
+++ b/tests/translator/output/aws-cn/function_with_alias.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "Description": "sam-testing",

--- a/tests/translator/output/aws-cn/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/aws-cn/function_with_alias_and_event_sources.json
@@ -358,7 +358,6 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_alias_intrinsics.json
+++ b/tests/translator/output/aws-cn/function_with_alias_intrinsics.json
@@ -8,7 +8,6 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_custom_codedeploy_deployment_preference.json
@@ -59,7 +59,6 @@
     }, 
     "CustomWithFindInMapVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -205,7 +204,6 @@
     }, 
     "CustomWithConditionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -244,7 +242,6 @@
     }, 
     "CustomWithCondition2Version640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -306,7 +303,6 @@
     }, 
     "NormalWithRefVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -433,7 +429,6 @@
     }, 
     "CustomWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -596,7 +591,6 @@
     }, 
     "NormalWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -819,7 +813,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -140,7 +140,6 @@
     }, 
     "HelloWorldFunctionVersionfb53d5c2e6": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_and_custom_role.json
@@ -102,7 +102,6 @@
     }, 
     "FunctionWithRoleVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -210,7 +209,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_no_service_role.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_no_service_role.json
@@ -86,7 +86,6 @@
     }, 
     "OtherFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -187,7 +186,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference.json
@@ -146,7 +146,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_all_parameters.json
@@ -205,7 +205,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_from_parameters.json
@@ -219,7 +219,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/aws-cn/function_with_deployment_preference_multiple_combinations.json
@@ -188,7 +188,6 @@
     }, 
     "MinimalFunctionWithMinimalDeploymentPreferenceVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -304,7 +303,6 @@
     }, 
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -378,7 +376,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_disabled_deployment_preference.json
+++ b/tests/translator/output/aws-cn/function_with_disabled_deployment_preference.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_event_dest_basic.json
+++ b/tests/translator/output/aws-cn/function_with_event_dest_basic.json
@@ -138,7 +138,6 @@
     }, 
     "MyTestFunctionVersiondaf9da458d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/function_with_layers.json
+++ b/tests/translator/output/aws-cn/function_with_layers.json
@@ -28,7 +28,6 @@
     }, 
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-cn/function_with_many_layers.json
+++ b/tests/translator/output/aws-cn/function_with_many_layers.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-cn/function_with_resource_refs.json
+++ b/tests/translator/output/aws-cn/function_with_resource_refs.json
@@ -159,7 +159,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/globals_for_function.json
+++ b/tests/translator/output/aws-cn/globals_for_function.json
@@ -223,7 +223,6 @@
     }, 
     "FunctionWithOverridesVersion096ed3b52b": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -233,7 +232,6 @@
     }, 
     "MinimalFunctionVersion0a06fc8fb1": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-cn/layers_all_properties.json
+++ b/tests/translator/output/aws-cn/layers_all_properties.json
@@ -66,7 +66,6 @@
     }, 
     "MyLayerd04062b365": {
       "DeletionPolicy": "Delete", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -78,7 +77,6 @@
     }, 
     "MyLayerWithANamefda8c9ec8c": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-cn/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-cn/layers_with_intrinsics.json
@@ -15,7 +15,6 @@
   "Resources": {
     "LayerWithNameIntrinsiccf8baed8b9": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -27,7 +26,6 @@
     },
     "LayerWithRefNameIntrinsicRegion186db7e435": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -39,7 +37,6 @@
     },
     "LayerWithSubNameIntrinsicRegionfbc3f9f13d": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -53,7 +50,6 @@
     },
     "LayerWithRuntimesIntrinsic1a006faa85": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -68,7 +64,6 @@
     },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -82,7 +77,6 @@
     "LayerWithSubNameIntrinsic6e9b477102": {
       "Type": "AWS::Lambda::LayerVersion",
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Properties": {
         "Content": {
           "S3Bucket": "sam-demo-bucket",

--- a/tests/translator/output/aws-us-gov/basic_layer.json
+++ b/tests/translator/output/aws-us-gov/basic_layer.json
@@ -10,7 +10,6 @@
   "Resources": {
     "LayerWithCondition7c655e10ea": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -23,7 +22,6 @@
     }, 
     "MinimalLayer0c7f96cce7": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -35,7 +33,6 @@
     }, 
     "CompleteLayer5d71a60e81": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -53,7 +50,6 @@
     }, 
     "LayerWithContentUriObjectbdbf1b82ac": {
       "DeletionPolicy": "Delete", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-us-gov/function_event_conditions.json
+++ b/tests/translator/output/aws-us-gov/function_event_conditions.json
@@ -316,7 +316,6 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Condition": "MyCondition",
       "Properties": {

--- a/tests/translator/output/aws-us-gov/function_with_alias.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "Description": "sam-testing",

--- a/tests/translator/output/aws-us-gov/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_and_event_sources.json
@@ -368,7 +368,6 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_alias_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/function_with_alias_intrinsics.json
@@ -8,7 +8,6 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_custom_codedeploy_deployment_preference.json
@@ -59,7 +59,6 @@
     }, 
     "CustomWithFindInMapVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -205,7 +204,6 @@
     }, 
     "CustomWithConditionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -244,7 +242,6 @@
     }, 
     "CustomWithCondition2Version640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -306,7 +303,6 @@
     }, 
     "NormalWithRefVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -433,7 +429,6 @@
     }, 
     "CustomWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -596,7 +591,6 @@
     }, 
     "NormalWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -819,7 +813,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -140,7 +140,6 @@
     }, 
     "HelloWorldFunctionVersionfb53d5c2e6": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_and_custom_role.json
@@ -102,7 +102,6 @@
     }, 
     "FunctionWithRoleVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -210,7 +209,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_no_service_role.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_no_service_role.json
@@ -86,7 +86,6 @@
     }, 
     "OtherFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -187,7 +186,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference.json
@@ -146,7 +146,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_all_parameters.json
@@ -205,7 +205,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_from_parameters.json
@@ -219,7 +219,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/aws-us-gov/function_with_deployment_preference_multiple_combinations.json
@@ -188,7 +188,6 @@
     }, 
     "MinimalFunctionWithMinimalDeploymentPreferenceVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -304,7 +303,6 @@
     }, 
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -378,7 +376,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_disabled_deployment_preference.json
+++ b/tests/translator/output/aws-us-gov/function_with_disabled_deployment_preference.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_event_dest_basic.json
+++ b/tests/translator/output/aws-us-gov/function_with_event_dest_basic.json
@@ -138,7 +138,6 @@
     }, 
     "MyTestFunctionVersiondaf9da458d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/function_with_layers.json
+++ b/tests/translator/output/aws-us-gov/function_with_layers.json
@@ -28,7 +28,6 @@
     }, 
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-us-gov/function_with_many_layers.json
+++ b/tests/translator/output/aws-us-gov/function_with_many_layers.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-us-gov/function_with_resource_refs.json
+++ b/tests/translator/output/aws-us-gov/function_with_resource_refs.json
@@ -159,7 +159,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/globals_for_function.json
+++ b/tests/translator/output/aws-us-gov/globals_for_function.json
@@ -223,7 +223,6 @@
     }, 
     "FunctionWithOverridesVersion096ed3b52b": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -233,7 +232,6 @@
     }, 
     "MinimalFunctionVersion0a06fc8fb1": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/aws-us-gov/layers_all_properties.json
+++ b/tests/translator/output/aws-us-gov/layers_all_properties.json
@@ -66,7 +66,6 @@
     }, 
     "MyLayerd04062b365": {
       "DeletionPolicy": "Delete", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -78,7 +77,6 @@
     }, 
     "MyLayerWithANamefda8c9ec8c": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
@@ -15,7 +15,6 @@
   "Resources": {
     "LayerWithNameIntrinsiccf8baed8b9": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -27,7 +26,6 @@
     },
     "LayerWithRefNameIntrinsicRegionad31c93c8b": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -39,7 +37,6 @@
     },
     "LayerWithSubNameIntrinsicRegion5b2c74d55e": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -53,7 +50,6 @@
     },
     "LayerWithRuntimesIntrinsic1a006faa85": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -68,7 +64,6 @@
     },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -82,7 +77,6 @@
     "LayerWithSubNameIntrinsic6e9b477102": {
       "Type": "AWS::Lambda::LayerVersion",
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Properties": {
         "Content": {
           "S3Bucket": "sam-demo-bucket",

--- a/tests/translator/output/basic_layer.json
+++ b/tests/translator/output/basic_layer.json
@@ -10,7 +10,6 @@
   "Resources": {
     "LayerWithCondition7c655e10ea": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -23,7 +22,6 @@
     }, 
     "MinimalLayer0c7f96cce7": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -35,7 +33,6 @@
     }, 
     "CompleteLayer5d71a60e81": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -53,7 +50,6 @@
     }, 
     "LayerWithContentUriObjectbdbf1b82ac": {
       "DeletionPolicy": "Delete", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/function_event_conditions.json
+++ b/tests/translator/output/function_event_conditions.json
@@ -316,7 +316,6 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Condition": "MyCondition",
       "Properties": {

--- a/tests/translator/output/function_with_alias.json
+++ b/tests/translator/output/function_with_alias.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "Description": "sam-testing",

--- a/tests/translator/output/function_with_alias_and_code_sha256.json
+++ b/tests/translator/output/function_with_alias_and_code_sha256.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MinimalFunctionVersion6b86b273ff": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "Description": "sam-testing",

--- a/tests/translator/output/function_with_alias_and_event_sources.json
+++ b/tests/translator/output/function_with_alias_and_event_sources.json
@@ -360,7 +360,6 @@
     },
     "MyAwesomeFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_alias_intrinsics.json
+++ b/tests/translator/output/function_with_alias_intrinsics.json
@@ -8,7 +8,6 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_custom_codedeploy_deployment_preference.json
+++ b/tests/translator/output/function_with_custom_codedeploy_deployment_preference.json
@@ -59,7 +59,6 @@
     }, 
     "CustomWithFindInMapVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -205,7 +204,6 @@
     }, 
     "CustomWithConditionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -244,7 +242,6 @@
     }, 
     "CustomWithCondition2Version640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -306,7 +303,6 @@
     }, 
     "NormalWithRefVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -433,7 +429,6 @@
     }, 
     "CustomWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -596,7 +591,6 @@
     }, 
     "NormalWithSubVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -819,7 +813,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_custom_conditional_codedeploy_deployment_preference.json
+++ b/tests/translator/output/function_with_custom_conditional_codedeploy_deployment_preference.json
@@ -140,7 +140,6 @@
     }, 
     "HelloWorldFunctionVersionfb53d5c2e6": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_and_custom_role.json
+++ b/tests/translator/output/function_with_deployment_and_custom_role.json
@@ -102,7 +102,6 @@
     }, 
     "FunctionWithRoleVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -210,7 +209,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_no_service_role.json
+++ b/tests/translator/output/function_with_deployment_no_service_role.json
@@ -86,7 +86,6 @@
     }, 
     "OtherFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -187,7 +186,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_preference.json
+++ b/tests/translator/output/function_with_deployment_preference.json
@@ -146,7 +146,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_preference_all_parameters.json
+++ b/tests/translator/output/function_with_deployment_preference_all_parameters.json
@@ -205,7 +205,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_preference_from_parameters.json
+++ b/tests/translator/output/function_with_deployment_preference_from_parameters.json
@@ -219,7 +219,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_deployment_preference_multiple_combinations.json
+++ b/tests/translator/output/function_with_deployment_preference_multiple_combinations.json
@@ -188,7 +188,6 @@
     }, 
     "MinimalFunctionWithMinimalDeploymentPreferenceVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -304,7 +303,6 @@
     }, 
     "MinimalFunctionWithDeploymentPreferenceWithHooksAndAlarmsVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -378,7 +376,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_disabled_deployment_preference.json
+++ b/tests/translator/output/function_with_disabled_deployment_preference.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_event_dest_basic.json
+++ b/tests/translator/output/function_with_event_dest_basic.json
@@ -138,7 +138,6 @@
     }, 
     "MyTestFunctionVersiondaf9da458d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/function_with_layers.json
+++ b/tests/translator/output/function_with_layers.json
@@ -28,7 +28,6 @@
     }, 
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/function_with_many_layers.json
+++ b/tests/translator/output/function_with_many_layers.json
@@ -2,7 +2,6 @@
   "Resources": {
     "MyLayera5167acaba": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/function_with_resource_refs.json
+++ b/tests/translator/output/function_with_resource_refs.json
@@ -159,7 +159,6 @@
     }, 
     "MinimalFunctionVersion640128d35d": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/globals_for_function.json
+++ b/tests/translator/output/globals_for_function.json
@@ -223,7 +223,6 @@
     }, 
     "FunctionWithOverridesVersion096ed3b52b": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {
@@ -233,7 +232,6 @@
     }, 
     "MinimalFunctionVersion0a06fc8fb1": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::Version", 
       "Properties": {
         "FunctionName": {

--- a/tests/translator/output/layers_all_properties.json
+++ b/tests/translator/output/layers_all_properties.json
@@ -66,7 +66,6 @@
     }, 
     "MyLayerd04062b365": {
       "DeletionPolicy": "Delete", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {
@@ -78,7 +77,6 @@
     }, 
     "MyLayerWithANamefda8c9ec8c": {
       "DeletionPolicy": "Retain", 
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion", 
       "Properties": {
         "Content": {

--- a/tests/translator/output/layers_with_intrinsics.json
+++ b/tests/translator/output/layers_with_intrinsics.json
@@ -15,7 +15,6 @@
   "Resources": {
     "LayerWithNameIntrinsiccf8baed8b9": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -27,7 +26,6 @@
     },
     "LayerWithRefNameIntrinsicRegion32bf7198a5": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -39,7 +37,6 @@
     },
     "LayerWithSubNameIntrinsicRegiond71326de24": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -53,7 +50,6 @@
     },
     "LayerWithRuntimesIntrinsic1a006faa85": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -68,7 +64,6 @@
     },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Type": "AWS::Lambda::LayerVersion",
       "Properties": {
         "Content": {
@@ -82,7 +77,6 @@
     "LayerWithSubNameIntrinsic6e9b477102": {
       "Type": "AWS::Lambda::LayerVersion",
       "DeletionPolicy": "Retain",
-      "UpdateReplacePolicy": "Delete",
       "Properties": {
         "Content": {
           "S3Bucket": "sam-demo-bucket",


### PR DESCRIPTION
This reverts commit 842c731c1d71409a27bc8aa9519fc31e1b266356.

*Issue #, if available:*
This commit is causing redeployments to Lambda:LayerVersion and Lambda:Version resources

*Description of changes:*
Rolling back this commit from v1.23.0 release

*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
