### PR TITLE
Restrict MQ security group ingress to VPC CIDR in integration test

### DIFF
--- a/integration/resources/templates/combination/function_with_mq.yaml
+++ b/integration/resources/templates/combination/function_with_mq.yaml
@@ -60,23 +60,23 @@ Resources:
       - IpProtocol: tcp
         FromPort: 8162
         ToPort: 8162
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
       - IpProtocol: tcp
         FromPort: 61617
         ToPort: 61617
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
       - IpProtocol: tcp
         FromPort: 5671
         ToPort: 5671
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
       - IpProtocol: tcp
         FromPort: 61614
         ToPort: 61614
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
       - IpProtocol: tcp
         FromPort: 8883
         ToPort: 8883
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
 
   MyLambdaExecutionRole:
     Type: AWS::IAM::Role

--- a/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
+++ b/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
@@ -60,23 +60,23 @@ Resources:
       - IpProtocol: tcp
         FromPort: 8162
         ToPort: 8162
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
       - IpProtocol: tcp
         FromPort: 61617
         ToPort: 61617
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
       - IpProtocol: tcp
         FromPort: 5671
         ToPort: 5671
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
       - IpProtocol: tcp
         FromPort: 61614
         ToPort: 61614
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
       - IpProtocol: tcp
         FromPort: 8883
         ToPort: 8883
-        CidrIp: 0.0.0.0/0
+        CidrIp: 10.0.0.0/16
 
   MyMqBroker:
     Properties:

--- a/tests/translator/input/graphqlapi_function_by_id.yaml
+++ b/tests/translator/input/graphqlapi_function_by_id.yaml
@@ -19,7 +19,7 @@ Resources:
     Properties:
       ApiId: !GetAtt SuperCoolAPI.ApiId
       Code: this is my epic code
-      DataSourceName: some-cool-datasource
+      DataSourceName: someCoolDataSource
       Name: MyFunction
       Runtime:
         Name: APPSYNC_JS

--- a/tests/translator/output/aws-cn/graphqlapi_function_by_id.json
+++ b/tests/translator/output/aws-cn/graphqlapi_function_by_id.json
@@ -9,7 +9,7 @@
           ]
         },
         "Code": "this is my epic code",
-        "DataSourceName": "some-cool-datasource",
+        "DataSourceName": "someCoolDataSource",
         "Name": "MyFunction",
         "Runtime": {
           "Name": "APPSYNC_JS",

--- a/tests/translator/output/aws-us-gov/graphqlapi_function_by_id.json
+++ b/tests/translator/output/aws-us-gov/graphqlapi_function_by_id.json
@@ -9,7 +9,7 @@
           ]
         },
         "Code": "this is my epic code",
-        "DataSourceName": "some-cool-datasource",
+        "DataSourceName": "someCoolDataSource",
         "Name": "MyFunction",
         "Runtime": {
           "Name": "APPSYNC_JS",

--- a/tests/translator/output/graphqlapi_function_by_id.json
+++ b/tests/translator/output/graphqlapi_function_by_id.json
@@ -9,7 +9,7 @@
           ]
         },
         "Code": "this is my epic code",
-        "DataSourceName": "some-cool-datasource",
+        "DataSourceName": "someCoolDataSource",
         "Name": "MyFunction",
         "Runtime": {
           "Name": "APPSYNC_JS",


### PR DESCRIPTION
The MQSecurityGroup in function_with_mq_using_autogen_role.yaml and function_with_mq.yaml was allowing ingress from 0.0.0.0/0, triggering Policy Engine violations in test account.

Since this is an integration test that only validates CloudFormation resource creation (no actual MQ message sending), restrict ingress to the companion stack VPC CIDR (10.0.0.0/16) instead of the public internet.

This prevents security groups from being flagged in Policy Engine risk assessment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
