### PR TITLE
fix: resource policy generation for {path+}

### DIFF
--- a/samtranslator/swagger/swagger.py
+++ b/samtranslator/swagger/swagger.py
@@ -1144,4 +1144,5 @@ class SwaggerEditor(object):
 
     @staticmethod
     def get_path_without_trailing_slash(path):
-        return re.sub(r"{([a-zA-Z0-9._-]+|proxy\+)}", "*", path)
+        # convert greedy paths to such as {greedy+}, {proxy+} to "*"
+        return re.sub(r"{([a-zA-Z0-9._-]+|[a-zA-Z0-9._-]+\+|proxy\+)}", "*", path)

--- a/tests/model/eventsources/test_api_event_source.py
+++ b/tests/model/eventsources/test_api_event_source.py
@@ -52,6 +52,23 @@ class ApiEventSource(TestCase):
         self.assertEqual(arn, "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo")
 
     @patch("boto3.session.Session.region_name", "eu-west-2")
+    def test_get_permission_with_path_parameter_to_any_path(self):
+        self.api_event_source.Path = "/foo/{userId+}"
+        cfn = self.api_event_source.to_cloudformation(function=self.func, explicit_api={})
+
+        perm = cfn[0]
+        self.assertIsInstance(perm, LambdaPermission)
+
+        try:
+            arn = self._extract_path_from_arn("{}PermissionProd".format(self.logical_id), perm)
+        except AttributeError:
+            self.fail("Permission class isn't valid")
+
+        self.assertEqual(
+            arn, "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${__ApiId__}/${__Stage__}/GET/foo/*"
+        )
+
+    @patch("boto3.session.Session.region_name", "eu-west-2")
     def test_get_permission_with_path_parameter(self):
         self.api_event_source.Path = "/foo/{userId}/bar"
         cfn = self.api_event_source.to_cloudformation(function=self.func, explicit_api={})


### PR DESCRIPTION
Why is this change necessary?

* To transfrom the arn in the api gateway resource policy to be "*"
instead of the name of the path itself.

How does it address the issue?

* Allow to address the appropriate resource.

What side effects does this change have?

* None that are known at this point.

*Issue #, if available:*

https://github.com/awslabs/serverless-application-model/issues/1549

*Description of changes:*

* Transform path of kinds, {path+}, {proxy+} into "*"

*Description of how you validated changes:*

- deployed the template without errors as referenced in https://github.com/awslabs/serverless-application-model/issues/1549

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
