### PR TITLE
fix: Allow Ref in CompatibleRuntimes property of AWS::Serverless::LayerVersion

### DIFF
--- a/samtranslator/model/lambda_.py
+++ b/samtranslator/model/lambda_.py
@@ -106,7 +106,7 @@ class LambdaLayerVersion(Resource):
         "Content": PropertyType(True, is_type(dict)),
         "Description": PropertyType(False, is_str()),
         "LayerName": PropertyType(False, is_str()),
-        "CompatibleRuntimes": PropertyType(False, list_of(is_str())),
+        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
         "LicenseInfo": PropertyType(False, is_str()),
     }
 

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -66,7 +66,7 @@ class SamFunction(SamResourceMacro):
         "VpcConfig": PropertyType(False, is_type(dict)),
         "Role": PropertyType(False, is_str()),
         "AssumeRolePolicyDocument": PropertyType(False, is_type(dict)),
-        "Policies": PropertyType(False, one_of(is_str(), list_of(one_of(is_str(), is_type(dict), is_type(dict))))),
+        "Policies": PropertyType(False, one_of(is_str(), is_type(dict), list_of(one_of(is_str(), is_type(dict))))),
         "PermissionsBoundary": PropertyType(False, is_str()),
         "Environment": PropertyType(False, dict_of(is_str(), is_type(dict))),
         "Events": PropertyType(False, dict_of(is_str(), is_type(dict))),
@@ -1015,7 +1015,7 @@ class SamLayerVersion(SamResourceMacro):
         "LayerName": PropertyType(False, one_of(is_str(), is_type(dict))),
         "Description": PropertyType(False, is_str()),
         "ContentUri": PropertyType(True, one_of(is_str(), is_type(dict))),
-        "CompatibleRuntimes": PropertyType(False, list_of(is_str())),
+        "CompatibleRuntimes": PropertyType(False, list_of(one_of(is_str(), is_type(dict)))),
         "LicenseInfo": PropertyType(False, is_str()),
         "RetentionPolicy": PropertyType(False, is_str()),
     }
@@ -1120,7 +1120,7 @@ class SamStateMachine(SamResourceMacro):
         "Name": PropertyType(False, is_str()),
         "Type": PropertyType(False, is_str()),
         "Tags": PropertyType(False, is_type(dict)),
-        "Policies": PropertyType(False, one_of(is_str(), list_of(one_of(is_str(), is_type(dict), is_type(dict))))),
+        "Policies": PropertyType(False, one_of(is_str(), is_type(dict), list_of(one_of(is_str(), is_type(dict))))),
     }
     event_resolver = ResourceTypeResolver(samtranslator.model.stepfunctions.events,)
 

--- a/tests/translator/input/layers_with_intrinsics.yaml
+++ b/tests/translator/input/layers_with_intrinsics.yaml
@@ -7,6 +7,9 @@ Parameters:
     Default: MIT-0 License
   LayerRuntimeList:
     Type: CommaDelimitedList
+  LayerRuntimeRefString:
+    Type: String
+    Default: SomeRuntimeName
 
 Resources:
   LayerWithLicenseIntrinsic:
@@ -21,6 +24,21 @@ Resources:
       ContentUri: s3://sam-demo-bucket/layer.zip
       CompatibleRuntimes:
         Ref: LayerRuntimeList
+
+  LayerWithSingleListRefRuntimesIntrinsic:
+    Type: 'AWS::Serverless::LayerVersion'
+    Properties:
+      ContentUri: s3://sam-demo-bucket/layer.zip
+      CompatibleRuntimes:
+        - Ref: LayerRuntimeRefString
+
+  LayerWithMixedListRefRuntimesIntrinsic:
+    Type: 'AWS::Serverless::LayerVersion'
+    Properties:
+      ContentUri: s3://sam-demo-bucket/layer.zip
+      CompatibleRuntimes:
+        - Ref: LayerRuntimeString
+        - 'SomeRuntimeNameString'
 
   LayerWithNameIntrinsic:
     Type: AWS::Serverless::LayerVersion
@@ -45,4 +63,5 @@ Resources:
     Properties:
       ContentUri: s3://sam-demo-bucket/layer.zip
       LayerName: !Sub 'layer-${AWS::Region}'
+
 

--- a/tests/translator/output/aws-cn/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-cn/layers_with_intrinsics.json
@@ -10,6 +10,10 @@
     "LayerNameParam": {
       "Default": "SomeLayerName",
       "Type": "String"
+    },
+    "LayerRuntimeRefString": {
+      "Default": "SomeRuntimeName",
+      "Type": "String"
     }
   },
   "Resources": {
@@ -61,6 +65,39 @@
           "Ref": "LayerRuntimeList"
         }
       }
+    },
+    "LayerWithSingleListRefRuntimesIntrinsic9d7a72f24a": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "CompatibleRuntimes": [
+          {
+            "Ref": "LayerRuntimeRefString"
+          }
+        ],
+        "Content": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "layer.zip"
+        },
+        "LayerName": "LayerWithSingleListRefRuntimesIntrinsic"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    },
+    "LayerWithMixedListRefRuntimesIntrinsic71fd80f592": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "CompatibleRuntimes": [
+          {
+            "Ref": "LayerRuntimeString"
+          },
+          "SomeRuntimeNameString"
+        ],
+        "Content": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "layer.zip"
+        },
+        "LayerName": "LayerWithMixedListRefRuntimesIntrinsic"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
     },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
       "DeletionPolicy": "Retain",

--- a/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
+++ b/tests/translator/output/aws-us-gov/layers_with_intrinsics.json
@@ -10,6 +10,10 @@
     "LayerNameParam": {
       "Default": "SomeLayerName",
       "Type": "String"
+    },
+    "LayerRuntimeRefString": {
+      "Default": "SomeRuntimeName",
+      "Type": "String"
     }
   },
   "Resources": {
@@ -61,6 +65,39 @@
           "Ref": "LayerRuntimeList"
         }
       }
+    },
+    "LayerWithSingleListRefRuntimesIntrinsic9d7a72f24a": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "CompatibleRuntimes": [
+          {
+            "Ref": "LayerRuntimeRefString"
+          }
+        ],
+        "Content": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "layer.zip"
+        },
+        "LayerName": "LayerWithSingleListRefRuntimesIntrinsic"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    },
+    "LayerWithMixedListRefRuntimesIntrinsic71fd80f592": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "CompatibleRuntimes": [
+          {
+            "Ref": "LayerRuntimeString"
+          },
+          "SomeRuntimeNameString"
+        ],
+        "Content": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "layer.zip"
+        },
+        "LayerName": "LayerWithMixedListRefRuntimesIntrinsic"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
     },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
       "DeletionPolicy": "Retain",

--- a/tests/translator/output/layers_with_intrinsics.json
+++ b/tests/translator/output/layers_with_intrinsics.json
@@ -10,6 +10,10 @@
     "LayerNameParam": {
       "Default": "SomeLayerName",
       "Type": "String"
+    },
+    "LayerRuntimeRefString": {
+      "Default": "SomeRuntimeName",
+      "Type": "String"
     }
   },
   "Resources": {
@@ -61,6 +65,39 @@
           "Ref": "LayerRuntimeList"
         }
       }
+    },
+    "LayerWithSingleListRefRuntimesIntrinsic9d7a72f24a": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "CompatibleRuntimes": [
+          {
+            "Ref": "LayerRuntimeRefString"
+          }
+        ],
+        "Content": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "layer.zip"
+        },
+        "LayerName": "LayerWithSingleListRefRuntimesIntrinsic"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
+    },
+    "LayerWithMixedListRefRuntimesIntrinsic71fd80f592": {
+      "DeletionPolicy": "Retain",
+      "Properties": {
+        "CompatibleRuntimes": [
+          {
+            "Ref": "LayerRuntimeString"
+          },
+          "SomeRuntimeNameString"
+        ],
+        "Content": {
+          "S3Bucket": "sam-demo-bucket",
+          "S3Key": "layer.zip"
+        },
+        "LayerName": "LayerWithMixedListRefRuntimesIntrinsic"
+      },
+      "Type": "AWS::Lambda::LayerVersion"
     },
     "LayerWithLicenseIntrinsic965c8d0c9b": {
       "DeletionPolicy": "Retain",


### PR DESCRIPTION


*Issue #, if available:*
#809 

*Description of changes:*
Allow intrinsics/objects in property "CompatibleRuntimes".

*Description of how you validated changes:*
Updated and verified test cases in TestTranslatorEndToEnd.

*Checklist:*

- [x] Write/update tests
- [x] `make pr` passes
- [ ] Update documentation
- [x] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
