### PR TITLE
test: ignore Boto3 deprecation warning in Python3.9

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -22,3 +22,5 @@ filterwarnings =
     ignore::DeprecationWarning:urllib3.*:
     # https://github.com/boto/boto3/issues/3889
     ignore:datetime.datetime.utcnow
+    # Boto3 will stop supporting Python3.9 starting April 29, 2026
+    ignore:Boto3 will no longer support Python 3.9:boto3.exceptions.PythonDeprecationWarning


### PR DESCRIPTION
### Issue #, if available

### Description of changes

### Description of how you validated changes

### Checklist

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
