### PR TITLE
fix: restrict cfn-lint schema update to us-east-1 to avoid pickle error

### DIFF
--- a/bin/run_cfn_lint.sh
+++ b/bin/run_cfn_lint.sh
@@ -11,10 +11,12 @@ fi
 
 "${VENV}/bin/python" -m pip install cfn-lint --upgrade --quiet
 # update cfn schema with retry logic (can fail due to network issues)
+# --regions us-east-1 avoids a cfn-lint bug where updating all regions causes a
+# multiprocessing pickle error. See https://github.com/aws-cloudformation/cfn-lint/issues/4379
 MAX_RETRIES=3
 RETRY_COUNT=0
 while [ $RETRY_COUNT -lt $MAX_RETRIES ]; do
-    if "${VENV}/bin/cfn-lint" -u; then
+    if "${VENV}/bin/cfn-lint" -u --regions us-east-1; then
         echo "Successfully updated cfn-lint schema"
         break
     else


### PR DESCRIPTION
## Problem

`cfn-lint -u` fails intermittently with a multiprocessing pickle error when updating schemas for all regions:

```
multiprocessing.pool.MaybeEncodingError: Error sending result: ...
Reason: 'TypeError("cannot pickle '_io.BufferedReader' object")'
```

This is a known cfn-lint bug: https://github.com/aws-cloudformation/cfn-lint/issues/4379

## Fix

Pass `--regions us-east-1` to restrict schema updates to a single region. This avoids the multiprocessing issue since cfn-lint is used here for CloudFormation template structure validation, which doesn't require region-specific schemas.