### PR TITLE
fix(integ): remove CapacityProviderName exceeding 64-char limit

### DIFF
--- a/integration/resources/templates/combination/function_lmi_custom.yaml
+++ b/integration/resources/templates/combination/function_lmi_custom.yaml
@@ -64,7 +64,6 @@ Resources:
   MyCapacityProvider:
     Type: AWS::Serverless::CapacityProvider
     Properties:
-      CapacityProviderName: !Sub "${AWS::StackName}-cp"
       VpcConfig:
         SubnetIds:
         - !Ref SubnetId

--- a/integration/resources/templates/combination/function_lmi_default.yaml
+++ b/integration/resources/templates/combination/function_lmi_default.yaml
@@ -28,7 +28,6 @@ Resources:
   AdvancedCapacityProvider:
     Type: AWS::Serverless::CapacityProvider
     Properties:
-      CapacityProviderName: !Sub "${AWS::StackName}-cp"
       VpcConfig:
         SubnetIds:
         - !Ref SubnetId


### PR DESCRIPTION
### Issue #, if available

N/A

### Description of changes

Removed `CapacityProviderName: !Sub "${AWS::StackName}-cp"` from integration test templates `function_lmi_custom.yaml` and `function_lmi_default.yaml`. The resolved name exceeded the 64-character limit enforced by Lambda's CapacityProvider API, causing deployment failures (e.g. `SamTranslatorLambda-sam-integ-stack-function-lmi-custom-eplzcyobezoy-cp` is 72 chars). Since `CapacityProviderName` is optional, CloudFormation will auto-generate a valid name.

### Description of how you validated changes

- Confirmed no integration test assertions depend on the `CapacityProviderName` value — the tests only use it as a lookup key via `get_physical_id_by_logical_id`, which works with auto-generated names.
- Verified both templates are syntactically valid after the change.

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
  - N/A — no transform logic changed
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)
  - Updated existing integration test templates to remove the problematic property

### Examples?

N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
