### PR TITLE
fix(lmi): exclude None values from CapacityProvider ScalingConfig and InstanceRequirements

### DIFF
--- a/samtranslator/model/capacity_provider/generators.py
+++ b/samtranslator/model/capacity_provider/generators.py
@@ -133,13 +133,13 @@ class CapacityProviderGenerator:
         """
         instance_requirements = {}
 
-        if "Architectures" in self.instance_requirements:
+        if self.instance_requirements.get("Architectures") is not None:
             instance_requirements["Architectures"] = self.instance_requirements["Architectures"]
 
-        if "AllowedTypes" in self.instance_requirements:
+        if self.instance_requirements.get("AllowedTypes") is not None:
             instance_requirements["AllowedInstanceTypes"] = self.instance_requirements["AllowedTypes"]
 
-        if "ExcludedTypes" in self.instance_requirements:
+        if self.instance_requirements.get("ExcludedTypes") is not None:
             instance_requirements["ExcludedInstanceTypes"] = self.instance_requirements["ExcludedTypes"]
 
         return instance_requirements
@@ -150,11 +150,11 @@ class CapacityProviderGenerator:
         """
         scaling_config = {}
 
-        if "MaxVCpuCount" in self.scaling_config:
+        if self.scaling_config.get("MaxVCpuCount") is not None:
             scaling_config["MaxVCpuCount"] = self.scaling_config["MaxVCpuCount"]
 
         # Handle AverageCPUUtilization structure
-        if "AverageCPUUtilization" in self.scaling_config:
+        if self.scaling_config.get("AverageCPUUtilization") is not None:
             scaling_config["ScalingMode"] = "Manual"
             scaling_policies = []
 

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1504,7 +1504,7 @@ class SamCapacityProvider(SamResourceMacro):
             instance_requirements=(
                 model.InstanceRequirements.dict(exclude_none=True) if model.InstanceRequirements else None
             ),
-            scaling_config=model.ScalingConfig.dict() if model.ScalingConfig else None,
+            scaling_config=model.ScalingConfig.dict(exclude_none=True) if model.ScalingConfig else None,
             kms_key_arn=passthrough_value(model.KMSKeyArn),
             depends_on=self.depends_on,
             resource_attributes=self.resource_attributes,

--- a/tests/translator/input/capacity_provider_full.yaml
+++ b/tests/translator/input/capacity_provider_full.yaml
@@ -26,3 +26,35 @@ Resources:
         MaxVCpuCount: 10
         AverageCPUUtilization: 75.0
       KMSKeyArn: arn:aws:kms:us-east-1:123456789012:key/abcd1234-ef56-gh78-ij90-klmnopqrstuv
+
+  CapacityProviderTwo:
+    Type: AWS::Serverless::CapacityProvider
+    Properties:
+      CapacityProviderName: customized-capacity-provider
+      VpcConfig:
+        SecurityGroupIds:
+        - sg-12345678
+        - sg-87654321
+        SubnetIds:
+        - subnet-12345678
+      ScalingConfig:
+        AverageCPUUtilization: 75.0
+      KMSKeyArn: arn:aws:kms:us-east-1:123456789012:key/abcd1234-ef56-gh78-ij90-klmnopqrstuv
+
+  PartialCapacityProviderThree:
+    Type: AWS::Serverless::CapacityProvider
+    Properties:
+      VpcConfig:
+        SecurityGroupIds:
+        - sg-12345678
+        SubnetIds:
+        - subnet-12345678
+      Tags:
+        Team: Tooling
+      PropagateTags: false
+      InstanceRequirements:
+        AllowedTypes:
+        - c5.xlarge
+      ScalingConfig:
+        MaxVCpuCount: 10
+      KMSKeyArn: arn:aws:kms:us-east-1:123456789012:key/abcd1234-ef56-gh78-ij90-klmnopqrstuv

--- a/tests/translator/output/aws-cn/capacity_provider_full.json
+++ b/tests/translator/output/aws-cn/capacity_provider_full.json
@@ -2,6 +2,75 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "Full CapacityProvider configuration test",
   "Resources": {
+    "CapacityProviderTwo": {
+      "Properties": {
+        "CapacityProviderName": "customized-capacity-provider",
+        "CapacityProviderScalingConfig": {
+          "ScalingMode": "Manual",
+          "ScalingPolicies": [
+            {
+              "PredefinedMetricType": "LambdaCapacityProviderAverageCPUUtilization",
+              "TargetValue": 75.0
+            }
+          ]
+        },
+        "KMSKeyArn": "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ef56-gh78-ij90-klmnopqrstuv",
+        "PermissionsConfig": {
+          "CapacityProviderOperatorRoleArn": {
+            "Fn::GetAtt": [
+              "CapacityProviderTwoOperatorRole",
+              "Arn"
+            ]
+          }
+        },
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            "sg-12345678",
+            "sg-87654321"
+          ],
+          "SubnetIds": [
+            "subnet-12345678"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::CapacityProvider"
+    },
+    "CapacityProviderTwoOperatorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/AWSLambdaManagedEC2ResourceOperator"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
     "FullCapacityProvider": {
       "Properties": {
         "CapacityProviderName": "customized-capacity-provider",
@@ -60,6 +129,77 @@
       "Type": "AWS::Lambda::CapacityProvider"
     },
     "FullCapacityProviderOperatorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-cn:iam::aws:policy/AWSLambdaManagedEC2ResourceOperator"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "PartialCapacityProviderThree": {
+      "Properties": {
+        "CapacityProviderScalingConfig": {
+          "MaxVCpuCount": 10,
+          "ScalingMode": "Auto"
+        },
+        "InstanceRequirements": {
+          "AllowedInstanceTypes": [
+            "c5.xlarge"
+          ]
+        },
+        "KMSKeyArn": "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ef56-gh78-ij90-klmnopqrstuv",
+        "PermissionsConfig": {
+          "CapacityProviderOperatorRoleArn": {
+            "Fn::GetAtt": [
+              "PartialCapacityProviderThreeOperatorRole",
+              "Arn"
+            ]
+          }
+        },
+        "Tags": [
+          {
+            "Key": "Team",
+            "Value": "Tooling"
+          },
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            "sg-12345678"
+          ],
+          "SubnetIds": [
+            "subnet-12345678"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::CapacityProvider"
+    },
+    "PartialCapacityProviderThreeOperatorRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [

--- a/tests/translator/output/aws-us-gov/capacity_provider_full.json
+++ b/tests/translator/output/aws-us-gov/capacity_provider_full.json
@@ -2,6 +2,75 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "Full CapacityProvider configuration test",
   "Resources": {
+    "CapacityProviderTwo": {
+      "Properties": {
+        "CapacityProviderName": "customized-capacity-provider",
+        "CapacityProviderScalingConfig": {
+          "ScalingMode": "Manual",
+          "ScalingPolicies": [
+            {
+              "PredefinedMetricType": "LambdaCapacityProviderAverageCPUUtilization",
+              "TargetValue": 75.0
+            }
+          ]
+        },
+        "KMSKeyArn": "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ef56-gh78-ij90-klmnopqrstuv",
+        "PermissionsConfig": {
+          "CapacityProviderOperatorRoleArn": {
+            "Fn::GetAtt": [
+              "CapacityProviderTwoOperatorRole",
+              "Arn"
+            ]
+          }
+        },
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            "sg-12345678",
+            "sg-87654321"
+          ],
+          "SubnetIds": [
+            "subnet-12345678"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::CapacityProvider"
+    },
+    "CapacityProviderTwoOperatorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/AWSLambdaManagedEC2ResourceOperator"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
     "FullCapacityProvider": {
       "Properties": {
         "CapacityProviderName": "customized-capacity-provider",
@@ -60,6 +129,77 @@
       "Type": "AWS::Lambda::CapacityProvider"
     },
     "FullCapacityProviderOperatorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws-us-gov:iam::aws:policy/AWSLambdaManagedEC2ResourceOperator"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "PartialCapacityProviderThree": {
+      "Properties": {
+        "CapacityProviderScalingConfig": {
+          "MaxVCpuCount": 10,
+          "ScalingMode": "Auto"
+        },
+        "InstanceRequirements": {
+          "AllowedInstanceTypes": [
+            "c5.xlarge"
+          ]
+        },
+        "KMSKeyArn": "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ef56-gh78-ij90-klmnopqrstuv",
+        "PermissionsConfig": {
+          "CapacityProviderOperatorRoleArn": {
+            "Fn::GetAtt": [
+              "PartialCapacityProviderThreeOperatorRole",
+              "Arn"
+            ]
+          }
+        },
+        "Tags": [
+          {
+            "Key": "Team",
+            "Value": "Tooling"
+          },
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            "sg-12345678"
+          ],
+          "SubnetIds": [
+            "subnet-12345678"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::CapacityProvider"
+    },
+    "PartialCapacityProviderThreeOperatorRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [

--- a/tests/translator/output/capacity_provider_full.json
+++ b/tests/translator/output/capacity_provider_full.json
@@ -2,6 +2,75 @@
   "AWSTemplateFormatVersion": "2010-09-09",
   "Description": "Full CapacityProvider configuration test",
   "Resources": {
+    "CapacityProviderTwo": {
+      "Properties": {
+        "CapacityProviderName": "customized-capacity-provider",
+        "CapacityProviderScalingConfig": {
+          "ScalingMode": "Manual",
+          "ScalingPolicies": [
+            {
+              "PredefinedMetricType": "LambdaCapacityProviderAverageCPUUtilization",
+              "TargetValue": 75.0
+            }
+          ]
+        },
+        "KMSKeyArn": "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ef56-gh78-ij90-klmnopqrstuv",
+        "PermissionsConfig": {
+          "CapacityProviderOperatorRoleArn": {
+            "Fn::GetAtt": [
+              "CapacityProviderTwoOperatorRole",
+              "Arn"
+            ]
+          }
+        },
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            "sg-12345678",
+            "sg-87654321"
+          ],
+          "SubnetIds": [
+            "subnet-12345678"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::CapacityProvider"
+    },
+    "CapacityProviderTwoOperatorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/AWSLambdaManagedEC2ResourceOperator"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
     "FullCapacityProvider": {
       "Properties": {
         "CapacityProviderName": "customized-capacity-provider",
@@ -60,6 +129,77 @@
       "Type": "AWS::Lambda::CapacityProvider"
     },
     "FullCapacityProviderOperatorRole": {
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Action": [
+                "sts:AssumeRole"
+              ],
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              }
+            }
+          ],
+          "Version": "2012-10-17"
+        },
+        "ManagedPolicyArns": [
+          "arn:aws:iam::aws:policy/AWSLambdaManagedEC2ResourceOperator"
+        ],
+        "Tags": [
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ]
+      },
+      "Type": "AWS::IAM::Role"
+    },
+    "PartialCapacityProviderThree": {
+      "Properties": {
+        "CapacityProviderScalingConfig": {
+          "MaxVCpuCount": 10,
+          "ScalingMode": "Auto"
+        },
+        "InstanceRequirements": {
+          "AllowedInstanceTypes": [
+            "c5.xlarge"
+          ]
+        },
+        "KMSKeyArn": "arn:aws:kms:us-east-1:123456789012:key/abcd1234-ef56-gh78-ij90-klmnopqrstuv",
+        "PermissionsConfig": {
+          "CapacityProviderOperatorRoleArn": {
+            "Fn::GetAtt": [
+              "PartialCapacityProviderThreeOperatorRole",
+              "Arn"
+            ]
+          }
+        },
+        "Tags": [
+          {
+            "Key": "Team",
+            "Value": "Tooling"
+          },
+          {
+            "Key": "lambda:createdBy",
+            "Value": "SAM"
+          }
+        ],
+        "VpcConfig": {
+          "SecurityGroupIds": [
+            "sg-12345678"
+          ],
+          "SubnetIds": [
+            "subnet-12345678"
+          ]
+        }
+      },
+      "Type": "AWS::Lambda::CapacityProvider"
+    },
+    "PartialCapacityProviderThreeOperatorRole": {
       "Properties": {
         "AssumeRolePolicyDocument": {
           "Statement": [


### PR DESCRIPTION
### Issue #, if available
https://github.com/aws/serverless-application-model/issues/3855

### Description of changes
- Fixed CapacityProvider generator to properly handle None values in ScalingConfig and InstanceRequirements
- Changed dictionary membership checks from `in` operator to `.get()` method with explicit None checks
- Updated ScalingConfig serialization in sam_resources.py to use `exclude_none=True` parameter
- This ensures that when only MaxVCpuCount is specified (without AverageCPUUtilization), the ScalingMode correctly defaults to "Auto" instead of incorrectly setting "Manual" with null target values

### Description of how you validated changes
- Added two new test cases (CapacityProviderTwo and PartialCapacityProviderThree) to `capacity_provider_full.yaml`
  - CapacityProviderTwo tests ScalingConfig with only AverageCPUUtilization (no MaxVCpuCount) → generates ScalingMode: "Manual"
  - PartialCapacityProviderThree tests ScalingConfig with only MaxVCpuCount (no AverageCPUUtilization) → generates ScalingMode: "Auto"
- Verified generated CloudFormation templates across all partitions (aws, aws-cn, aws-us-gov) correctly set ScalingMode and exclude unspecified properties
- All transform tests pass with correct output

### Checklist
- [x] Review the generative AI contribution guidelines
- [x] Adheres to the development guidelines
- [x] Add/update transform tests
  - [x] Using correct values
  - [x] Using wrong values
- [ ] Add/update integration tests

### Examples?

**Before this fix:**
```yaml
# SAM Template
Resources:
  MyCapacityProvider:
    Type: AWS::Serverless::CapacityProvider
    Properties:
      ScalingConfig:
        MaxVCpuCount: 10
        # AverageCPUUtilization intentionally omitted - should use Auto scaling
```
Generated CloudFormation would incorrectly produce:
```
"CapacityProviderScalingConfig": {
  "MaxVCpuCount": 10,
  "ScalingMode": "Manual",  // ❌ Wrong! Should be "Auto"
  "ScalingPolicies": [] // ❌ Wrong! Should not be included 
}
```

**After this fix:**
```
"CapacityProviderScalingConfig": {
  "MaxVCpuCount": 10,
  "ScalingMode": "Auto"  // ✅ Correct! Auto scaling when no CPU target specified
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.


