### PR TITLE
fix: Load the sub schemas in a store instead of using file: in $ref

### DIFF
--- a/samtranslator/validator/sam_schema/definitions/api.json
+++ b/samtranslator/validator/sam_schema/definitions/api.json
@@ -18,13 +18,13 @@
         "additionalProperties": false,
         "properties": {
           "Condition": {
-            "$ref": "file:common.json#definitions/Condition"
+            "$ref": "common.json#definitions/Condition"
           },
           "DeletionPolicy": {
-            "$ref": "file:common.json#definitions/DeletionPolicy"
+            "$ref": "common.json#definitions/DeletionPolicy"
           },
           "DependsOn": {
-            "$ref": "file:common.json#definitions/DependsOn"
+            "$ref": "common.json#definitions/DependsOn"
           },
           "Metadata": {
             "type": "object"
@@ -33,7 +33,7 @@
             "additionalProperties": false,
             "properties": {
               "AccessLogSetting": {
-                "$ref": "file:cfn.json#definitions/AWS::ApiGateway::Stage.AccessLogSetting"
+                "$ref": "cfn.json#definitions/AWS::ApiGateway::Stage.AccessLogSetting"
               },
               "Auth": {
                 "$ref": "#definitions/AWS::Serverless::Api.Auth"
@@ -63,7 +63,7 @@
                 ]
               },
               "CanarySetting": {
-                "$ref": "file:cfn.json#definitions/AWS::ApiGateway::Stage.CanarySetting"
+                "$ref": "cfn.json#definitions/AWS::ApiGateway::Stage.CanarySetting"
               },
               "Cors": {
                 "if": {
@@ -105,7 +105,7 @@
                 "$ref": "#definitions/AWS::Serverless::Api.EndpointConfiguration"
               },
               "GatewayResponses": {
-                "$ref": "file:common.json#definitions/GatewayResponses",
+                "$ref": "common.json#definitions/GatewayResponses",
                 "references": [
                   "https://docs.aws.amazon.com/apigateway/api-reference/resource/gateway-response/"
                 ]
@@ -116,7 +116,7 @@
                 },
                 "then": {
                   "items": {
-                    "$ref": "file:cfn.json#definitions/AWS::ApiGateway::Stage.MethodSetting"
+                    "$ref": "cfn.json#definitions/AWS::ApiGateway::Stage.MethodSetting"
                   }
                 },
                 "type": [
@@ -157,7 +157,7 @@
                 ]
               },
               "Tags": {
-                "$ref": "file:common.json#definitions/TagsMap"
+                "$ref": "common.json#definitions/TagsMap"
               },
               "TracingEnabled": {
                 "type": [
@@ -191,10 +191,10 @@
             "const": "AWS::Serverless::Api"
           },
           "UpdatePolicy": {
-            "$ref": "file:common.json#definitions/UpdatePolicy"
+            "$ref": "common.json#definitions/UpdatePolicy"
           },
           "UpdateReplacePolicy": {
-            "$ref": "file:common.json#definitions/UpdateReplacePolicy"
+            "$ref": "common.json#definitions/UpdateReplacePolicy"
           }
         },
         "required": [
@@ -222,13 +222,13 @@
           ]
         },
         "Quota": {
-          "$ref": "file:cfn.json#definitions/AWS::ApiGateway::UsagePlan.QuotaSettings"
+          "$ref": "cfn.json#definitions/AWS::ApiGateway::UsagePlan.QuotaSettings"
         },
         "Tags": {
-          "$ref": "file:common.json#definitions/TagsList"
+          "$ref": "common.json#definitions/TagsList"
         },
         "Throttle": {
-          "$ref": "file:cfn.json#definitions/AWS::ApiGateway::UsagePlan.ThrottleSettings"
+          "$ref": "cfn.json#definitions/AWS::ApiGateway::UsagePlan.ThrottleSettings"
         },
         "UsagePlanName": {
           "type": [
@@ -433,7 +433,7 @@
           "type": "string"
         },
         "MutualTlsAuthentication": {
-          "$ref": "file:cfn.json#definitions/AWS::ApiGatewayV2::DomainName.MutualTlsAuthentication"
+          "$ref": "cfn.json#definitions/AWS::ApiGatewayV2::DomainName.MutualTlsAuthentication"
         },
         "Route53": {
           "$ref": "#definitions/AWS::Serverless::Api.Route53Configuration"

--- a/samtranslator/validator/sam_schema/schema_new.json
+++ b/samtranslator/validator/sam_schema/schema_new.json
@@ -53,7 +53,7 @@
       "maxProperties": 50,
       "patternProperties": {
         "^[a-zA-Z0-9]+$": {
-          "$ref": "file:definitions/parameter.json#/definitions/Parameter"
+          "$ref": "parameter.json#/definitions/Parameter"
         }
       },
       "type": "object"
@@ -64,7 +64,7 @@
         "^[a-zA-Z0-9]+$": {
           "allOf": [
             {
-              "$ref": "file:definitions/api.json#/definitions/AWS::Serverless::Api"
+              "$ref": "api.json#/definitions/AWS::Serverless::Api"
             },
             {
               "if": {


### PR DESCRIPTION
**Issue #, if available:**


**Description of changes:**
Using `file:` in `$ref` can lead to issues when using the library from the CLI on a Windows machine where path separators are different.

Instead, we load the sub schemas into a store that we pass to the RefResolver. 

*Description of how you validated changes:*
Unit tests + integrate with CLI on AppVeyor Ubuntu + Windows

*Checklist:*

- [ ] Add/update tests using:
    - [ ] Correct values
    - [ ] Bad/wrong values (None, empty, wrong type, length, etc.)
    - [ ] [Intrinsic Functions](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html)
- [ ] `make pr` passes
- [ ] Update documentation
- [ ] Verify transformed template deploys and application functions as expected

*Examples?*

Please reach out in the comments, if you want to add an example. Examples will be 
added to `sam init` through https://github.com/awslabs/aws-sam-cli-app-templates/

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
