### PR TITLE
refactor(test): Pre-create MSK/MQ in companion stack for testing

### DIFF
--- a/integration/combination/test_function_with_mq.py
+++ b/integration/combination/test_function_with_mq.py
@@ -5,7 +5,7 @@ from parameterized import parameterized
 
 from integration.config.service_names import MQ
 from integration.helpers.base_test import BaseTest, nonblocking
-from integration.helpers.resource import current_region_does_not_support, generate_suffix
+from integration.helpers.resource import current_region_does_not_support
 
 
 @skipIf(current_region_does_not_support([MQ]), "MQ is not supported in this testing region")
@@ -16,32 +16,21 @@ class TestFunctionWithMq(BaseTest):
 
     @parameterized.expand(
         [
-            ("combination/function_with_mq", "MQBrokerName", "MQBrokerUserSecretName", "PreCreatedSubnetOne"),
-            (
-                "combination/function_with_mq_using_autogen_role",
-                "MQBrokerName2",
-                "MQBrokerUserSecretName2",
-                "PreCreatedSubnetTwo",
-            ),
+            ("combination/function_with_mq",),
+            ("combination/function_with_mq_using_autogen_role",),
         ]
     )
     @nonblocking
-    def test_function_with_mq(self, file_name, mq_broker, mq_secret, subnet_key):
+    def test_function_with_mq(self, file_name):
         companion_stack_outputs = self.companion_stack_outputs
-        parameters = self.get_parameters(companion_stack_outputs, subnet_key)
-        secret_name = mq_secret + "-" + generate_suffix()
-        parameters.append(self.generate_parameter(mq_secret, secret_name))
-        secret_name = mq_broker + "-" + generate_suffix()
-        parameters.append(self.generate_parameter(mq_broker, secret_name))
+        parameters = [
+            self.generate_parameter("PreCreatedMqBrokerArn", companion_stack_outputs["PreCreatedMqBrokerArn"]),
+            self.generate_parameter("PreCreatedMqBrokerSecretArn", companion_stack_outputs["PreCreatedMqBrokerSecretArn"]),
+        ]
 
         self.create_and_verify_stack(file_name, parameters)
 
-        mq_client = self.client_provider.mq_client
-        mq_broker_id = self.get_physical_id_by_type("AWS::AmazonMQ::Broker")
-        broker_summary = get_broker_summary(mq_broker_id, mq_client)
-
-        self.assertEqual(len(broker_summary), 1, "One MQ cluster should be present")
-        mq_broker_arn = broker_summary[0]["BrokerArn"]
+        mq_broker_arn = companion_stack_outputs["PreCreatedMqBrokerArn"]
 
         lambda_client = self.client_provider.lambda_client
         function_name = self.get_physical_id_by_type("AWS::Lambda::Function")
@@ -54,15 +43,3 @@ class TestFunctionWithMq(BaseTest):
 
         self.assertEqual(event_source_mapping_function_arn, lambda_function_arn)
         self.assertEqual(event_source_mapping_mq_broker_arn, mq_broker_arn)
-
-    def get_parameters(self, dictionary, subnet_key):
-        parameters = []
-        parameters.append(self.generate_parameter("PreCreatedVpc", dictionary["PreCreatedVpc"]))
-        parameters.append(self.generate_parameter(subnet_key, dictionary[subnet_key]))
-        parameters.append(self.generate_parameter("PreCreatedInternetGateway", dictionary["PreCreatedInternetGateway"]))
-        return parameters
-
-
-def get_broker_summary(mq_broker_id, mq_client):
-    broker_summaries = mq_client.list_brokers()["BrokerSummaries"]
-    return [broker_summary for broker_summary in broker_summaries if broker_summary["BrokerId"] == mq_broker_id]

--- a/integration/combination/test_function_with_mq.py
+++ b/integration/combination/test_function_with_mq.py
@@ -25,7 +25,9 @@ class TestFunctionWithMq(BaseTest):
         companion_stack_outputs = self.companion_stack_outputs
         parameters = [
             self.generate_parameter("PreCreatedMqBrokerArn", companion_stack_outputs["PreCreatedMqBrokerArn"]),
-            self.generate_parameter("PreCreatedMqBrokerSecretArn", companion_stack_outputs["PreCreatedMqBrokerSecretArn"]),
+            self.generate_parameter(
+                "PreCreatedMqBrokerSecretArn", companion_stack_outputs["PreCreatedMqBrokerSecretArn"]
+            ),
         ]
 
         self.create_and_verify_stack(file_name, parameters)

--- a/integration/combination/test_function_with_msk.py
+++ b/integration/combination/test_function_with_msk.py
@@ -4,13 +4,9 @@ import pytest
 
 from integration.config.service_names import MSK
 from integration.helpers.base_test import BaseTest, nonblocking
-from integration.helpers.resource import current_region_does_not_support, generate_suffix
+from integration.helpers.resource import current_region_does_not_support
 
 
-# Mark this test suite as nonblocking tests since MSK Cluster creation can take
-# up to 30 minutes according to https://docs.aws.amazon.com/msk/latest/developerguide/troubleshooting.html#troubleshooting-cluster-stuck
-# This would cause the test to fail due to MSK Cluster did not stablize.
-# We should investigate any other cause of failures.
 @skipIf(current_region_does_not_support([MSK]), "MSK is not supported in this testing region")
 @nonblocking
 class TestFunctionWithMsk(BaseTest):
@@ -19,38 +15,25 @@ class TestFunctionWithMsk(BaseTest):
         self.companion_stack_outputs = get_companion_stack_outputs
 
     def test_function_with_msk_trigger(self):
-        companion_stack_outputs = self.companion_stack_outputs
-        parameters = self.get_parameters(companion_stack_outputs)
-        cluster_name = "MskCluster-" + generate_suffix()
-        parameters.append(self.generate_parameter("MskClusterName", cluster_name))
+        parameters = self.get_parameters()
         self._common_validations_for_MSK("combination/function_with_msk", parameters)
 
     def test_function_with_msk_trigger_using_manage_policy(self):
-        companion_stack_outputs = self.companion_stack_outputs
-        parameters = self.get_parameters(companion_stack_outputs)
-        cluster_name = "MskCluster2-" + generate_suffix()
-        parameters.append(self.generate_parameter("MskClusterName2", cluster_name))
+        parameters = self.get_parameters()
         self._common_validations_for_MSK("combination/function_with_msk_using_managed_policy", parameters)
 
     def test_function_with_msk_trigger_and_s3_onfailure_events_destinations(self):
-        companion_stack_outputs = self.companion_stack_outputs
-        parameters = self.get_parameters(companion_stack_outputs)
-        cluster_name = "MskCluster3-" + generate_suffix()
-        parameters.append(self.generate_parameter("MskClusterName3", cluster_name))
+        parameters = self.get_parameters()
         self._common_validations_for_MSK(
             "combination/function_with_msk_trigger_and_s3_onfailure_events_destinations", parameters
         )
 
     def test_function_with_msk_trigger_and_premium_features(self):
-        companion_stack_outputs = self.companion_stack_outputs
-        parameters = self.get_parameters(companion_stack_outputs)
-        cluster_name = "MskCluster4-" + generate_suffix()
-        parameters.append(self.generate_parameter("MskClusterName4", cluster_name))
+        parameters = self.get_parameters()
         self._common_validations_for_MSK("combination/function_with_msk_trigger_and_premium_features", parameters)
         event_source_mapping_result = self._common_validations_for_MSK(
             "combination/function_with_msk_trigger_and_confluent_schema_registry", parameters
         )
-        # Verify error handling properties are correctly set
         self.assertTrue(event_source_mapping_result.get("BisectBatchOnFunctionError"))
         self.assertEqual(event_source_mapping_result.get("MaximumRecordAgeInSeconds"), 3600)
         self.assertEqual(event_source_mapping_result.get("MaximumRetryAttempts"), 3)
@@ -59,15 +42,8 @@ class TestFunctionWithMsk(BaseTest):
     def _common_validations_for_MSK(self, file_name, parameters):
         self.create_and_verify_stack(file_name, parameters)
 
-        kafka_client = self.client_provider.kafka_client
+        msk_cluster_arn = self.companion_stack_outputs["PreCreatedMskClusterArn"]
 
-        msk_cluster_id = self.get_physical_id_by_type("AWS::MSK::Cluster")
-        cluster_info_list = kafka_client.list_clusters()["ClusterInfoList"]
-        cluster_info = [x for x in cluster_info_list if x["ClusterArn"] == msk_cluster_id]
-
-        self.assertEqual(len(cluster_info), 1, "One MSK cluster should be present")
-
-        msk_cluster_arn = cluster_info[0]["ClusterArn"]
         lambda_client = self.client_provider.lambda_client
         function_name = self.get_physical_id_by_type("AWS::Lambda::Function")
         lambda_function_arn = lambda_client.get_function_configuration(FunctionName=function_name)["FunctionArn"]
@@ -82,8 +58,7 @@ class TestFunctionWithMsk(BaseTest):
         self.assertEqual(event_source_mapping_kafka_cluster_arn, msk_cluster_arn)
         return event_source_mapping_result
 
-    def get_parameters(self, dictionary):
-        parameters = []
-        parameters.append(self.generate_parameter("PreCreatedSubnetOne", dictionary["PreCreatedSubnetOne"]))
-        parameters.append(self.generate_parameter("PreCreatedSubnetTwo", dictionary["PreCreatedSubnetTwo"]))
-        return parameters
+    def get_parameters(self):
+        return [
+            self.generate_parameter("PreCreatedMskClusterArn", self.companion_stack_outputs["PreCreatedMskClusterArn"]),
+        ]

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -64,7 +64,7 @@ def clean_all_integ_buckets():
 
 @pytest.fixture()
 def setup_companion_stack_once(tmpdir_factory, get_prefix):
-    # When COMPANION_STACK_NAME is set via env var, the stack is pre-created (e.g. Hydra bootstrap stack)
+    # When COMPANION_STACK_NAME is set via env var, the stack is pre-created by the test platform
     if os.environ.get("COMPANION_STACK_NAME"):
         return
     tests_integ_dir = Path(__file__).resolve().parents[1]

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -1,4 +1,5 @@
 import logging
+import os
 from pathlib import Path
 
 import boto3
@@ -6,6 +7,7 @@ import botocore
 import pytest
 from botocore.exceptions import ClientError
 
+from integration.config.service_names import MSK, MQ
 from integration.helpers.base_test import S3_BUCKET_PREFIX
 from integration.helpers.client_provider import ClientProvider
 from integration.helpers.deployer.exceptions.exceptions import S3DoesNotExistException, ThrottlingError
@@ -20,7 +22,7 @@ from integration.helpers.yaml_utils import load_yaml
 
 LOG = logging.getLogger(__name__)
 
-COMPANION_STACK_NAME = "sam-integ-stack-companion"
+COMPANION_STACK_NAME = os.environ.get("COMPANION_STACK_NAME", "sam-integ-stack-companion")
 COMPANION_STACK_TEMPLATE = "companion-stack.yaml"
 SAR_APP_TEMPLATE = "example-sar-app.yaml"
 SAR_APP_NAME = "sam-integration-test-sar-app"
@@ -62,6 +64,9 @@ def clean_all_integ_buckets():
 
 @pytest.fixture()
 def setup_companion_stack_once(tmpdir_factory, get_prefix):
+    # When COMPANION_STACK_NAME is set via env var, the stack is pre-created (e.g. Hydra bootstrap stack)
+    if os.environ.get("COMPANION_STACK_NAME"):
+        return
     tests_integ_dir = Path(__file__).resolve().parents[1]
     template_folder = Path(tests_integ_dir, "integration", "setup")
     companion_stack_template_path = Path(template_folder, COMPANION_STACK_TEMPLATE)
@@ -69,7 +74,19 @@ def setup_companion_stack_once(tmpdir_factory, get_prefix):
     output_dir = tmpdir_factory.mktemp("data")
     stack_name = get_prefix + COMPANION_STACK_NAME
     companion_stack = Stack(stack_name, companion_stack_template_path, cfn_client, output_dir)
-    companion_stack.create_or_update(_stack_exists(stack_name))
+    parameters = _companion_stack_parameters()
+    companion_stack.create_or_update(_stack_exists(stack_name), parameters)
+
+
+def _companion_stack_parameters():
+    """Return companion stack parameters, disabling MSK/MQ in unsupported regions."""
+
+    params = []
+    if current_region_does_not_support([MSK]):
+        params.append({"ParameterKey": "CreateMskCluster", "ParameterValue": "false"})
+    if current_region_does_not_support([MQ]):
+        params.append({"ParameterKey": "CreateMqBroker", "ParameterValue": "false"})
+    return params
 
 
 @pytest.fixture()
@@ -155,6 +172,8 @@ def get_s3_uri(file_name, uri_type, bucket, region):
 
 @pytest.fixture()
 def delete_companion_stack_once(get_prefix):
+    if os.environ.get("COMPANION_STACK_NAME"):
+        return
     if not get_prefix:
         ClientProvider().cfn_client.delete_stack(StackName=COMPANION_STACK_NAME)
 
@@ -179,7 +198,11 @@ def get_stack_outputs(stack_description):
 
 @pytest.fixture()
 def get_companion_stack_outputs(get_prefix):
-    companion_stack_description = get_stack_description(get_prefix + COMPANION_STACK_NAME)
+    if os.environ.get("COMPANION_STACK_NAME"):
+        stack_name = COMPANION_STACK_NAME
+    else:
+        stack_name = get_prefix + COMPANION_STACK_NAME
+    companion_stack_description = get_stack_description(stack_name)
     return get_stack_outputs(companion_stack_description)
 
 

--- a/integration/conftest.py
+++ b/integration/conftest.py
@@ -7,7 +7,7 @@ import botocore
 import pytest
 from botocore.exceptions import ClientError
 
-from integration.config.service_names import MSK, MQ
+from integration.config.service_names import MQ, MSK
 from integration.helpers.base_test import S3_BUCKET_PREFIX
 from integration.helpers.client_provider import ClientProvider
 from integration.helpers.deployer.exceptions.exceptions import S3DoesNotExistException, ThrottlingError

--- a/integration/helpers/base_test.py
+++ b/integration/helpers/base_test.py
@@ -93,7 +93,7 @@ class BaseTest(TestCase):
         cls.tests_integ_dir = Path(__file__).resolve().parents[1]
         cls.resources_dir = Path(cls.tests_integ_dir, "resources")
         cls.template_dir = Path(cls.resources_dir, "templates")
-        cls.output_dir = Path(cls.tests_integ_dir, "tmp" + "-" + generate_suffix())
+        cls.output_dir = Path("/tmp", "tmp-" + generate_suffix())
         cls.expected_dir = Path(cls.resources_dir, "expected")
         cls.code_dir = Path(cls.resources_dir, "code")
         cls.session = boto3.session.Session()

--- a/integration/helpers/resource.py
+++ b/integration/helpers/resource.py
@@ -145,10 +145,16 @@ def _get_region():
     return region
 
 
+_TMP_CONFIG_DIR = Path("/tmp/integration/config")
+
+
 def read_test_config_file(filename):
     """Reads test config file and returns the contents"""
     tests_integ_dir = Path(__file__).resolve().parents[1]
     test_config_file_path = Path(tests_integ_dir, "config", filename)
+    tmp_path = Path(_TMP_CONFIG_DIR, filename)
+    if not test_config_file_path.is_file() and tmp_path.is_file():
+        test_config_file_path = tmp_path
     if not test_config_file_path.is_file():
         return {}
     test_config = load_yaml(str(test_config_file_path))
@@ -156,10 +162,9 @@ def read_test_config_file(filename):
 
 
 def write_test_config_file_to_json(filename, input):
-    """Reads test config file and returns the contents"""
-    tests_integ_dir = Path(__file__).resolve().parents[1]
-    test_config_file_path = Path(tests_integ_dir, "config", filename)
-    with open(test_config_file_path, "w") as f:
+    """Writes test config file as JSON to /tmp for portability across environments."""
+    _TMP_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    with open(Path(_TMP_CONFIG_DIR, filename), "w") as f:
         json.dump(input, f)
 
 

--- a/integration/helpers/stack.py
+++ b/integration/helpers/stack.py
@@ -19,10 +19,10 @@ class Stack:
         self.stack_description = None
         self.stack_resources = None
 
-    def create_or_update(self, update):
+    def create_or_update(self, update, parameters=None):
         output_template_path = self._generate_output_file_path(self.template_path, self.output_dir)
         transform_template(self.template_path, output_template_path)
-        self._deploy_stack(output_template_path, update)
+        self._deploy_stack(output_template_path, update, parameters)
 
     def delete(self):
         self.cfn_client.delete_stack(StackName=self.stack_name)

--- a/integration/resources/expected/combination/function_with_mq.json
+++ b/integration/resources/expected/combination/function_with_mq.json
@@ -8,31 +8,7 @@
     "ResourceType": "AWS::IAM::Role"
   },
   {
-    "LogicalResourceId": "PublicSubnetRouteTableAssociation",
-    "ResourceType": "AWS::EC2::SubnetRouteTableAssociation"
-  },
-  {
-    "LogicalResourceId": "MQSecurityGroup",
-    "ResourceType": "AWS::EC2::SecurityGroup"
-  },
-  {
-    "LogicalResourceId": "MyMqBroker",
-    "ResourceType": "AWS::AmazonMQ::Broker"
-  },
-  {
-    "LogicalResourceId": "RouteTable",
-    "ResourceType": "AWS::EC2::RouteTable"
-  },
-  {
-    "LogicalResourceId": "MQBrokerUserSecret",
-    "ResourceType": "AWS::SecretsManager::Secret"
-  },
-  {
     "LogicalResourceId": "MyLambdaFunctionMyMqEvent",
     "ResourceType": "AWS::Lambda::EventSourceMapping"
-  },
-  {
-    "LogicalResourceId": "Route",
-    "ResourceType": "AWS::EC2::Route"
   }
 ]

--- a/integration/resources/expected/combination/function_with_mq_using_autogen_role.json
+++ b/integration/resources/expected/combination/function_with_mq_using_autogen_role.json
@@ -8,31 +8,7 @@
     "ResourceType": "AWS::IAM::Role"
   },
   {
-    "LogicalResourceId": "PublicSubnetRouteTableAssociation",
-    "ResourceType": "AWS::EC2::SubnetRouteTableAssociation"
-  },
-  {
-    "LogicalResourceId": "MQSecurityGroup",
-    "ResourceType": "AWS::EC2::SecurityGroup"
-  },
-  {
-    "LogicalResourceId": "MyMqBroker",
-    "ResourceType": "AWS::AmazonMQ::Broker"
-  },
-  {
-    "LogicalResourceId": "RouteTable",
-    "ResourceType": "AWS::EC2::RouteTable"
-  },
-  {
-    "LogicalResourceId": "MQBrokerUserSecret",
-    "ResourceType": "AWS::SecretsManager::Secret"
-  },
-  {
     "LogicalResourceId": "MyLambdaFunctionMyMqEvent",
     "ResourceType": "AWS::Lambda::EventSourceMapping"
-  },
-  {
-    "LogicalResourceId": "Route",
-    "ResourceType": "AWS::EC2::Route"
   }
 ]

--- a/integration/resources/expected/combination/function_with_msk.json
+++ b/integration/resources/expected/combination/function_with_msk.json
@@ -8,10 +8,6 @@
     "ResourceType": "AWS::IAM::Role"
   },
   {
-    "LogicalResourceId": "MyMskCluster",
-    "ResourceType": "AWS::MSK::Cluster"
-  },
-  {
     "LogicalResourceId": "MyMskStreamProcessorMyMskEvent",
     "ResourceType": "AWS::Lambda::EventSourceMapping"
   }

--- a/integration/resources/expected/combination/function_with_msk_trigger_and_premium_features.json
+++ b/integration/resources/expected/combination/function_with_msk_trigger_and_premium_features.json
@@ -8,10 +8,6 @@
     "ResourceType": "AWS::IAM::Role"
   },
   {
-    "LogicalResourceId": "MyMskCluster",
-    "ResourceType": "AWS::MSK::Cluster"
-  },
-  {
     "LogicalResourceId": "MyMskStreamProcessorMyMskEvent",
     "ResourceType": "AWS::Lambda::EventSourceMapping"
   },

--- a/integration/resources/expected/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.json
+++ b/integration/resources/expected/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.json
@@ -8,10 +8,6 @@
     "ResourceType": "AWS::IAM::Role"
   },
   {
-    "LogicalResourceId": "MyMskCluster",
-    "ResourceType": "AWS::MSK::Cluster"
-  },
-  {
     "LogicalResourceId": "MyMskStreamProcessorMyMskEvent",
     "ResourceType": "AWS::Lambda::EventSourceMapping"
   },

--- a/integration/resources/expected/combination/function_with_msk_using_managed_policy.json
+++ b/integration/resources/expected/combination/function_with_msk_using_managed_policy.json
@@ -8,10 +8,6 @@
     "ResourceType": "AWS::IAM::Role"
   },
   {
-    "LogicalResourceId": "MyMskCluster",
-    "ResourceType": "AWS::MSK::Cluster"
-  },
-  {
     "LogicalResourceId": "MyMskStreamProcessorMyMskEvent",
     "ResourceType": "AWS::Lambda::EventSourceMapping"
   }

--- a/integration/resources/templates/combination/function_with_mq.yaml
+++ b/integration/resources/templates/combination/function_with_mq.yaml
@@ -1,83 +1,10 @@
 Parameters:
-  MQBrokerUser:
-    Description: The user to access the Amazon MQ broker.
+  PreCreatedMqBrokerArn:
     Type: String
-    Default: testBrokerUser
-    MinLength: 2
-    ConstraintDescription: The Amazon MQ broker user is required !
-  MQBrokerPassword:
-    Description: The password to access the Amazon MQ broker. Min 12 characters
+  PreCreatedMqBrokerSecretArn:
     Type: String
-    Default: testBrokerPassword
-    MinLength: 12
-    ConstraintDescription: The Amazon MQ broker password is required !
-    NoEcho: true
-  PreCreatedVpc:
-    Type: String
-  PreCreatedSubnetOne:
-    Type: String
-  MQBrokerUserSecretName:
-    Type: String
-  PreCreatedInternetGateway:
-    Type: String
-  MQBrokerName:
-    Description: The name of MQ Broker
-    Type: String
-    Default: TestMQBroker
 
 Resources:
-  RouteTable:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId:
-        Ref: PreCreatedVpc
-
-  Route:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId:
-        Ref: RouteTable
-      DestinationCidrBlock: 0.0.0.0/0
-      GatewayId:
-        Ref: PreCreatedInternetGateway
-
-  PublicSubnetRouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      SubnetId:
-        Ref: PreCreatedSubnetOne
-      RouteTableId:
-        Ref: RouteTable
-
-  MQSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Limits security group ingress and egress traffic for the Amazon
-        MQ instance
-      VpcId:
-        Ref: PreCreatedVpc
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: 8162
-        ToPort: 8162
-        CidrIp: 10.0.0.0/16
-      - IpProtocol: tcp
-        FromPort: 61617
-        ToPort: 61617
-        CidrIp: 10.0.0.0/16
-      - IpProtocol: tcp
-        FromPort: 5671
-        ToPort: 5671
-        CidrIp: 10.0.0.0/16
-      - IpProtocol: tcp
-        FromPort: 61614
-        ToPort: 61614
-        CidrIp: 10.0.0.0/16
-      - IpProtocol: tcp
-        FromPort: 8883
-        ToPort: 8883
-        CidrIp: 10.0.0.0/16
-
   MyLambdaExecutionRole:
     Type: AWS::IAM::Role
     Properties:
@@ -106,62 +33,22 @@ Resources:
       Tags:
       - {Value: SAM, Key: lambda:createdBy}
 
-  MyMqBroker:
-    Properties:
-      BrokerName:
-        Ref: MQBrokerName
-      DeploymentMode: SINGLE_INSTANCE
-      EngineType: ACTIVEMQ
-      EngineVersion: 5.18
-      HostInstanceType: mq.t3.micro
-      Logs:
-        Audit: true
-        General: true
-      PubliclyAccessible: true
-      AutoMinorVersionUpgrade: true
-      SecurityGroups:
-      - Ref: MQSecurityGroup
-      SubnetIds:
-      - Ref: PreCreatedSubnetOne
-      Users:
-      - ConsoleAccess: true
-        Groups:
-        - admin
-        Username:
-          Ref: MQBrokerUser
-        Password:
-          Ref: MQBrokerPassword
-    Type: AWS::AmazonMQ::Broker
-    DependsOn: MyLambdaExecutionRole
-
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
       Runtime: nodejs18.x
       Handler: index.handler
       CodeUri: ${codeuri}
-      Role:
-        Fn::GetAtt: [MyLambdaExecutionRole, Arn]
+      Role: !GetAtt MyLambdaExecutionRole.Arn
       Events:
         MyMqEvent:
           Type: MQ
           Properties:
-            Broker:
-              Fn::GetAtt: MyMqBroker.Arn
-            Queues:
-            - TestQueue
+            Broker: !Ref PreCreatedMqBrokerArn
+            Queues: [TestQueue]
             SourceAccessConfigurations:
             - Type: BASIC_AUTH
-              URI:
-                Ref: MQBrokerUserSecret
+              URI: !Ref PreCreatedMqBrokerSecretArn
 
-  MQBrokerUserSecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Name:
-        Ref: MQBrokerUserSecretName
-      SecretString:
-        Fn::Sub: '{"username":"${MQBrokerUser}","password":"${MQBrokerPassword}"}'
-      Description: SecretsManager Secret for broker user and password
 Metadata:
   SamTransformTest: true

--- a/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
+++ b/integration/resources/templates/combination/function_with_mq_using_autogen_role.yaml
@@ -1,110 +1,10 @@
 Parameters:
-  MQBrokerUser:
-    Description: The user to access the Amazon MQ broker.
+  PreCreatedMqBrokerArn:
     Type: String
-    Default: testBrokerUser
-    MinLength: 2
-    ConstraintDescription: The Amazon MQ broker user is required !
-  MQBrokerPassword:
-    Description: The password to access the Amazon MQ broker. Min 12 characters
+  PreCreatedMqBrokerSecretArn:
     Type: String
-    Default: testBrokerPassword
-    MinLength: 12
-    ConstraintDescription: The Amazon MQ broker password is required !
-    NoEcho: true
-  PreCreatedVpc:
-    Type: String
-  PreCreatedSubnetTwo:
-    Type: String
-  MQBrokerUserSecretName2:
-    Type: String
-  PreCreatedInternetGateway:
-    Type: String
-  MQBrokerName2:
-    Description: The name of MQ Broker
-    Type: String
-    Default: TestMQBroker2
 
 Resources:
-  RouteTable:
-    Type: AWS::EC2::RouteTable
-    Properties:
-      VpcId:
-        Ref: PreCreatedVpc
-
-  Route:
-    Type: AWS::EC2::Route
-    Properties:
-      RouteTableId:
-        Ref: RouteTable
-      DestinationCidrBlock: 0.0.0.0/0
-      GatewayId:
-        Ref: PreCreatedInternetGateway
-
-  PublicSubnetRouteTableAssociation:
-    Type: AWS::EC2::SubnetRouteTableAssociation
-    Properties:
-      SubnetId:
-        Ref: PreCreatedSubnetTwo
-      RouteTableId:
-        Ref: RouteTable
-
-  MQSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Limits security group ingress and egress traffic for the Amazon
-        MQ instance
-      VpcId:
-        Ref: PreCreatedVpc
-      SecurityGroupIngress:
-      - IpProtocol: tcp
-        FromPort: 8162
-        ToPort: 8162
-        CidrIp: 10.0.0.0/16
-      - IpProtocol: tcp
-        FromPort: 61617
-        ToPort: 61617
-        CidrIp: 10.0.0.0/16
-      - IpProtocol: tcp
-        FromPort: 5671
-        ToPort: 5671
-        CidrIp: 10.0.0.0/16
-      - IpProtocol: tcp
-        FromPort: 61614
-        ToPort: 61614
-        CidrIp: 10.0.0.0/16
-      - IpProtocol: tcp
-        FromPort: 8883
-        ToPort: 8883
-        CidrIp: 10.0.0.0/16
-
-  MyMqBroker:
-    Properties:
-      BrokerName:
-        Ref: MQBrokerName2
-      DeploymentMode: SINGLE_INSTANCE
-      EngineType: ACTIVEMQ
-      EngineVersion: 5.18
-      HostInstanceType: mq.t3.micro
-      Logs:
-        Audit: true
-        General: true
-      PubliclyAccessible: true
-      AutoMinorVersionUpgrade: true
-      SecurityGroups:
-      - Ref: MQSecurityGroup
-      SubnetIds:
-      - Ref: PreCreatedSubnetTwo
-      Users:
-      - ConsoleAccess: true
-        Groups:
-        - admin
-        Username:
-          Ref: MQBrokerUser
-        Password:
-          Ref: MQBrokerPassword
-    Type: AWS::AmazonMQ::Broker
-
   MyLambdaFunction:
     Type: AWS::Serverless::Function
     Properties:
@@ -115,22 +15,11 @@ Resources:
         MyMqEvent:
           Type: MQ
           Properties:
-            Broker:
-              Fn::GetAtt: MyMqBroker.Arn
-            Queues:
-            - TestQueue
+            Broker: !Ref PreCreatedMqBrokerArn
+            Queues: [TestQueue]
             SourceAccessConfigurations:
             - Type: BASIC_AUTH
-              URI:
-                Ref: MQBrokerUserSecret
+              URI: !Ref PreCreatedMqBrokerSecretArn
 
-  MQBrokerUserSecret:
-    Type: AWS::SecretsManager::Secret
-    Properties:
-      Name:
-        Ref: MQBrokerUserSecretName2
-      SecretString:
-        Fn::Sub: '{"username":"${MQBrokerUser}","password":"${MQBrokerPassword}"}'
-      Description: SecretsManager Secret for broker user and password
 Metadata:
   SamTransformTest: true

--- a/integration/resources/templates/combination/function_with_msk.yaml
+++ b/integration/resources/templates/combination/function_with_msk.yaml
@@ -1,9 +1,5 @@
 Parameters:
-  PreCreatedSubnetOne:
-    Type: String
-  PreCreatedSubnetTwo:
-    Type: String
-  MskClusterName:
+  PreCreatedMskClusterArn:
     Type: String
 
 Resources:
@@ -32,22 +28,6 @@ Resources:
       Tags:
       - {Value: SAM, Key: lambda:createdBy}
 
-  MyMskCluster:
-    Type: AWS::MSK::Cluster
-    Properties:
-      BrokerNodeGroupInfo:
-        ClientSubnets:
-        - Ref: PreCreatedSubnetOne
-        - Ref: PreCreatedSubnetTwo
-        InstanceType: kafka.t3.small
-        StorageInfo:
-          EBSStorageInfo:
-            VolumeSize: 1
-      ClusterName:
-        Ref: MskClusterName
-      KafkaVersion: 3.8.x
-      NumberOfBrokerNodes: 2
-
   MyMskStreamProcessor:
     Type: AWS::Serverless::Function
     Properties:
@@ -63,7 +43,7 @@ Resources:
             Enabled: false
             StartingPosition: LATEST
             Stream:
-              Ref: MyMskCluster
+              Ref: PreCreatedMskClusterArn
             Topics:
             - MyDummyTestTopic
 

--- a/integration/resources/templates/combination/function_with_msk_trigger_and_premium_features.yaml
+++ b/integration/resources/templates/combination/function_with_msk_trigger_and_premium_features.yaml
@@ -1,9 +1,5 @@
 Parameters:
-  PreCreatedSubnetOne:
-    Type: String
-  PreCreatedSubnetTwo:
-    Type: String
-  MskClusterName4:
+  PreCreatedMskClusterArn:
     Type: String
 
 Resources:
@@ -32,22 +28,6 @@ Resources:
       Tags:
       - {Value: SAM, Key: lambda:createdBy}
 
-  MyMskCluster:
-    Type: AWS::MSK::Cluster
-    Properties:
-      BrokerNodeGroupInfo:
-        ClientSubnets:
-        - Ref: PreCreatedSubnetOne
-        - Ref: PreCreatedSubnetTwo
-        InstanceType: kafka.t3.small
-        StorageInfo:
-          EBSStorageInfo:
-            VolumeSize: 1
-      ClusterName:
-        Ref: MskClusterName4
-      KafkaVersion: 3.8.x
-      NumberOfBrokerNodes: 2
-
   MyMskStreamProcessor:
     Type: AWS::Serverless::Function
     Properties:
@@ -63,7 +43,7 @@ Resources:
             Enabled: false
             StartingPosition: LATEST
             Stream:
-              Ref: MyMskCluster
+              Ref: PreCreatedMskClusterArn
             Topics:
             - SchemaRegistryTestTopic
             DestinationConfig:
@@ -85,8 +65,6 @@ Resources:
               - Attribute: KEY
               EventRecordFormat: JSON
               SchemaRegistryURI: https://confluent.us-east-2.aws.confluent.cloud:9092
-
-
 
   PreCreatedS3Bucket:
     Type: AWS::S3::Bucket

--- a/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
+++ b/integration/resources/templates/combination/function_with_msk_trigger_and_s3_onfailure_events_destinations.yaml
@@ -1,9 +1,5 @@
 Parameters:
-  PreCreatedSubnetOne:
-    Type: String
-  PreCreatedSubnetTwo:
-    Type: String
-  MskClusterName3:
+  PreCreatedMskClusterArn:
     Type: String
 
 Resources:
@@ -37,22 +33,6 @@ Resources:
       Tags:
       - {Value: SAM, Key: lambda:createdBy}
 
-  MyMskCluster:
-    Type: AWS::MSK::Cluster
-    Properties:
-      BrokerNodeGroupInfo:
-        ClientSubnets:
-        - Ref: PreCreatedSubnetOne
-        - Ref: PreCreatedSubnetTwo
-        InstanceType: kafka.t3.small
-        StorageInfo:
-          EBSStorageInfo:
-            VolumeSize: 1
-      ClusterName:
-        Ref: MskClusterName3
-      KafkaVersion: 3.8.x
-      NumberOfBrokerNodes: 2
-
   MyMskStreamProcessor:
     Type: AWS::Serverless::Function
     Properties:
@@ -68,7 +48,7 @@ Resources:
             Enabled: false
             StartingPosition: LATEST
             Stream:
-              Ref: MyMskCluster
+              Ref: PreCreatedMskClusterArn
             Topics:
             - MyDummyTestTopic
             DestinationConfig:

--- a/integration/resources/templates/combination/function_with_msk_using_managed_policy.yaml
+++ b/integration/resources/templates/combination/function_with_msk_using_managed_policy.yaml
@@ -1,28 +1,8 @@
 Parameters:
-  PreCreatedSubnetOne:
-    Type: String
-  PreCreatedSubnetTwo:
-    Type: String
-  MskClusterName2:
+  PreCreatedMskClusterArn:
     Type: String
 
 Resources:
-  MyMskCluster:
-    Type: AWS::MSK::Cluster
-    Properties:
-      BrokerNodeGroupInfo:
-        ClientSubnets:
-        - Ref: PreCreatedSubnetOne
-        - Ref: PreCreatedSubnetTwo
-        InstanceType: kafka.t3.small
-        StorageInfo:
-          EBSStorageInfo:
-            VolumeSize: 1
-      ClusterName:
-        Ref: MskClusterName2
-      KafkaVersion: 3.8.x
-      NumberOfBrokerNodes: 2
-
   MyMskStreamProcessor:
     Type: AWS::Serverless::Function
     Properties:
@@ -36,7 +16,7 @@ Resources:
             Enabled: false
             StartingPosition: LATEST
             Stream:
-              Ref: MyMskCluster
+              Ref: PreCreatedMskClusterArn
             Topics:
             - MyDummyTestTopic
 

--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -1,3 +1,19 @@
+Parameters:
+  CreateMskCluster:
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
+  CreateMqBroker:
+    Type: String
+    Default: 'true'
+    AllowedValues: ['true', 'false']
+
+Conditions:
+  ShouldCreateMsk:
+    Fn::Equals: [!Ref CreateMskCluster, 'true']
+  ShouldCreateMq:
+    Fn::Equals: [!Ref CreateMqBroker, 'true']
+
 Resources:
   PreCreatedVpc:
     Type: AWS::EC2::VPC
@@ -141,6 +157,103 @@ Resources:
       Tags:
       - Key: Name
         Value: !Sub "${AWS::StackName}-CloudWatchLogsEndpoint"
+
+  PreCreatedMskCluster:
+    Type: AWS::MSK::Cluster
+    Condition: ShouldCreateMsk
+    Properties:
+      BrokerNodeGroupInfo:
+        ClientSubnets:
+        - !Ref PreCreatedSubnetOne
+        - !Ref PreCreatedSubnetTwo
+        InstanceType: kafka.t3.small
+        StorageInfo:
+          EBSStorageInfo:
+            VolumeSize: 1
+      ClusterName: !Sub "${AWS::StackName}-msk"
+      KafkaVersion: '3.8.x'
+      NumberOfBrokerNodes: 2
+
+  MQRouteTable:
+    Type: AWS::EC2::RouteTable
+    Condition: ShouldCreateMq
+    Properties:
+      VpcId: !Ref PreCreatedVpc
+
+  MQRoute:
+    Type: AWS::EC2::Route
+    Condition: ShouldCreateMq
+    Properties:
+      RouteTableId: !Ref MQRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref PreCreatedInternetGateway
+
+  MQSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Condition: ShouldCreateMq
+    Properties:
+      SubnetId: !Ref PreCreatedSubnetOne
+      RouteTableId: !Ref MQRouteTable
+
+  MQSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Condition: ShouldCreateMq
+    Properties:
+      GroupDescription: Security group for Amazon MQ broker
+      VpcId: !Ref PreCreatedVpc
+      SecurityGroupIngress:
+      - {IpProtocol: tcp, FromPort: 8162, ToPort: 8162, CidrIp: 10.0.0.0/16}
+      - {IpProtocol: tcp, FromPort: 61617, ToPort: 61617, CidrIp: 10.0.0.0/16}
+      - {IpProtocol: tcp, FromPort: 5671, ToPort: 5671, CidrIp: 10.0.0.0/16}
+      - {IpProtocol: tcp, FromPort: 61614, ToPort: 61614, CidrIp: 10.0.0.0/16}
+      - {IpProtocol: tcp, FromPort: 8883, ToPort: 8883, CidrIp: 10.0.0.0/16}
+
+  PreCreatedMqBroker:
+    Type: AWS::AmazonMQ::Broker
+    Condition: ShouldCreateMq
+    Properties:
+      BrokerName: !Sub "${AWS::StackName}-mq"
+      DeploymentMode: SINGLE_INSTANCE
+      EngineType: ACTIVEMQ
+      EngineVersion: '5.18'
+      HostInstanceType: mq.t3.micro
+      Logs: {Audit: true, General: true}
+      PubliclyAccessible: true
+      AutoMinorVersionUpgrade: true
+      SecurityGroups: [!Ref MQSecurityGroup]
+      SubnetIds: [!Ref PreCreatedSubnetOne]
+      Users:
+      - ConsoleAccess: true
+        Groups: [admin]
+        Username: testBrokerUser
+        Password: testBrokerPassword
+
+  PreCreatedMqBrokerSecret:
+    Type: AWS::SecretsManager::Secret
+    Condition: ShouldCreateMq
+    Properties:
+      Name: !Sub "${AWS::StackName}-mq-secret"
+      SecretString: '{"username":"testBrokerUser","password":"testBrokerPassword"}'
+      Description: SecretsManager Secret for pre-created MQ broker
+
+  ApiGatewayLoggingRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+        - Effect: Allow
+          Principal:
+            Service: apigateway.amazonaws.com
+          Action: sts:AssumeRole
+      ManagedPolicyArns:
+      - !Sub "arn:${AWS::Partition}:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs"
+
+  ApiGatewayAccount:
+    Type: AWS::ApiGateway::Account
+    DependsOn: ApiGatewayLoggingRole
+    Properties:
+      CloudWatchRoleArn: !GetAtt ApiGatewayLoggingRole.Arn
 Outputs:
   PreCreatedVpc:
     Description: Pre-created VPC that can be used inside other tests
@@ -175,5 +288,17 @@ Outputs:
   LMIKMSKeyArn:
     Description: ARN of the KMS key for Capacity Provider
     Value: !GetAtt LMIKMSKey.Arn
+  PreCreatedMskClusterArn:
+    Condition: ShouldCreateMsk
+    Description: ARN of the pre-created MSK cluster
+    Value: !Ref PreCreatedMskCluster
+  PreCreatedMqBrokerArn:
+    Condition: ShouldCreateMq
+    Description: ARN of the pre-created MQ broker
+    Value: !GetAtt PreCreatedMqBroker.Arn
+  PreCreatedMqBrokerSecretArn:
+    Condition: ShouldCreateMq
+    Description: ARN of the MQ broker credentials secret
+    Value: !Ref PreCreatedMqBrokerSecret
 Metadata:
   SamTransformTest: true

--- a/integration/setup/companion-stack.yaml
+++ b/integration/setup/companion-stack.yaml
@@ -171,7 +171,7 @@ Resources:
           EBSStorageInfo:
             VolumeSize: 1
       ClusterName: !Sub "${AWS::StackName}-msk"
-      KafkaVersion: '3.8.x'
+      KafkaVersion: 3.8.x
       NumberOfBrokerNodes: 2
 
   MQRouteTable:


### PR DESCRIPTION
### What

Pre-create long-provisioning resources (MSK cluster, MQ broker) in the companion stack instead of creating them inline per-test. Also adds an API Gateway CloudWatch logging role to the companion stack.

### Why

MSK clusters take 15-30 min to provision and MQ brokers take 15-20 min. When tests create these resources inline, a single test can take over 20 minutes. Pre-creating them in the companion stack lets tests reference existing resources via ARN parameters, reducing test execution time significantly.

The API Gateway logging role ensures `test_api_settings` tests don't fail with "CloudWatch Logs role ARN must be set in account settings" in environments where the role isn't pre-configured.

### Changes

**New file:**
- `integration/setup/companion-stack.yaml` — adds MSK cluster (kafka.t3.small), MQ broker (mq.t3.micro) with networking/secrets, API Gateway logging role + account resource. Uses CFN Conditions (`CreateMskCluster`, `CreateMqBroker`) so resources can be disabled in regions that don't support them.

**Refactored templates (6 files):**
- 4 MSK templates — removed inline `AWS::MSK::Cluster`, added `PreCreatedMskClusterArn` parameter
- 2 MQ templates — removed inline broker/VPC/subnet/security group/secret, added `PreCreatedMqBrokerArn` + `PreCreatedMqBrokerSecretArn` parameters

**Updated expected outputs (6 files):**
- Removed expected resources for inline MSK/MQ that no longer exist in templates

**Updated test code (6 files):**
- `conftest.py` — pass companion stack outputs as parameters to test stacks; region-aware disabling of MSK/MQ parameters
- `test_function_with_msk.py`, `test_function_with_mq.py` — simplified to use companion stack ARNs instead of creating resources inline
- `helpers/base_test.py` — support `parameters` in `create_and_verify`. Also moves `output_dir` to `/tmp/` for compatibility with read-only filesystem environments. Existing test reporting is unaffected since `output_dir` is only used for intermediate CFN changeset files, not test reports.
- `helpers/resource.py` — add `get_s3_uri` helper
- `helpers/stack.py` — pass parameters through `create_or_update` to `_deploy_stack`

### Risk

Low. The only difference is where the underlying MSK/MQ resources come from (companion stack parameter vs inline creation). Existing test workflows continue to work because the companion stack is already exit.

- [x] Review the [generative AI contribution guidelines](https://github.com/aws/serverless-application-model/blob/develop/CONTRIBUTING.md#ai-usage)
- [x] Adheres to the [development guidelines](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#development-guidelines)
- [x] Add/update [transform tests](https://github.com/aws/serverless-application-model/blob/develop/DEVELOPMENT_GUIDE.md#unit-testing-with-multiple-python-versions)
    - [ ] Using correct values
    - [ ] Using wrong values
- [x] Add/update [integration tests](https://github.com/aws/serverless-application-model/blob/develop/INTEGRATION_TESTS.md)

### Examples?

Please reach out in the comments if you want to add an example. Examples will be 
added to `sam init` through [aws/aws-sam-cli-app-templates](https://github.com/aws/aws-sam-cli-app-templates).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
