### PR TITLE
Add proptags for codedeploy resources

### DIFF
--- a/samtranslator/model/codedeploy.py
+++ b/samtranslator/model/codedeploy.py
@@ -7,6 +7,7 @@ class CodeDeployApplication(Resource):
     property_types = {
         "ComputePlatform": GeneratedProperty(),
         "Tags": GeneratedProperty(),
+        "PropagateTags": GeneratedProperty(),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}
@@ -23,6 +24,7 @@ class CodeDeployDeploymentGroup(Resource):
         "ServiceRoleArn": GeneratedProperty(),
         "TriggerConfigurations": GeneratedProperty(),
         "Tags": GeneratedProperty(),
+        "PropagateTags": GeneratedProperty(),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}

--- a/samtranslator/model/codedeploy.py
+++ b/samtranslator/model/codedeploy.py
@@ -7,7 +7,6 @@ class CodeDeployApplication(Resource):
     property_types = {
         "ComputePlatform": GeneratedProperty(),
         "Tags": GeneratedProperty(),
-        "PropagateTags": GeneratedProperty(),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}
@@ -24,7 +23,6 @@ class CodeDeployDeploymentGroup(Resource):
         "ServiceRoleArn": GeneratedProperty(),
         "TriggerConfigurations": GeneratedProperty(),
         "Tags": GeneratedProperty(),
-        "PropagateTags": GeneratedProperty(),
     }
 
     runtime_attrs = {"name": lambda self: ref(self.logical_id)}

--- a/samtranslator/model/preferences/deployment_preference.py
+++ b/samtranslator/model/preferences/deployment_preference.py
@@ -22,6 +22,8 @@ from samtranslator.model.exceptions import InvalidResourceException
 :param enabled: Whether this deployment preference is enabled (true by default)
 :param trigger_configurations: Information about triggers associated with the deployment group. Duplicates are
     not allowed.
+:param tags: Tags to propagate to CodeDeploy resources when propagate_tags is enabled
+:param propagate_tags: Whether to propagate tags to CodeDeploy resources
 """
 DeploymentPreferenceTuple = namedtuple(
     "DeploymentPreferenceTuple",
@@ -34,6 +36,8 @@ DeploymentPreferenceTuple = namedtuple(
         "role",
         "trigger_configurations",
         "condition",
+        "tags",
+        "propagate_tags",
     ],
 )
 
@@ -46,18 +50,20 @@ class DeploymentPreference(DeploymentPreferenceTuple):
     """
 
     @classmethod
-    def from_dict(cls, logical_id, deployment_preference_dict, condition=None):  # type: ignore[no-untyped-def]
+    def from_dict(cls, logical_id, deployment_preference_dict, condition=None, tags=None, propagate_tags=False):  # type: ignore[no-untyped-def]
         """
         :param logical_id: the logical_id of the resource that owns this deployment preference
         :param deployment_preference_dict: the dict object taken from the SAM template
         :param condition: condition on this deployment preference
+        :param tags: tags from the SAM resource to propagate to CodeDeploy resources
+        :param propagate_tags: whether to propagate tags to CodeDeploy resources
         :return:
         """
         enabled = deployment_preference_dict.get("Enabled", True)
         enabled = False if enabled in ["false", "False"] else enabled
 
         if not enabled:
-            return DeploymentPreference(None, None, None, None, False, None, None, None)
+            return DeploymentPreference(None, None, None, None, False, None, None, None, None, None)
 
         if "Type" not in deployment_preference_dict:
             raise InvalidResourceException(logical_id, "'DeploymentPreference' is missing required Property 'Type'")
@@ -85,4 +91,6 @@ class DeploymentPreference(DeploymentPreferenceTuple):
             role,
             trigger_configurations,
             condition if passthrough_condition else None,
+            tags if propagate_tags and tags else None,
+            propagate_tags,
         )

--- a/samtranslator/model/preferences/deployment_preference_collection.py
+++ b/samtranslator/model/preferences/deployment_preference_collection.py
@@ -140,7 +140,7 @@ class DeploymentPreferenceCollection:
 
         merged_tags: Dict[str, Any] = {}
         for preference in self._resource_preferences.values():
-            if preference.tags:
+            if preference.enabled and preference.propagate_tags and preference.tags:
                 merged_tags.update(preference.tags)
         if merged_tags:
             codedeploy_application_resource.Tags = get_tag_list(merged_tags)
@@ -150,14 +150,6 @@ class DeploymentPreferenceCollection:
             if len(conditions) <= 1:
                 condition_name = conditions.pop()
             codedeploy_application_resource.set_resource_attribute("Condition", condition_name)
-
-        merged_tags: Dict[str, Any] = {}
-        for preference in self._resource_preferences.values():
-            if preference.enabled and preference.propagate_tags and preference.tags:
-                merged_tags.update(preference.tags)
-        if merged_tags:
-            codedeploy_application_resource.Tags = get_tag_list(merged_tags)
-
         return codedeploy_application_resource
 
     def get_codedeploy_iam_role(self) -> IAMRole:
@@ -239,9 +231,6 @@ class DeploymentPreferenceCollection:
 
         if deployment_preference.condition:
             deployment_group.set_resource_attribute("Condition", deployment_preference.condition)
-
-        if deployment_preference.tags:
-            deployment_group.Tags = get_tag_list(deployment_preference.tags)
 
         return deployment_group
 

--- a/samtranslator/model/preferences/deployment_preference_collection.py
+++ b/samtranslator/model/preferences/deployment_preference_collection.py
@@ -14,6 +14,7 @@ from samtranslator.model.intrinsics import (
     ref,
     validate_intrinsic_if_items,
 )
+from samtranslator.model.tags.resource_tagging import get_tag_list
 from samtranslator.model.update_policy import UpdatePolicy
 from samtranslator.translator.arn_generator import ArnGenerator
 
@@ -52,7 +53,14 @@ class DeploymentPreferenceCollection:
         """
         self._resource_preferences: Dict[str, Any] = {}
 
-    def add(self, logical_id: str, deployment_preference_dict: Dict[str, Any], condition: Optional[str] = None) -> None:
+    def add(
+        self,
+        logical_id: str,
+        deployment_preference_dict: Dict[str, Any],
+        condition: Optional[str] = None,
+        tags: Optional[Dict[str, Any]] = None,
+        propagate_tags: Optional[bool] = False,
+    ) -> None:
         """
         Add this deployment preference to the collection
 
@@ -60,13 +68,16 @@ class DeploymentPreferenceCollection:
         :param logical_id: logical id of the resource where this deployment preference applies
         :param deployment_preference_dict: the input SAM template deployment preference mapping
         :param condition: the condition (if it exists) on the serverless function
+        :param tags: tags from the SAM resource to propagate to CodeDeploy resources
+        :param propagate_tags: whether to propagate tags to CodeDeploy resources
         """
         if logical_id in self._resource_preferences:
             raise ValueError(f"logical_id {logical_id} previously added to this deployment_preference_collection")
 
-        self._resource_preferences[logical_id] = DeploymentPreference.from_dict(  # type: ignore[no-untyped-call]
-            logical_id, deployment_preference_dict, condition
+        deployment_pref = DeploymentPreference.from_dict(  # type: ignore[no-untyped-call]
+            logical_id, deployment_preference_dict, condition, tags, propagate_tags
         )
+        self._resource_preferences[logical_id] = deployment_pref
 
     def get(self, logical_id: str) -> DeploymentPreference:
         """
@@ -127,6 +138,13 @@ class DeploymentPreferenceCollection:
     def get_codedeploy_application(self) -> CodeDeployApplication:
         codedeploy_application_resource = CodeDeployApplication(CODEDEPLOY_APPLICATION_LOGICAL_ID)
         codedeploy_application_resource.ComputePlatform = "Lambda"
+
+        merged_tags: Dict[str, Any] = {}
+        for preference in self._resource_preferences.values():
+            if preference.tags:
+                merged_tags.update(preference.tags)
+        if merged_tags:
+            codedeploy_application_resource.Tags = get_tag_list(merged_tags)
         if self.needs_resource_condition():
             conditions = self.get_all_deployment_conditions()
             condition_name = CODE_DEPLOY_CONDITION_NAME
@@ -200,6 +218,9 @@ class DeploymentPreferenceCollection:
 
         if deployment_preference.trigger_configurations:
             deployment_group.TriggerConfigurations = deployment_preference.trigger_configurations
+
+        if deployment_preference.tags:
+            deployment_group.Tags = get_tag_list(deployment_preference.tags)
 
         if deployment_preference.condition:
             deployment_group.set_resource_attribute("Condition", deployment_preference.condition)

--- a/samtranslator/model/preferences/deployment_preference_collection.py
+++ b/samtranslator/model/preferences/deployment_preference_collection.py
@@ -74,10 +74,9 @@ class DeploymentPreferenceCollection:
         if logical_id in self._resource_preferences:
             raise ValueError(f"logical_id {logical_id} previously added to this deployment_preference_collection")
 
-        deployment_pref = DeploymentPreference.from_dict(  # type: ignore[no-untyped-call]
+        self._resource_preferences[logical_id] = DeploymentPreference.from_dict(  # type: ignore[no-untyped-call]
             logical_id, deployment_preference_dict, condition, tags, propagate_tags
         )
-        self._resource_preferences[logical_id] = deployment_pref
 
     def get(self, logical_id: str) -> DeploymentPreference:
         """
@@ -151,6 +150,14 @@ class DeploymentPreferenceCollection:
             if len(conditions) <= 1:
                 condition_name = conditions.pop()
             codedeploy_application_resource.set_resource_attribute("Condition", condition_name)
+
+        merged_tags: Dict[str, Any] = {}
+        for preference in self._resource_preferences.values():
+            if preference.enabled and preference.propagate_tags and preference.tags:
+                merged_tags.update(preference.tags)
+        if merged_tags:
+            codedeploy_application_resource.Tags = get_tag_list(merged_tags)
+
         return codedeploy_application_resource
 
     def get_codedeploy_iam_role(self) -> IAMRole:
@@ -183,6 +190,14 @@ class DeploymentPreferenceCollection:
             if len(conditions) <= 1:
                 condition_name = conditions.pop()
             iam_role.set_resource_attribute("Condition", condition_name)
+
+        merged_tags: Dict[str, Any] = {}
+        for preference in self._resource_preferences.values():
+            if preference.enabled and preference.propagate_tags and preference.tags:
+                merged_tags.update(preference.tags)
+        if merged_tags:
+            iam_role.Tags = get_tag_list(merged_tags)
+
         return iam_role
 
     def deployment_group(self, function_logical_id: str) -> CodeDeployDeploymentGroup:
@@ -224,6 +239,9 @@ class DeploymentPreferenceCollection:
 
         if deployment_preference.condition:
             deployment_group.set_resource_attribute("Condition", deployment_preference.condition)
+
+        if deployment_preference.tags:
+            deployment_group.Tags = get_tag_list(deployment_preference.tags)
 
         return deployment_group
 

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1,4 +1,4 @@
-﻿"""SAM macro definitions"""
+"""SAM macro definitions"""
 
 import copy
 import re

--- a/samtranslator/model/sam_resources.py
+++ b/samtranslator/model/sam_resources.py
@@ -1308,6 +1308,8 @@ class SamFunction(SamResourceMacro):
             self.logical_id,
             self.DeploymentPreference,
             passthrough_resource_attributes.get("Condition"),
+            self.Tags,
+            self.PropagateTags,
         )
 
         if deployment_preference_collection.get(self.logical_id).enabled:

--- a/tests/translator/input/function_with_propagate_tags_and_no_tags.yaml
+++ b/tests/translator/input/function_with_propagate_tags_and_no_tags.yaml
@@ -6,7 +6,7 @@ Resources:
         exports.handler = async () => ‘Hello World!'
       Handler: index.handler
       Runtime: nodejs18.x
-      # PropagateTags: True
+      PropagateTags: true
       AutoPublishAlias: Live
       Events:
         CWEvent:

--- a/tests/translator/input/function_with_propagate_tags_and_no_tags.yaml
+++ b/tests/translator/input/function_with_propagate_tags_and_no_tags.yaml
@@ -6,7 +6,7 @@ Resources:
         exports.handler = async () => ‘Hello World!'
       Handler: index.handler
       Runtime: nodejs18.x
-      PropagateTags: true
+      PropagateTags: True
       AutoPublishAlias: Live
       Events:
         CWEvent:

--- a/tests/translator/input/function_with_propagate_tags_and_no_tags.yaml
+++ b/tests/translator/input/function_with_propagate_tags_and_no_tags.yaml
@@ -6,7 +6,7 @@ Resources:
         exports.handler = async () => ‘Hello World!'
       Handler: index.handler
       Runtime: nodejs18.x
-      PropagateTags: True
+      PropagateTags: true
       AutoPublishAlias: Live
       Events:
         CWEvent:

--- a/tests/translator/model/preferences/test_deployment_preference.py
+++ b/tests/translator/model/preferences/test_deployment_preference.py
@@ -29,6 +29,8 @@ class TestDeploymentPreference(TestCase):
             self.role,
             self.trigger_configurations,
             None,
+            None,
+            False,
         )
 
         deployment_preference_yaml_dict = dict()
@@ -56,6 +58,8 @@ class TestDeploymentPreference(TestCase):
             self.role,
             self.trigger_configurations,
             None,
+            None,
+            False,
         )
 
         deployment_preference_yaml_dict = dict()
@@ -83,6 +87,8 @@ class TestDeploymentPreference(TestCase):
             self.role,
             self.trigger_configurations,
             self.condition,
+            None,
+            False,
         )
 
         deployment_preference_yaml_dict = dict()
@@ -102,7 +108,7 @@ class TestDeploymentPreference(TestCase):
         self.assertEqual(expected_deployment_preference, deployment_preference_from_yaml_dict)
 
     def test_from_dict_with_disabled_preference_does_not_require_other_parameters(self):
-        expected_deployment_preference = DeploymentPreference(None, None, None, None, False, None, None, None)
+        expected_deployment_preference = DeploymentPreference(None, None, None, None, False, None, None, None, None, None)
 
         deployment_preference_yaml_dict = dict()
         deployment_preference_yaml_dict["Enabled"] = False
@@ -113,7 +119,7 @@ class TestDeploymentPreference(TestCase):
         self.assertEqual(expected_deployment_preference, deployment_preference_from_yaml_dict)
 
     def test_from_dict_with_string_disabled_preference_does_not_require_other_parameters(self):
-        expected_deployment_preference = DeploymentPreference(None, None, None, None, False, None, None, None)
+        expected_deployment_preference = DeploymentPreference(None, None, None, None, False, None, None, None, None, None)
 
         deployment_preference_yaml_dict = dict()
         deployment_preference_yaml_dict["Enabled"] = "False"
@@ -124,7 +130,7 @@ class TestDeploymentPreference(TestCase):
         self.assertEqual(expected_deployment_preference, deployment_preference_from_yaml_dict)
 
     def test_from_dict_with_lowercase_string_disabled_preference_does_not_require_other_parameters(self):
-        expected_deployment_preference = DeploymentPreference(None, None, None, None, False, None, None, None)
+        expected_deployment_preference = DeploymentPreference(None, None, None, None, False, None, None, None, None, None)
 
         deployment_preference_yaml_dict = dict()
         deployment_preference_yaml_dict["Enabled"] = "false"

--- a/tests/translator/model/preferences/test_deployment_preference.py
+++ b/tests/translator/model/preferences/test_deployment_preference.py
@@ -108,7 +108,9 @@ class TestDeploymentPreference(TestCase):
         self.assertEqual(expected_deployment_preference, deployment_preference_from_yaml_dict)
 
     def test_from_dict_with_disabled_preference_does_not_require_other_parameters(self):
-        expected_deployment_preference = DeploymentPreference(None, None, None, None, False, None, None, None, None, None)
+        expected_deployment_preference = DeploymentPreference(
+            None, None, None, None, False, None, None, None, None, None
+        )
 
         deployment_preference_yaml_dict = dict()
         deployment_preference_yaml_dict["Enabled"] = False
@@ -119,7 +121,9 @@ class TestDeploymentPreference(TestCase):
         self.assertEqual(expected_deployment_preference, deployment_preference_from_yaml_dict)
 
     def test_from_dict_with_string_disabled_preference_does_not_require_other_parameters(self):
-        expected_deployment_preference = DeploymentPreference(None, None, None, None, False, None, None, None, None, None)
+        expected_deployment_preference = DeploymentPreference(
+            None, None, None, None, False, None, None, None, None, None
+        )
 
         deployment_preference_yaml_dict = dict()
         deployment_preference_yaml_dict["Enabled"] = "False"
@@ -130,7 +134,9 @@ class TestDeploymentPreference(TestCase):
         self.assertEqual(expected_deployment_preference, deployment_preference_from_yaml_dict)
 
     def test_from_dict_with_lowercase_string_disabled_preference_does_not_require_other_parameters(self):
-        expected_deployment_preference = DeploymentPreference(None, None, None, None, False, None, None, None, None, None)
+        expected_deployment_preference = DeploymentPreference(
+            None, None, None, None, False, None, None, None, None, None
+        )
 
         deployment_preference_yaml_dict = dict()
         deployment_preference_yaml_dict["Enabled"] = "false"

--- a/tests/translator/output/aws-cn/function_with_events_and_propagate_tags.json
+++ b/tests/translator/output/aws-cn/function_with_events_and_propagate_tags.json
@@ -311,7 +311,17 @@
             "DeploymentRole",
             "Arn"
           ]
-        }
+        },
+        "Tags": [
+          {
+            "Key": "Key1",
+            "Value": "Value1"
+          },
+          {
+            "Key": "Key2",
+            "Value": "Value2"
+          }
+        ]
       },
       "Type": "AWS::CodeDeploy::DeploymentGroup"
     },
@@ -520,7 +530,17 @@
     },
     "ServerlessDeploymentApplication": {
       "Properties": {
-        "ComputePlatform": "Lambda"
+        "ComputePlatform": "Lambda",
+        "Tags": [
+          {
+            "Key": "Key1",
+            "Value": "Value1"
+          },
+          {
+            "Key": "Key2",
+            "Value": "Value2"
+          }
+        ]
       },
       "Type": "AWS::CodeDeploy::Application"
     },

--- a/tests/translator/output/aws-us-gov/function_with_events_and_propagate_tags.json
+++ b/tests/translator/output/aws-us-gov/function_with_events_and_propagate_tags.json
@@ -311,7 +311,17 @@
             "DeploymentRole",
             "Arn"
           ]
-        }
+        },
+        "Tags": [
+          {
+            "Key": "Key1",
+            "Value": "Value1"
+          },
+          {
+            "Key": "Key2",
+            "Value": "Value2"
+          }
+        ]
       },
       "Type": "AWS::CodeDeploy::DeploymentGroup"
     },
@@ -520,7 +530,17 @@
     },
     "ServerlessDeploymentApplication": {
       "Properties": {
-        "ComputePlatform": "Lambda"
+        "ComputePlatform": "Lambda",
+        "Tags": [
+          {
+            "Key": "Key1",
+            "Value": "Value1"
+          },
+          {
+            "Key": "Key2",
+            "Value": "Value2"
+          }
+        ]
       },
       "Type": "AWS::CodeDeploy::Application"
     },

--- a/tests/translator/output/function_with_events_and_propagate_tags.json
+++ b/tests/translator/output/function_with_events_and_propagate_tags.json
@@ -311,7 +311,17 @@
             "DeploymentRole",
             "Arn"
           ]
-        }
+        },
+        "Tags": [
+          {
+            "Key": "Key1",
+            "Value": "Value1"
+          },
+          {
+            "Key": "Key2",
+            "Value": "Value2"
+          }
+        ]
       },
       "Type": "AWS::CodeDeploy::DeploymentGroup"
     },
@@ -520,7 +530,17 @@
     },
     "ServerlessDeploymentApplication": {
       "Properties": {
-        "ComputePlatform": "Lambda"
+        "ComputePlatform": "Lambda",
+        "Tags": [
+          {
+            "Key": "Key1",
+            "Value": "Value1"
+          },
+          {
+            "Key": "Key2",
+            "Value": "Value2"
+          }
+        ]
       },
       "Type": "AWS::CodeDeploy::Application"
     },

--- a/tests/translator/test_function_resources.py
+++ b/tests/translator/test_function_resources.py
@@ -149,7 +149,7 @@ class TestVersionsAndAliases(TestCase):
 
         deployment_preference_collection.update_policy.assert_called_once_with(self.sam_func.logical_id)
         deployment_preference_collection.add.assert_called_once_with(
-            self.sam_func.logical_id, deploy_preference_dict, None
+            self.sam_func.logical_id, deploy_preference_dict, None, None, None
         )
 
         aliases = [r.to_dict() for r in resources if r.resource_type == LambdaAlias.resource_type]
@@ -230,7 +230,7 @@ class TestVersionsAndAliases(TestCase):
 
         resources = sam_func.to_cloudformation(**kwargs)
 
-        preference_collection.add.assert_called_once_with(sam_func.logical_id, deploy_preference_dict, None)
+        preference_collection.add.assert_called_once_with(sam_func.logical_id, deploy_preference_dict, None, None, None)
         preference_collection.get.assert_called_once_with(sam_func.logical_id)
         self.intrinsics_resolver_mock.resolve_parameter_refs.assert_has_calls([call(enabled), call(None)])
         aliases = [r.to_dict() for r in resources if r.resource_type == LambdaAlias.resource_type]
@@ -330,7 +330,7 @@ class TestVersionsAndAliases(TestCase):
 
         deployment_preference_collection.update_policy.assert_called_once_with(self.sam_func.logical_id)
         deployment_preference_collection.add.assert_called_once_with(
-            self.sam_func.logical_id, deploy_preference_dict, None
+            self.sam_func.logical_id, deploy_preference_dict, None, None, None
         )
         self.intrinsics_resolver_mock.resolve_parameter_refs.assert_any_call(enabled)
 
@@ -451,7 +451,7 @@ class TestVersionsAndAliases(TestCase):
 
         deployment_preference_collection.update_policy.assert_called_once_with(self.sam_func.logical_id)
         deployment_preference_collection.add.assert_called_once_with(
-            self.sam_func.logical_id, deploy_preference_dict, "Condition1"
+            self.sam_func.logical_id, deploy_preference_dict, "Condition1", None, None
         )
 
         aliases = [r.to_dict() for r in resources if r.resource_type == LambdaAlias.resource_type]
@@ -502,7 +502,7 @@ class TestVersionsAndAliases(TestCase):
 
         deployment_preference_collection.update_policy.assert_called_once_with(self.sam_func.logical_id)
         deployment_preference_collection.add.assert_called_once_with(
-            self.sam_func.logical_id, deploy_preference_dict, "Condition1"
+            self.sam_func.logical_id, deploy_preference_dict, "Condition1", None, None
         )
 
         aliases = [r.to_dict() for r in resources if r.resource_type == LambdaAlias.resource_type]


### PR DESCRIPTION
### Issue #, if available

### Description of changes
There is currently no tag propagation on SAM generated CodeDeploy resources. This adds support for that

### Description of how you validated changes
Ran transform on template with DeploymentPreference with PropagateTags on Function.

Existing input test of `tests/translator/input/function_with_events_and_propagate_tags.yaml` does not need to be modified as it already has DeploymentPreference with PropagateTags on Function. The output should now be different to add those tags to the generated CodeDeploy resources.

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
