### PR TITLE
docs: fix link to all_policy_templates example file

### DIFF
--- a/docs/policy_templates.rst
+++ b/docs/policy_templates.rst
@@ -74,4 +74,4 @@ folder.
       - CloudWatchPutMetricPolicy: {}      
 
 .. _policy_templates.json: https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
-.. _all_policy_templates.yaml: https://github.com/awslabs/serverless-application-model/blob/develop/examples/2016-10-31/policy_templates/all_policy_templates.yaml
+.. _all_policy_templates.yaml: https://github.com/awslabs/serverless-application-model/blob/develop/tests/translator/input/all_policy_templates.yaml


### PR DESCRIPTION
*Issue #, if available:*
#1677 
*Description of changes:*
Updated URL of file in doc
*Description of how you validated changes:*

*Checklist:*

- [ ] Write/update tests
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
