### PR TITLE
chore: update docs with current repository links

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ following questions in the issue that you create:
 ## Adding features to AWS SAM
 
 We welcome pull requests to add new features to AWS SAM. Take a look at the
-backlog of [Feature Requests](https://github.com/awslabs/serverless-application-specification/labels/feature-request) and pick an item that you find interesting. If the requirements have been well-scoped, feel free to make the change and send a pull request.
+backlog of [Feature Requests](https://github.com/aws/serverless-application-model/issues?q=state%3Aopen%20label%3Atype%2Ffeature) and pick an item that you find interesting. If the requirements have been well-scoped, feel free to make the change and send a pull request.
 
 If you don't find an item tracking what you have in mind, start a conversation with your plan for implementing
 the feature. When defining your feature, keep in mind that one of the core
@@ -97,7 +97,7 @@ Here are some questions that you should answer in your plan:
 
 We welcome you to use the GitHub issue tracker to report bugs or suggest features.
 
-When filing an issue, please check [existing open](https://github.com/awslabs/serverless-application-model/issues), or [recently closed](https://github.com/awslabs/serverless-application-model/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
+When filing an issue, please check [existing open](https://github.com/aws/serverless-application-model/issues), or [recently closed](https://github.com/aws/serverless-application-model/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20), issues to make sure somebody else hasn't already
 reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
 
 - A reproducible test case or series of steps
@@ -127,7 +127,7 @@ GitHub provides additional document on [forking a repository](https://help.githu
 
 ## Finding contributions to work on
 
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels ((enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any ['help wanted'](https://github.com/awslabs/PRIVATE-aws-sam-development/labels/help%20wanted) issues is a great place to start.
+Looking at the existing issues is a great way to find something to contribute on. Looking at any ['contributors/welcome'](https://github.com/aws/serverless-application-model/issues?q=state%3Aopen%20label%3Acontributors%2Fwelcome) issues is a great place to start.
 
 ## Code of Conduct
 
@@ -139,6 +139,6 @@ If you discover a potential security issue in this project we ask that you notif
 
 ## Licensing
 
-See the [LICENSE](https://github.com/awslabs/PRIVATE-aws-sam-development/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+See the [LICENSE](https://github.com/aws/serverless-application-model/blob/master/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
 
 We may ask you to sign a [Contributor License Agreement (CLA)](http://en.wikipedia.org/wiki/Contributor_License_Agreement) for larger changes.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,7 +3,7 @@
 SAM is called by the CloudFormation Service. CloudFormation recognises the `Transform: AWS::Serverless-2016-10-31` header and invokes the SAM translator. This will then take your SAM template and expand it
 into a full fledged CloudFormation Template. The CloudFormation Template that is produced from SAM is the template that is executed by CloudFormation to create/update/delete AWS resources.
 
-The entry point for SAM starts in the Translator class [here](https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/translator/translator.py#L29), where SAM iterates through the
+The entry point for SAM starts in the Translator class [here](https://github.com/aws/serverless-application-model/blob/develop/samtranslator/translator/translator.py#L45), where SAM iterates through the
 template and acts on `AWS::Serverless::*` Type Resources.
 
 # Design decisions

--- a/HOWTO.md
+++ b/HOWTO.md
@@ -3,7 +3,7 @@ The AWS Serverless Application Model (AWS SAM) allows you to easily create and
 manage resources used in your serverless application using AWS CloudFormation. 
 You can define your serverless application as a SAM template - a JSON or YAML 
 configuration file that describes Lambda function, API endpoints and
-other resources in your application. Using a variety of [nifty commands](https://github.com/awslabs/aws-sam-cli#usage), you upload this 
+other resources in your application. Using a variety of [nifty commands](https://github.com/aws/aws-sam-cli#usage), you upload this
 template to CloudFormation, which in turn creates all the individual resources and
 groups them into a *CloudFormation Stack* for ease of management. 
 When you update your SAM template, you will re-deploy the changes to 
@@ -18,10 +18,10 @@ deploy them via AWS CloudFormation.
 Check out the [latest specification](versions/2016-10-31.md) for details on how to write a SAM template
 
 
-You could also use the [aws-sam-cli](https://github.com/awslabs/aws-sam-cli) to get started 
+You could also use the [aws-sam-cli](https://github.com/aws/aws-sam-cli) to get started
 
 ```shell
-$ sam init --runtime python3.8
+$ sam init --runtime python3.14
 ```
 ## Packing Artifacts
 Before you can deploy a SAM template, you should first upload your Lambda 
@@ -108,7 +108,7 @@ $ sam deploy \
     --capabilities CAPABILITY_IAM
 ```
 
-Refer to the [cloudformation documentation](http://docs.aws.amazon.com/cli/latest/reference/cloudformation/deploy/index.html) and [samcli](https://github.com/awslabs/aws-sam-cli) for more details.
+Refer to the [cloudformation documentation](http://docs.aws.amazon.com/cli/latest/reference/cloudformation/deploy.html) and [SAM CLI](https://github.com/aws/aws-sam-cli) for more details.
 
 ## Using Intrinsic Functions
 CloudFormation provides handy functions that you can use to generate values at runtime. These are called [Intrinsic Functions](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/intrinsic-function-reference.html). Since SAM is deployed using CloudFormation, you can use these intrinsic functions within SAM as well. Here are some examples:
@@ -130,7 +130,7 @@ Resources:
         Type: AWS::Serverless::Function
         Properties:
             Handler: index.handler
-            Runtime: nodejs12.x
+            Runtime: nodejs24.x
             CodeUri:
                 # !Ref function allows you to fetch value 
                 # of parameters and other resources at runtime
@@ -158,7 +158,7 @@ Resources:
             FunctionName: !Sub "mylambda-${FunctionNameSuffix}"
 
             Handler: index.handler
-            Runtime: nodejs12.x
+            Runtime: nodejs24.x
             CodeUri: s3://bucket/key
 ```
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Resources:
   MyFunction:
     Type: AWS::Serverless::Function
     Properties:
-      Runtime: nodejs18.x
+      Runtime: nodejs24.x
       Handler: index.handler
       InlineCode: |
         exports.handler = async (event) => {
@@ -56,7 +56,7 @@ Resources:
           }
       Handler: index.handler
       Role: !GetAtt MyFunctionRole.Arn
-      Runtime: nodejs18.x
+      Runtime: nodejs24.x
       Tags:
         - Key: lambda:createdBy
           Value: SAM

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -48,4 +48,4 @@ Please note that in either case you will see metric gaps between the time CloudF
 How to deploy Lambda\@Edge functions with SAM?
 ----------------------------------------------
 
-At present, SAM doesn't support `Lambda@Edge <https://aws.amazon.com/lambda/edge/>`_ as a native event. However you can follow this example to ease deployment: `Lambda Edge Example <https://github.com/awslabs/serverless-application-model/tree/master/examples/2016-10-31/lambda_edge>`_.
+At present, SAM doesn't support `Lambda@Edge <https://aws.amazon.com/lambda/edge/>`_ as a native event. However you can follow this example to ease deployment: `Lambda Edge Example <https://github.com/aws/serverless-application-model/tree/c00b8a3/examples/2016-10-31/lambda_edge>`_.

--- a/docs/globals.rst
+++ b/docs/globals.rst
@@ -13,7 +13,7 @@ Example:
 
   Globals:
     Function:
-      Runtime: nodejs6.10
+      Runtime: nodejs24.x
       Timeout: 180
       Handler: index.handler
       Environment:
@@ -39,7 +39,7 @@ Example:
               Method: POST
 
 
-In the above example, both ``HelloWorldFunction`` and ``ThumbnailFunction`` will use nodejs6.10 runtime, 180 seconds 
+In the above example, both ``HelloWorldFunction`` and ``ThumbnailFunction`` will use nodejs24.x runtime, 180 seconds 
 timeout and index.handler Handler. ``HelloWorldFunction`` adds MESSAGE environment variable in addition to the 
 inherited TABLE_NAME. ``ThumbnailFunction`` inherits all the Globals properties and adds an API Event source.
 
@@ -168,19 +168,19 @@ Value specified in the resource will **replace** Global value
 
 Example:
 
-Runtime of ``MyFunction`` will be set to python3.6
+Runtime of ``MyFunction`` will be set to python3.14
 
 .. code:: yaml
 
   Globals:
     Function:
-      Runtime: nodejs4.3
+      Runtime: nodejs24.x
 
   Resources:
     MyFunction:
       Type: AWS::Serverless::Function
       Properties:
-        Runtime: python3.6
+        Runtime: python3.14
 
 Maps are merged
 ~~~~~~~~~~~~~~~

--- a/docs/policy_templates.rst
+++ b/docs/policy_templates.rst
@@ -73,5 +73,5 @@ folder.
     Policies:
       - CloudWatchPutMetricPolicy: {}      
 
-.. _policy_templates.json: https://github.com/awslabs/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
-.. _all_policy_templates.yaml: https://github.com/awslabs/serverless-application-model/blob/develop/tests/translator/input/all_policy_templates.yaml
+.. _policy_templates.json: https://github.com/aws/serverless-application-model/blob/develop/samtranslator/policy_templates_data/policy_templates.json
+.. _all_policy_templates.yaml: https://github.com/aws/serverless-application-model/blob/develop/tests/translator/input/all_policy_templates.yaml

--- a/docs/safe_lambda_deployments.rst
+++ b/docs/safe_lambda_deployments.rst
@@ -95,7 +95,7 @@ resource:
     Type: AWS::Serverless::Function
     Properties:
       Handler: index.handler
-      Runtime: nodejs12.x
+      Runtime: nodejs24.x
       AutoPublishAlias: live
       DeploymentPreference:
         Type: Linear10PercentEvery10Minutes
@@ -165,7 +165,7 @@ resource:
             Action:
               - "lambda:InvokeFunction"
             Resource: !GetAtt MyLambdaFunction.Arn
-      Runtime: nodejs12.x
+      Runtime: nodejs24.x
       FunctionName: 'CodeDeployHook_preTrafficHook'
       DeploymentPreference:
         Enabled: False
@@ -198,7 +198,7 @@ Traffic Shifting Configurations
 In the above example ``Linear10PercentEvery10Minutes`` is one of several preselected traffic shifting configurations 
 available in CodeDeploy. You can pick the configuration that best suits your application. See docs_ for the complete list:
 
-.. _docs: https://github.com/awslabs/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst#traffic-shifting-configurations
+.. _docs: https://github.com/aws/serverless-application-model/blob/master/docs/safe_lambda_deployments.rst#traffic-shifting-configurations
 
 - Canary10Percent30Minutes
 - Canary10Percent5Minutes
@@ -269,7 +269,7 @@ Hooks are extremely powerful because:
     Instead, use the Policies_ attribute to provide the CodeDeploy and Lambda permissions needed. The example also shows a Policy that provides access to the CodeDeploy resource that SAM automatically generates.
     Finally, use the ``FunctionName`` property to control the exact name of the Lambda function CloudFormation creates. Otherwise, CloudFormation will create your Lambda function with the Stack name and a unique ID added as part of the name.
 
-.. _Policies: https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#resource-types
+.. _Policies: https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#resource-types
 
 .. code:: yaml
 

--- a/integration/resources/templates/combination/depends_on.yaml
+++ b/integration/resources/templates/combination/depends_on.yaml
@@ -3,7 +3,7 @@ Resources:
   # Classic DependsOn case
   # http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-attribute-dependson.html#gatewayattachment
   # Template would fail to create stack without DependsOn
-  # https://github.com/awslabs/serverless-application-model/issues/68#issuecomment-276495326
+  # https://github.com/aws/serverless-application-model/issues/68#issuecomment-276495326
 
   MyLambdaFunction:
     Type: AWS::Serverless::Function

--- a/samtranslator/plugins/api/implicit_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_api_plugin.py
@@ -20,7 +20,7 @@ T = TypeVar("T", bound=Union[Type[OpenApiEditor], Type[SwaggerEditor]])
 class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
     """
     This plugin provides Implicit API shorthand syntax in the SAM Spec.
-    https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+    https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#api
 
     Implicit API syntax is just a syntactic sugar, which will be translated to AWS::Serverless::Api resource.
     This is the only event source implemented as a plugin. Other event sources are not plugins because,
@@ -305,7 +305,7 @@ class ImplicitApiPlugin(BasePlugin, Generic[T], metaclass=ABCMeta):
             else:
                 # If multiple functions with multiple different conditions reference the Implicit Api, we need to
                 # aggregate those conditions in order to conditionally create the Implicit Api. See RFC:
-                # https://github.com/awslabs/serverless-application-model/issues/758
+                # https://github.com/aws/serverless-application-model/issues/758
                 implicit_api_resource["Condition"] = self.IMPLICIT_API_CONDITION
                 self._add_combined_condition_to_template(  # type: ignore[no-untyped-call]
                     template_dict, self.IMPLICIT_API_CONDITION, all_resource_method_conditions

--- a/samtranslator/plugins/api/implicit_rest_api_plugin.py
+++ b/samtranslator/plugins/api/implicit_rest_api_plugin.py
@@ -10,7 +10,7 @@ from samtranslator.validator.value_validator import sam_expect
 class ImplicitRestApiPlugin(ImplicitApiPlugin[Type[SwaggerEditor]]):
     """
     This plugin provides Implicit API shorthand syntax in the SAM Spec.
-    https://github.com/awslabs/serverless-application-model/blob/master/versions/2016-10-31.md#api
+    https://github.com/aws/serverless-application-model/blob/master/versions/2016-10-31.md#api
 
     Implicit API syntax is just a syntactic sugar, which will be translated to AWS::Serverless::Api resource.
     This is the only event source implemented as a plugin. Other event sources are not plugins because,

--- a/samtranslator/plugins/globals/globals.py
+++ b/samtranslator/plugins/globals/globals.py
@@ -317,15 +317,15 @@ class GlobalProperties:
       ```
       Global:
         Function:
-          Runtime: nodejs
+          Runtime: nodejs24.x
 
       Function:
-         Runtime: python
+         Runtime: python3.14
       ```
 
     After processing, Function resource will contain:
       ```
-      Runtime: python
+      Runtime: python3.14
       ```
 
     **Different data types**


### PR DESCRIPTION
A lot of old links pointed to `github.com/awslabs` so they needed to be updated. Some places in the docs referenced deprecated runtimes, so I updated that too.

### Issue #, if available

### Description of changes
Update repositories and runtimes in documentation and/or comments.

I did leave one link still pointing to `awslabs` [inside setup.py](https://github.com/aws/serverless-application-model/blob/develop/setup.py#L58), only because that *could* maybe affect something on the build/publish, so I prefer to get out all the things that have absolutely no impact first.

### Description of how you validated changes
- visual check.

### Checklist

- [ ] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [ ] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
