### PR TITLE
refactor: improve HttpApi authorizer validation

### DIFF
--- a/samtranslator/model/apigatewayv2.py
+++ b/samtranslator/model/apigatewayv2.py
@@ -165,54 +165,48 @@ class ApiGatewayV2Authorizer:
             return "JWT"
         return "REQUEST"
 
+    # Maps each authorizer type to the set of properties it accepts
+    ALLOWED_PROPERTIES = {
+        "JWT": {"authorization_scopes", "jwt_configuration", "id_source"},
+        "REQUEST": {
+            "function_arn",
+            "function_invoke_role",
+            "identity",
+            "authorizer_payload_format_version",
+            "enable_simple_responses",
+            "enable_function_default_permissions",
+        },
+        "AWS_IAM": set(),
+    }
+
+    # Maps internal attr name to (display name, error hint)
+    PROPERTY_DISPLAY = {
+        "authorization_scopes": ("AuthorizationScopes", "OAuth2 Authorizer"),
+        "jwt_configuration": ("JwtConfiguration", "OAuth2 Authorizer"),
+        "id_source": (
+            "IdentitySource",
+            "OAuth2 Authorizer. For Lambda Authorizer, use the 'Identity' property instead",
+        ),
+        "function_arn": ("FunctionArn", "Lambda Authorizer"),
+        "function_invoke_role": ("FunctionInvokeRole", "Lambda Authorizer"),
+        "identity": ("Identity", "Lambda Authorizer"),
+        "authorizer_payload_format_version": ("AuthorizerPayloadFormatVersion", "Lambda Authorizer"),
+        "enable_simple_responses": ("EnableSimpleResponses", "Lambda Authorizer"),
+        "enable_function_default_permissions": ("EnableFunctionDefaultPermissions", "Lambda Authorizer"),
+    }
+
     def _validate_input_parameters(self) -> None:
         authorizer_type = self._get_auth_type()
 
         if self.authorization_scopes is not None and not isinstance(self.authorization_scopes, list):
             raise InvalidResourceException(self.api_logical_id, "AuthorizationScopes must be a list.")
 
-        if self.authorization_scopes is not None and not authorizer_type == "JWT":
-            raise InvalidResourceException(
-                self.api_logical_id, "AuthorizationScopes must be defined only for OAuth2 Authorizer."
-            )
-
-        if self.jwt_configuration is not None and not authorizer_type == "JWT":
-            raise InvalidResourceException(
-                self.api_logical_id, "JwtConfiguration must be defined only for OAuth2 Authorizer."
-            )
-
-        if self.id_source is not None and not authorizer_type == "JWT":
-            raise InvalidResourceException(
-                self.api_logical_id, "IdentitySource must be defined only for OAuth2 Authorizer."
-            )
-
-        if self.function_arn is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(
-                self.api_logical_id, "FunctionArn must be defined only for Lambda Authorizer."
-            )
-
-        if self.function_invoke_role is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(
-                self.api_logical_id, "FunctionInvokeRole must be defined only for Lambda Authorizer."
-            )
-
-        if self.identity is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(self.api_logical_id, "Identity must be defined only for Lambda Authorizer.")
-
-        if self.authorizer_payload_format_version is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(
-                self.api_logical_id, "AuthorizerPayloadFormatVersion must be defined only for Lambda Authorizer."
-            )
-
-        if self.enable_simple_responses is not None and not authorizer_type == "REQUEST":
-            raise InvalidResourceException(
-                self.api_logical_id, "EnableSimpleResponses must be defined only for Lambda Authorizer."
-            )
-
-        if self.enable_function_default_permissions is not None and authorizer_type != "REQUEST":
-            raise InvalidResourceException(
-                self.api_logical_id, "EnableFunctionDefaultPermissions must be defined only for Lambda Authorizer."
-            )
+        allowed = self.ALLOWED_PROPERTIES.get(authorizer_type, set())
+        for attr, (display_name, allowed_for) in self.PROPERTY_DISPLAY.items():
+            if getattr(self, attr) is not None and attr not in allowed:
+                raise InvalidResourceException(
+                    self.api_logical_id, f"{display_name} is only supported for {allowed_for}."
+                )
 
     def _validate_jwt_authorizer(self) -> None:
         if not self.jwt_configuration:

--- a/tests/model/test_api_v2.py
+++ b/tests/model/test_api_v2.py
@@ -64,7 +64,7 @@ class TestApiGatewayV2Authorizer(TestCase):
         self.assertEqual(
             e.value.message,
             "Resource with id [logicalId] is invalid. "
-            + "AuthorizationScopes must be defined only for OAuth2 Authorizer.",
+            + "AuthorizationScopes is only supported for OAuth2 Authorizer.",
         )
 
     @mock.patch(
@@ -79,8 +79,7 @@ class TestApiGatewayV2Authorizer(TestCase):
             )
         self.assertEqual(
             e.value.message,
-            "Resource with id [logicalId] is invalid. "
-            + "JwtConfiguration must be defined only for OAuth2 Authorizer.",
+            "Resource with id [logicalId] is invalid. " + "JwtConfiguration is only supported for OAuth2 Authorizer.",
         )
 
     def test_create_authorizer_fails_with_id_source_non_oauth2(self):
@@ -92,7 +91,8 @@ class TestApiGatewayV2Authorizer(TestCase):
             )
         self.assertEqual(
             e.value.message,
-            "Resource with id [logicalId] is invalid. " + "IdentitySource must be defined only for OAuth2 Authorizer.",
+            "Resource with id [logicalId] is invalid. " + "IdentitySource is only supported for OAuth2 Authorizer."
+            " For Lambda Authorizer, use the 'Identity' property instead.",
         )
 
     def test_create_authorizer_fails_with_function_arn_non_lambda(self):
@@ -106,7 +106,7 @@ class TestApiGatewayV2Authorizer(TestCase):
             )
         self.assertEqual(
             e.value.message,
-            "Resource with id [logicalId] is invalid. " + "FunctionArn must be defined only for Lambda Authorizer.",
+            "Resource with id [logicalId] is invalid. " + "FunctionArn is only supported for Lambda Authorizer.",
         )
 
     def test_create_authorizer_fails_with_function_invoke_role_non_lambda(self):
@@ -120,8 +120,7 @@ class TestApiGatewayV2Authorizer(TestCase):
             )
         self.assertEqual(
             e.value.message,
-            "Resource with id [logicalId] is invalid. "
-            + "FunctionInvokeRole must be defined only for Lambda Authorizer.",
+            "Resource with id [logicalId] is invalid. " + "FunctionInvokeRole is only supported for Lambda Authorizer.",
         )
 
     def test_create_authorizer_fails_with_identity_non_lambda(self):
@@ -135,7 +134,7 @@ class TestApiGatewayV2Authorizer(TestCase):
             )
         self.assertEqual(
             e.value.message,
-            "Resource with id [logicalId] is invalid. " + "Identity must be defined only for Lambda Authorizer.",
+            "Resource with id [logicalId] is invalid. " + "Identity is only supported for Lambda Authorizer.",
         )
 
     def test_create_authorizer_fails_with_authorizer_payload_format_version_non_lambda(self):
@@ -150,7 +149,7 @@ class TestApiGatewayV2Authorizer(TestCase):
         self.assertEqual(
             e.value.message,
             "Resource with id [logicalId] is invalid. "
-            + "AuthorizerPayloadFormatVersion must be defined only for Lambda Authorizer.",
+            + "AuthorizerPayloadFormatVersion is only supported for Lambda Authorizer.",
         )
 
     def test_create_authorizer_fails_with_enable_simple_responses_non_lambda(self):
@@ -165,7 +164,7 @@ class TestApiGatewayV2Authorizer(TestCase):
         self.assertEqual(
             e.value.message,
             "Resource with id [logicalId] is invalid. "
-            + "EnableSimpleResponses must be defined only for Lambda Authorizer.",
+            + "EnableSimpleResponses is only supported for Lambda Authorizer.",
         )
 
     def test_create_authorizer_fails_with_enable_function_default_permissions_non_lambda(self):
@@ -180,7 +179,7 @@ class TestApiGatewayV2Authorizer(TestCase):
         self.assertEqual(
             e.value.message,
             "Resource with id [logicalId] is invalid. "
-            + "EnableFunctionDefaultPermissions must be defined only for Lambda Authorizer.",
+            + "EnableFunctionDefaultPermissions is only supported for Lambda Authorizer.",
         )
 
     @mock.patch(

--- a/tests/translator/output/error_http_api_invalid_lambda_auth.json
+++ b/tests/translator/output/error_http_api_invalid_lambda_auth.json
@@ -9,7 +9,7 @@
     "Resource with id [MyApi3] is invalid. ",
     "Property 'Authorizers.LambdaAuth.EnableFunctionDefaultPermissions' should be a boolean. ",
     "Resource with id [MyApi4] is invalid. ",
-    "EnableFunctionDefaultPermissions must be defined only for Lambda Authorizer."
+    "EnableFunctionDefaultPermissions is only supported for Lambda Authorizer."
   ],
-  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 4. Resource with id [MyApi1] is invalid. LambdaAuth Lambda Authorizer must define 'AuthorizerPayloadFormatVersion'. Resource with id [MyApi2] is invalid. LambdaAuth Lambda Authorizer must define 'FunctionArn'. Resource with id [MyApi3] is invalid. Property 'Authorizers.LambdaAuth.EnableFunctionDefaultPermissions' should be a boolean. Resource with id [MyApi4] is invalid. EnableFunctionDefaultPermissions must be defined only for Lambda Authorizer."
+  "errorMessage": "Invalid Serverless Application Specification document. Number of errors found: 4. Resource with id [MyApi1] is invalid. LambdaAuth Lambda Authorizer must define 'AuthorizerPayloadFormatVersion'. Resource with id [MyApi2] is invalid. LambdaAuth Lambda Authorizer must define 'FunctionArn'. Resource with id [MyApi3] is invalid. Property 'Authorizers.LambdaAuth.EnableFunctionDefaultPermissions' should be a boolean. Resource with id [MyApi4] is invalid. EnableFunctionDefaultPermissions is only supported for Lambda Authorizer."
 }


### PR DESCRIPTION
 ## Issue #, if available                                                                                                                                                                                            
  Close #3817                                                                                                                                                                                                            
                                                                                                                                                                                                                   
### Description of changes                                                                                                                                                                                           
  Refactor HttpApi authorizer property validation in apigatewayv2.py from repetitive if/raise blocks to a data-driven approach using two declarative dicts (ALLOWED_PROPERTIES and PROPERTY_DISPLAY). This replaces
  ~40 lines of repetitive validation with a 4-line loop, making it easier to maintain and extend when new authorizer types or properties are added.                                                                
                                                                                                                                                                                                                   
  No behavior change — same properties are blocked for the same authorizer types. The only user-facing difference is improved error messages:                                                                      
  - Before: "IdentitySource must be defined only for OAuth2 Authorizer."                                                                                                                                           
  - After: "IdentitySource is only supported for OAuth2 Authorizer. For Lambda Authorizer, use the 'Identity' property instead."                                                                                   
  The IdentitySource property is intentionally only supported for OAuth2Authorizer per the SAM schema                                                                                                              
  (https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-httpapi-oauth2authorizer.html). For LambdaAuthorizer, the `Identity`                                                
  (https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/sam-property-httpapi-lambdaauthorizationidentity.html) property (with Headers, QueryStrings, StageVariables, Context) is the     
  correct way to set identitySource. The updated error message now guides users to this.                                                                                                                           
                                                                                                                                                                                                                   
 ### Description of how you validated changes                                                                                                                                                                         
  - All 17 existing unit tests in tests/model/test_api_v2.py pass (error message strings updated to match)                                                                                                         
  - make pr passes: black, ruff, mypy --strict, cfn-lint, schema generation all clean                                                                                                                              
  - Manually deployed a REQUEST authorizer using the Identity property workaround and verified the authorizer was created with correct identitySource: ["$request.header.Authorization"] via aws apigatewayv2      
  get-authorizers                                                                                                                                                                                                  
                                                                                                                                                                                                                   
 ### Checklist                                                                                                                                                                                                        
  - [x] Review the generative AI contribution guidelines (https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)                                                               
  - [x] Adheres to the development guidelines (https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)                                                       
  - [x] Add/update transform tests (https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)                                              
  - [x] Using correct values                                                                                                                                                                                       
  - [x] Using wrong values                                                                                                                                                                                         
  - [ ] Add/update integration tests (https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)                                                                                       
                                                                                                                                                                                                                   
### Examples?                                                                                                                                                                                                        
  Please reach out in the comments if you want to add an example. Examples will be                                                                                                                                 
  added to sam init through aws/aws-sam-cli-app-templates (https://github.com/aws/aws-sam-cli-app-templates).                                                                                                      
                                                                                                                                                                                                                   
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.   