### PR TITLE
chore: Exclude test modules in whl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ setup(
     url="https://github.com/awslabs/serverless-application-model",
     license="Apache License 2.0",
     # Exclude all but the code folders
-    packages=find_packages(exclude=("tests", "docs", "examples", "versions")),
+    packages=find_packages(exclude=("tests", "tests.*", "docs", "examples", "versions")),
     install_requires=read_requirements("base.txt"),
     include_package_data=True,
     extras_require={"dev": read_requirements("dev.txt")},


### PR DESCRIPTION
*Issue #, if available:*
#1595

*Description of changes:*
Exclude test modules from whl

*Description of how you validated changes:*
Built whl locally to make sure `tests.*` modules are not packaged in the whl.

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected
- [ ] Add/update example to `examples/2016-10-31`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
