### PR TITLE
Skip service role when all deploy prefs with no role are disabled

### DIFF
--- a/samtranslator/model/preferences/deployment_preference_collection.py
+++ b/samtranslator/model/preferences/deployment_preference_collection.py
@@ -76,7 +76,7 @@ class DeploymentPreferenceCollection(object):
         service role altogether.
         :return: True, if we can skip creating service role. False otherwise
         """
-        return all(preference.role for preference in self._resource_preferences.values())
+        return all(preference.role or not preference.enabled for preference in self._resource_preferences.values())
 
     def enabled_logical_ids(self):
         """

--- a/tests/translator/input/function_with_disabled_traffic_hook.yaml
+++ b/tests/translator/input/function_with_disabled_traffic_hook.yaml
@@ -1,0 +1,49 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+Description: Template with preference that does not require a new CodeDeploy Service Role
+
+Resources:
+
+  Function:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: lambda.lambda_handler
+      Role:
+        Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:role/lambda-role
+      Runtime: python3.7
+      CodeUri: s3://bucket/key
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: Linear10PercentEvery1Minute
+        Role:
+          Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:role/custom-codedeploy-servicerole
+        Hooks:
+          PreTraffic:
+            Ref: preTrafficHook
+        Events:
+          Api:
+            Type: Api
+            Properties:
+              Path: /test
+              Method: get
+
+  preTrafficHook:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: hook.lambda_handler
+      Role:
+        Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:role/lambda-role
+      Runtime: python3.7
+      CodeUri: s3://bucket/key
+      FunctionName: 'CodeDeployHook_preTrafficHook'
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Enabled: false
+        Role:
+          Fn::Sub: arn:${AWS::Partition}:iam::${AWS::AccountId}:role/custom-codedeploy-servicerole
+        Type: Linear10PercentEvery1Minute
+      Timeout: 5
+      Environment:
+        Variables:
+          NewVersion:
+            Ref: Function.Version

--- a/tests/translator/output/aws-cn/function_with_disabled_traffic_hook.json
+++ b/tests/translator/output/aws-cn/function_with_disabled_traffic_hook.json
@@ -1,0 +1,153 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Template with preference that does not require a new CodeDeploy Service Role",
+  "Resources": {
+    "Function": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "lambda.lambda_handler",
+        "Role": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/lambda-role"
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionVersionfb53d5c2e6": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "Function"
+        }
+      }
+    },
+    "FunctionAliaslive": {
+      "Type": "AWS::Lambda::Alias",
+      "UpdatePolicy": {
+        "CodeDeployLambdaAliasUpdate": {
+          "ApplicationName": {
+            "Ref": "ServerlessDeploymentApplication"
+          },
+          "DeploymentGroupName": {
+            "Ref": "FunctionDeploymentGroup"
+          },
+          "BeforeAllowTrafficHook": {
+            "Ref": "preTrafficHook"
+          }
+        }
+      },
+      "Properties": {
+        "Name": "live",
+        "FunctionName": {
+          "Ref": "Function"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionVersionfb53d5c2e6",
+            "Version"
+          ]
+        }
+      }
+    },
+    "preTrafficHook": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "FunctionName": "CodeDeployHook_preTrafficHook",
+        "Handler": "hook.lambda_handler",
+        "Role": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/lambda-role"
+        },
+        "Runtime": "python3.7",
+        "Timeout": 5,
+        "Environment": {
+          "Variables": {
+            "NewVersion": {
+              "Ref": "FunctionVersionfb53d5c2e6"
+            }
+          }
+        },
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "preTrafficHookVersion5e9ab26520": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "preTrafficHook"
+        }
+      }
+    },
+    "preTrafficHookAliaslive": {
+      "Type": "AWS::Lambda::Alias",
+      "Properties": {
+        "Name": "live",
+        "FunctionName": {
+          "Ref": "preTrafficHook"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "preTrafficHookVersion5e9ab26520",
+            "Version"
+          ]
+        }
+      }
+    },
+    "ServerlessDeploymentApplication": {
+      "Type": "AWS::CodeDeploy::Application",
+      "Properties": {
+        "ComputePlatform": "Lambda"
+      }
+    },
+    "FunctionDeploymentGroup": {
+      "Type": "AWS::CodeDeploy::DeploymentGroup",
+      "Properties": {
+        "ApplicationName": {
+          "Ref": "ServerlessDeploymentApplication"
+        },
+        "AutoRollbackConfiguration": {
+          "Enabled": true,
+          "Events": [
+            "DEPLOYMENT_FAILURE",
+            "DEPLOYMENT_STOP_ON_ALARM",
+            "DEPLOYMENT_STOP_ON_REQUEST"
+          ]
+        },
+        "DeploymentConfigName": {
+          "Fn::Sub": [
+            "CodeDeployDefault.Lambda${ConfigName}",
+            {
+              "ConfigName": "Linear10PercentEvery1Minute"
+            }
+          ]
+        },
+        "DeploymentStyle": {
+          "DeploymentType": "BLUE_GREEN",
+          "DeploymentOption": "WITH_TRAFFIC_CONTROL"
+        },
+        "ServiceRoleArn": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/custom-codedeploy-servicerole"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/aws-us-gov/function_with_disabled_traffic_hook.json
+++ b/tests/translator/output/aws-us-gov/function_with_disabled_traffic_hook.json
@@ -1,0 +1,153 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Template with preference that does not require a new CodeDeploy Service Role",
+  "Resources": {
+    "Function": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "lambda.lambda_handler",
+        "Role": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/lambda-role"
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionVersionfb53d5c2e6": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "Function"
+        }
+      }
+    },
+    "FunctionAliaslive": {
+      "Type": "AWS::Lambda::Alias",
+      "UpdatePolicy": {
+        "CodeDeployLambdaAliasUpdate": {
+          "ApplicationName": {
+            "Ref": "ServerlessDeploymentApplication"
+          },
+          "DeploymentGroupName": {
+            "Ref": "FunctionDeploymentGroup"
+          },
+          "BeforeAllowTrafficHook": {
+            "Ref": "preTrafficHook"
+          }
+        }
+      },
+      "Properties": {
+        "Name": "live",
+        "FunctionName": {
+          "Ref": "Function"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionVersionfb53d5c2e6",
+            "Version"
+          ]
+        }
+      }
+    },
+    "preTrafficHook": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "FunctionName": "CodeDeployHook_preTrafficHook",
+        "Handler": "hook.lambda_handler",
+        "Role": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/lambda-role"
+        },
+        "Runtime": "python3.7",
+        "Timeout": 5,
+        "Environment": {
+          "Variables": {
+            "NewVersion": {
+              "Ref": "FunctionVersionfb53d5c2e6"
+            }
+          }
+        },
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "preTrafficHookVersion5e9ab26520": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "preTrafficHook"
+        }
+      }
+    },
+    "preTrafficHookAliaslive": {
+      "Type": "AWS::Lambda::Alias",
+      "Properties": {
+        "Name": "live",
+        "FunctionName": {
+          "Ref": "preTrafficHook"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "preTrafficHookVersion5e9ab26520",
+            "Version"
+          ]
+        }
+      }
+    },
+    "ServerlessDeploymentApplication": {
+      "Type": "AWS::CodeDeploy::Application",
+      "Properties": {
+        "ComputePlatform": "Lambda"
+      }
+    },
+    "FunctionDeploymentGroup": {
+      "Type": "AWS::CodeDeploy::DeploymentGroup",
+      "Properties": {
+        "ApplicationName": {
+          "Ref": "ServerlessDeploymentApplication"
+        },
+        "AutoRollbackConfiguration": {
+          "Enabled": true,
+          "Events": [
+            "DEPLOYMENT_FAILURE",
+            "DEPLOYMENT_STOP_ON_ALARM",
+            "DEPLOYMENT_STOP_ON_REQUEST"
+          ]
+        },
+        "DeploymentConfigName": {
+          "Fn::Sub": [
+            "CodeDeployDefault.Lambda${ConfigName}",
+            {
+              "ConfigName": "Linear10PercentEvery1Minute"
+            }
+          ]
+        },
+        "DeploymentStyle": {
+          "DeploymentType": "BLUE_GREEN",
+          "DeploymentOption": "WITH_TRAFFIC_CONTROL"
+        },
+        "ServiceRoleArn": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/custom-codedeploy-servicerole"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/output/function_with_disabled_traffic_hook.json
+++ b/tests/translator/output/function_with_disabled_traffic_hook.json
@@ -1,0 +1,153 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Template with preference that does not require a new CodeDeploy Service Role",
+  "Resources": {
+    "Function": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "Handler": "lambda.lambda_handler",
+        "Role": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/lambda-role"
+        },
+        "Runtime": "python3.7",
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "FunctionVersionfb53d5c2e6": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "Function"
+        }
+      }
+    },
+    "FunctionAliaslive": {
+      "Type": "AWS::Lambda::Alias",
+      "UpdatePolicy": {
+        "CodeDeployLambdaAliasUpdate": {
+          "ApplicationName": {
+            "Ref": "ServerlessDeploymentApplication"
+          },
+          "DeploymentGroupName": {
+            "Ref": "FunctionDeploymentGroup"
+          },
+          "BeforeAllowTrafficHook": {
+            "Ref": "preTrafficHook"
+          }
+        }
+      },
+      "Properties": {
+        "Name": "live",
+        "FunctionName": {
+          "Ref": "Function"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "FunctionVersionfb53d5c2e6",
+            "Version"
+          ]
+        }
+      }
+    },
+    "preTrafficHook": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": "bucket",
+          "S3Key": "key"
+        },
+        "FunctionName": "CodeDeployHook_preTrafficHook",
+        "Handler": "hook.lambda_handler",
+        "Role": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/lambda-role"
+        },
+        "Runtime": "python3.7",
+        "Timeout": 5,
+        "Environment": {
+          "Variables": {
+            "NewVersion": {
+              "Ref": "FunctionVersionfb53d5c2e6"
+            }
+          }
+        },
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      }
+    },
+    "preTrafficHookVersion5e9ab26520": {
+      "Type": "AWS::Lambda::Version",
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "FunctionName": {
+          "Ref": "preTrafficHook"
+        }
+      }
+    },
+    "preTrafficHookAliaslive": {
+      "Type": "AWS::Lambda::Alias",
+      "Properties": {
+        "Name": "live",
+        "FunctionName": {
+          "Ref": "preTrafficHook"
+        },
+        "FunctionVersion": {
+          "Fn::GetAtt": [
+            "preTrafficHookVersion5e9ab26520",
+            "Version"
+          ]
+        }
+      }
+    },
+    "ServerlessDeploymentApplication": {
+      "Type": "AWS::CodeDeploy::Application",
+      "Properties": {
+        "ComputePlatform": "Lambda"
+      }
+    },
+    "FunctionDeploymentGroup": {
+      "Type": "AWS::CodeDeploy::DeploymentGroup",
+      "Properties": {
+        "ApplicationName": {
+          "Ref": "ServerlessDeploymentApplication"
+        },
+        "AutoRollbackConfiguration": {
+          "Enabled": true,
+          "Events": [
+            "DEPLOYMENT_FAILURE",
+            "DEPLOYMENT_STOP_ON_ALARM",
+            "DEPLOYMENT_STOP_ON_REQUEST"
+          ]
+        },
+        "DeploymentConfigName": {
+          "Fn::Sub": [
+            "CodeDeployDefault.Lambda${ConfigName}",
+            {
+              "ConfigName": "Linear10PercentEvery1Minute"
+            }
+          ]
+        },
+        "DeploymentStyle": {
+          "DeploymentType": "BLUE_GREEN",
+          "DeploymentOption": "WITH_TRAFFIC_CONTROL"
+        },
+        "ServiceRoleArn": {
+          "Fn::Sub": "arn:${AWS::Partition}:iam::${AWS::AccountId}:role/custom-codedeploy-servicerole"
+        }
+      }
+    }
+  }
+}

--- a/tests/translator/test_translator.py
+++ b/tests/translator/test_translator.py
@@ -230,6 +230,7 @@ class TestTranslatorEndToEnd(TestCase):
                 "function_with_custom_codedeploy_deployment_preference",
                 "function_with_custom_conditional_codedeploy_deployment_preference",
                 "function_with_disabled_deployment_preference",
+                "function_with_disabled_traffic_hook",
                 "function_with_deployment_preference",
                 "function_with_deployment_preference_all_parameters",
                 "function_with_deployment_preference_from_parameters",


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/serverless-application-model/issues/1496

*Description of changes:*
This PR modifies the translated templates output by sam-translator in order to make sure that no unnecessary CodeDeployServiceRole is created. If there is a deployment preference which has no role (but that's okay because it's disabled), then the role will not be created.

I went for the easiest win, which was changing the logic in `can_skip_service_role`. Do we feel like that is the best place? Alternatively, I think we could modify `self._resource_preferences.values()` so that disabled DeploymentPreferences are not present.

There are some broken unit tests on this branch but it looks like those are broken on `develop` too right now, so I don't believe that was introduced by this change.

*Description of how you validated changes:*
By running bin/translate-sam.py by hand, and by adding unit tests.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [x] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
