### PR TITLE
test: update integ tests to nodejs22.x

### DIFF
--- a/integration/resources/templates/combination/api_with_authorizer_override_api_auth.yaml
+++ b/integration/resources/templates/combination/api_with_authorizer_override_api_auth.yaml
@@ -51,14 +51,14 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       InlineCode: |
-        exports.handler = async (event, context, callback) => {
+        exports.handler = async (event, context) => {
           return {
             statusCode: 200,
             body: 'Success'
           }
         }
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs22.x
       Events:
         LambdaRequest:
           Type: Api
@@ -94,9 +94,9 @@ Resources:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs16.x
+      Runtime: nodejs22.x
       InlineCode: |
-        exports.handler = async (event, context, callback) => {
+        exports.handler = async (event, context) => {
           const auth = event.queryStringParameters.authorization
           const policyDocument = {
             Version: '2012-10-17',

--- a/integration/resources/templates/combination/connector_appsync_to_eventbus.yaml
+++ b/integration/resources/templates/combination/connector_appsync_to_eventbus.yaml
@@ -117,7 +117,7 @@ Resources:
           API_KEY: !GetAtt ApiKey.ApiKey
           GRAPHQL_URL: !GetAtt AppSyncApi.GraphQLUrl
           EventBusName: !Ref EventBus
-      Runtime: nodejs16.x
+      Runtime: nodejs22.x
       Handler: index.handler
       InlineCode: |
         const https = require("https");

--- a/integration/resources/templates/combination/intrinsics_serverless_function.yaml
+++ b/integration/resources/templates/combination/intrinsics_serverless_function.yaml
@@ -44,7 +44,7 @@ Resources:
         Fn::Sub: ['${filename}.handler', filename: index]
 
       Runtime:
-        Fn::Join: ['', [nodejs, 16.x]]
+        Fn::Join: ['', [nodejs, 22.x]]
 
       Role:
         Fn::GetAtt: [MyNewRole, Arn]


### PR DESCRIPTION
### Issue #, if available

### Description of changes
- Update integration tests to nodejs22.x, because it's deprecated. Even though the creation is still allowed, it might not be available in newer regions. 
- We should still update the unit tests, but integ tests are actually running, so they have higher priority.

### Description of how you validated changes
```
pytest --no-cov integration/combination/test_intrinsic_function_support.py -k "test_serverless_function"
pytest --no-cov integration/combination/test_connectors.py -k "appsync" -k "eventbus"
pytest --no-cov integration/combination/test_api_with_authorizer_override_api_auth.py
```

### Checklist

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
