### PR TITLE
fix: pin closed-issue-message to hash

### DIFF
--- a/.github/workflows/close_issue_message.yml
+++ b/.github/workflows/close_issue_message.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       issues: write
     steps:
-      - uses: aws-actions/closed-issue-message@v2
+      - uses: aws-actions/closed-issue-message@10aaf6366131b673a7c8b7742f8b3849f1d44f18 # v2
         with:
           # These inputs are both required
           repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
### Description of changes
This change pins the version of a GitHub action we're using to a specific hash, to avoid unintended updates.

### Description of how you validated changes
I took the hash from https://github.com/aws-actions/closed-issue-message/commit/10aaf6366131b673a7c8b7742f8b3849f1d44f18

### Checklist

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [ ] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [ ] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
